### PR TITLE
Ran deepsec on deepsec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
       matrix:
         node: ['22', '24']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # pnpm version is read from `packageManager` in the root package.json,
       # so bumping it there is enough — no version pin needed here.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,14 +39,16 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write  # required for npm OIDC trusted publishing + provenance
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write  # required for npm OIDC trusted publishing + provenance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Compare the version in packages/deepsec/package.json with whatever is
       # currently published on npm. Skip if equal — re-running this workflow
@@ -73,10 +75,10 @@ jobs:
 
       # pnpm version is read from `packageManager` in the root package.json.
       - if: steps.ver.outputs.publish == 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - if: steps.ver.outputs.publish == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ next-env.d.ts
 .DS_Store
 .claude
 linear-*
+.deepsec

--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ uploaded; `.git` is excluded. Both OIDC tokens (local) and access
 tokens (CI) are supported — see
 [docs/vercel-setup.md](docs/vercel-setup.md).
 
+## Security model of deepsec itself
+
+Treat `deepsec` like a coding agent with full shell access on the enviroment that it is
+running on. It is designed to run on trusted inputs (your source code) but you may still
+be concerned about prompt injection due to external dependencies or vendored code.
+
+Running on a sandbox (see above) does limit the potential exposure substantially:
+
+- The API keys for the coding agents are injected outside of the sandbox and hence cannot be exfiltrated
+- For the worker sandboxes, network egress from the sandbox is limited to coding agent hosts (Egress is allowed during the bootstrap process, but this does not run the coding agent)
+
 ## Workflow reference
 
 | Command         | What it does                                             |

--- a/README.md
+++ b/README.md
@@ -94,14 +94,16 @@ Both agent backends route through Vercel AI Gateway by default, but you can prov
 your own API keys, of course. The AI Gateway has default quotas suitable for highly concurrent research.
 
 ```
-ANTHROPIC_AUTH_TOKEN=vck_...
-ANTHROPIC_BASE_URL=https://ai-gateway.vercel.sh
-OPENAI_BASE_URL=https://ai-gateway.vercel.sh/v1
+AI_GATEWAY_API_KEY=vck_...
 ```
 
-See [docs/vercel-setup.md](docs/vercel-setup.md) for getting a key
-and for the Vercel Sandbox setup. To bypass the gateway, define
-`ANTHROPIC_BASE_URL` or `OPENAI_API_KEY` with their respective provider values.
+That single key covers both Claude and Codex; deepsec expands it into
+the `ANTHROPIC_AUTH_TOKEN` / `OPENAI_API_KEY` / `*_BASE_URL` quartet
+the SDKs read. See [docs/vercel-setup.md](docs/vercel-setup.md) for
+getting a key and for the Vercel Sandbox setup. To bypass the
+gateway, set `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL` (or the
+OpenAI pair) explicitly — explicit values always win over the
+`AI_GATEWAY_API_KEY` expansion.
 
 ## Severity levels
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,17 +99,21 @@ from the process environment.
 
 ### Required
 
+You need either the one-line shortcut **or** an explicit token for the
+backend you're using.
+
 | Var | Used by | Purpose |
 |---|---|---|
-| `ANTHROPIC_AUTH_TOKEN` | `process`, `revalidate`, `triage` (Claude backend) | API token for the Claude Agent SDK. AI Gateway-issued or Anthropic-issued. |
-| `ANTHROPIC_BASE_URL` | same | Default: `https://ai-gateway.vercel.sh`. Set to `https://api.anthropic.com` for direct Anthropic. |
+| `AI_GATEWAY_API_KEY` | all AI commands | Shortcut. Expands at CLI startup into `ANTHROPIC_AUTH_TOKEN` / `OPENAI_API_KEY` / `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` — one key covers both Claude and Codex through Vercel AI Gateway. Any of those four vars set explicitly takes precedence. |
+| `ANTHROPIC_AUTH_TOKEN` | `process`, `revalidate`, `triage` (Claude backend) | API token for the Claude Agent SDK. AI Gateway-issued or Anthropic-issued. Set this if you don't use `AI_GATEWAY_API_KEY`. |
+| `ANTHROPIC_BASE_URL` | same | Default (when `AI_GATEWAY_API_KEY` is set): `https://ai-gateway.vercel.sh`. Set to `https://api.anthropic.com` for direct Anthropic. |
 
 ### Optional
 
 | Var | Used by | Purpose |
 |---|---|---|
-| `OPENAI_API_KEY` | `--agent codex` | Codex SDK token. Unset is fine if Codex routes through AI Gateway with the Anthropic token. |
-| `OPENAI_BASE_URL` | `--agent codex` | Default: `https://ai-gateway.vercel.sh/v1`. |
+| `OPENAI_API_KEY` | `--agent codex` | Codex SDK token. Unset is fine if `AI_GATEWAY_API_KEY` is set, or if Codex routes through AI Gateway with the Anthropic token. |
+| `OPENAI_BASE_URL` | `--agent codex` | Default (when `AI_GATEWAY_API_KEY` is set): `https://ai-gateway.vercel.sh/v1`. |
 | `DEEPSEC_AGENT_DEBUG` | both backends | Set to `1` to enable verbose agent logging. |
 | `DEEPSEC_DATA_ROOT` | core | Override the data directory location. Equivalent to `dataDir` in config. |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,10 +26,11 @@ prompt), workspace-level `AGENTS.md`, `.env.local`, `.gitignore`. No
 custom matchers in the scaffold — add those later, only when a real
 finding shapes one for you.
 
-Open `.env.local` and fill in `ANTHROPIC_AUTH_TOKEN`. Get one from
-[Vercel AI Gateway](https://vercel.com/ai-gateway) (one token covers
-Claude and Codex) or set `ANTHROPIC_BASE_URL=https://api.anthropic.com`
-to use Anthropic directly. See [vercel-setup.md](vercel-setup.md).
+Open `.env.local` and fill in `AI_GATEWAY_API_KEY`. Get one from
+[Vercel AI Gateway](https://vercel.com/ai-gateway) — one token covers
+both Claude and Codex. Prefer Anthropic directly? Set
+`ANTHROPIC_AUTH_TOKEN=sk-ant-…` and `ANTHROPIC_BASE_URL=https://api.anthropic.com`
+instead. See [vercel-setup.md](vercel-setup.md).
 
 To scan a *different* codebase from the same `.deepsec/`, run
 `pnpm deepsec init-project <path>` — relative paths resolve against

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -29,15 +29,16 @@ Full reference:
 Edit `.env.local` in your scanning workspace:
 
 ```bash
-ANTHROPIC_AUTH_TOKEN=vck_…
-ANTHROPIC_BASE_URL=https://ai-gateway.vercel.sh
+AI_GATEWAY_API_KEY=vck_…
 ```
 
-That's it. The Claude Agent SDK sends the token via the bearer header
-the gateway expects, so the AI Gateway key works as the
-`ANTHROPIC_AUTH_TOKEN`. The same key also routes Codex (`--agent
-codex`) — deepsec falls back to `ANTHROPIC_AUTH_TOKEN` when
-`OPENAI_API_KEY` is unset, so you don't need a second token.
+That's it. deepsec expands this at startup into the four vars the
+agent SDKs read (`ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`,
+`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`), so the same key covers both
+Claude (`--agent claude-agent-sdk`, the default) and Codex
+(`--agent codex`). Any of those four vars you set explicitly takes
+precedence over the gateway expansion — useful for mixing direct
+Anthropic with gateway-routed OpenAI, etc.
 
 ### BYOK (optional)
 
@@ -123,7 +124,7 @@ vars (access token).
 
 | Symptom | Likely cause |
 |---|---|
-| `401` from `process` / `revalidate` | `ANTHROPIC_AUTH_TOKEN` not loaded — confirm `.env.local` is in the cwd deepsec runs from. |
+| `401` from `process` / `revalidate` | `AI_GATEWAY_API_KEY` (or `ANTHROPIC_AUTH_TOKEN`) not loaded — confirm `.env.local` is in the cwd deepsec runs from. |
 | Sandbox spawn fails with auth error | OIDC token expired (12 h) — re-run `vercel env pull`. Or fall back to access-token mode. |
-| `OPENAI_API_KEY missing` on `--agent codex` | Set `OPENAI_API_KEY` explicitly *or* leave it unset and let deepsec fall back to `ANTHROPIC_AUTH_TOKEN` against the gateway. |
+| `Missing AI credentials for --agent codex` | Set `AI_GATEWAY_API_KEY` (covers both backends) or `OPENAI_API_KEY` directly. |
 | Findings missing cost in the log | Pricing entry missing for a non-default Codex model. See [models.md](models.md#future-models-eg-anthropic-mythos). |

--- a/e2e/scan.test.ts
+++ b/e2e/scan.test.ts
@@ -26,7 +26,7 @@ describe("scan e2e", () => {
       root: FIXTURES,
     });
 
-    expect(result.runId).toMatch(/^\d{14}-[a-f0-9]{4}$/);
+    expect(result.runId).toMatch(/^\d{14}-[a-f0-9]{16}$/);
     expect(result.candidateCount).toBeGreaterThanOrEqual(5);
 
     // Verify project.json exists

--- a/packages/core/src/__tests__/paths.test.ts
+++ b/packages/core/src/__tests__/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fileRecordPath, filesDir, runMetaPath, runsDir } from "../paths.js";
+import { dataDir, fileRecordPath, filesDir, runMetaPath, runsDir } from "../paths.js";
 
 describe("paths", () => {
   it("filesDir follows convention", () => {
@@ -18,5 +18,38 @@ describe("paths", () => {
 
   it("runMetaPath is flat file", () => {
     expect(runMetaPath("myapp", "run1")).toBe("data/myapp/runs/run1.json");
+  });
+
+  // Path-traversal protection — any segment that could escape the per-project
+  // mirror (`..`, absolute paths, separators, null bytes) must throw, since
+  // these are the documented sandbox-round-trip and CLI-flag attack vectors.
+  describe("path traversal", () => {
+    it("dataDir rejects '..' projectId", () => {
+      expect(() => dataDir("..")).toThrow(/Invalid projectId/);
+    });
+
+    it("dataDir rejects projectId with slash", () => {
+      expect(() => dataDir("../escape")).toThrow(/Invalid projectId/);
+    });
+
+    it("dataDir rejects absolute projectId", () => {
+      expect(() => dataDir("/etc/passwd")).toThrow(/Invalid projectId/);
+    });
+
+    it("dataDir rejects null byte", () => {
+      expect(() => dataDir("foo\0bar")).toThrow(/null byte/);
+    });
+
+    it("fileRecordPath rejects '..' segment in filePath", () => {
+      expect(() => fileRecordPath("myapp", "../../tmp/evil")).toThrow(/Invalid filePath/);
+    });
+
+    it("fileRecordPath rejects absolute filePath", () => {
+      expect(() => fileRecordPath("myapp", "/etc/passwd")).toThrow(/Invalid filePath/);
+    });
+
+    it("runMetaPath rejects runId with separator", () => {
+      expect(() => runMetaPath("myapp", "../escape")).toThrow(/Invalid runId/);
+    });
   });
 });

--- a/packages/core/src/__tests__/run.test.ts
+++ b/packages/core/src/__tests__/run.test.ts
@@ -4,7 +4,7 @@ import { createRunMeta, generateRunId } from "../run.js";
 describe("generateRunId", () => {
   it("returns a string with timestamp and suffix", () => {
     const id = generateRunId();
-    expect(id).toMatch(/^\d{14}-[a-f0-9]{4}$/);
+    expect(id).toMatch(/^\d{14}-[a-f0-9]{16}$/);
   });
 
   it("generates unique IDs", () => {
@@ -27,7 +27,7 @@ describe("createRunMeta", () => {
     expect(meta.phase).toBe("running");
     expect(meta.scannerConfig?.matcherSlugs).toEqual(["xss", "rce"]);
     expect(meta.stats).toEqual({});
-    expect(meta.runId).toMatch(/^\d{14}-[a-f0-9]{4}$/);
+    expect(meta.runId).toMatch(/^\d{14}-[a-f0-9]{16}$/);
   });
 
   it("creates a process RunMeta", () => {

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,10 +1,58 @@
 import path from "node:path";
 
-function getDataRoot(): string {
+export function getDataRoot(): string {
   return process.env.DEEPSEC_DATA_ROOT || "data";
 }
 
+// Reject empty, '.', '..', absolute paths, null bytes, and any path
+// separator. Used at every entry point that joins user-supplied segments
+// onto a per-project mirror so a `../`-laced projectId/runId can't escape
+// the mirror or clobber a sibling project's files.
+export function assertSafeSegment(name: string, label = "segment"): void {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error(`Invalid ${label}: must be a non-empty string`);
+  }
+  if (name === "." || name === "..") {
+    throw new Error(`Invalid ${label}: ${JSON.stringify(name)}`);
+  }
+  if (name.includes("\0")) {
+    throw new Error(`Invalid ${label}: contains null byte`);
+  }
+  if (name.includes("/") || name.includes("\\")) {
+    throw new Error(`Invalid ${label}: contains path separator`);
+  }
+  if (path.isAbsolute(name)) {
+    throw new Error(`Invalid ${label}: must not be absolute`);
+  }
+}
+
+// FilePath is a relative path under a project root that may contain
+// forward-slash directory separators (record paths come from glob output).
+// We allow `/` between segments but still reject `..` components, absolute
+// paths, null bytes, and backslashes (which would otherwise be folded into
+// path separators on Windows).
+export function assertSafeFilePath(filePath: string): void {
+  if (typeof filePath !== "string" || filePath.length === 0) {
+    throw new Error("Invalid filePath: must be a non-empty string");
+  }
+  if (filePath.includes("\0")) {
+    throw new Error("Invalid filePath: contains null byte");
+  }
+  if (filePath.includes("\\")) {
+    throw new Error("Invalid filePath: contains backslash");
+  }
+  if (path.isAbsolute(filePath)) {
+    throw new Error("Invalid filePath: must not be absolute");
+  }
+  for (const part of filePath.split("/")) {
+    if (part === "" || part === "." || part === "..") {
+      throw new Error(`Invalid filePath: contains "${part}" segment`);
+    }
+  }
+}
+
 export function dataDir(projectId: string): string {
+  assertSafeSegment(projectId, "projectId");
   return path.join(getDataRoot(), projectId);
 }
 
@@ -19,6 +67,7 @@ export function filesDir(projectId: string): string {
 }
 
 export function fileRecordPath(projectId: string, filePath: string): string {
+  assertSafeFilePath(filePath);
   return path.join(filesDir(projectId), filePath + ".json");
 }
 
@@ -29,6 +78,7 @@ export function runsDir(projectId: string): string {
 }
 
 export function runMetaPath(projectId: string, runId: string): string {
+  assertSafeSegment(runId, "runId");
   return path.join(runsDir(projectId), runId + ".json");
 }
 
@@ -39,16 +89,19 @@ export function reportsDir(projectId: string): string {
 }
 
 export function reportJsonPath(projectId: string, runId?: string): string {
+  if (runId !== undefined) assertSafeSegment(runId, "runId");
   const name = runId ? `report-${runId}.json` : "report.json";
   return path.join(reportsDir(projectId), name);
 }
 
 export function reportMdPath(projectId: string, runId?: string): string {
+  if (runId !== undefined) assertSafeSegment(runId, "runId");
   const name = runId ? `report-${runId}.md` : "report.md";
   return path.join(reportsDir(projectId), name);
 }
 
 export function reportCsvPath(projectId: string, runId?: string): string {
+  if (runId !== undefined) assertSafeSegment(runId, "runId");
   const name = runId ? `report-${runId}.csv` : "report.csv";
   return path.join(reportsDir(projectId), name);
 }

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -20,7 +20,7 @@ export function defaultConcurrency(): number {
 export function generateRunId(): string {
   const now = new Date();
   const ts = now.toISOString().replace(/[-:T]/g, "").slice(0, 14); // YYYYMMDDHHmmss
-  const suffix = crypto.randomBytes(2).toString("hex"); // 4 hex chars
+  const suffix = crypto.randomBytes(8).toString("hex"); // 16 hex chars / 64 bits
   return `${ts}-${suffix}`;
 }
 

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "MIT",
   "repository": {

--- a/packages/deepsec/src/__tests__/credential-brokering.test.ts
+++ b/packages/deepsec/src/__tests__/credential-brokering.test.ts
@@ -59,7 +59,7 @@ describe("credential brokering", () => {
       process.env.ANTHROPIC_AUTH_TOKEN = "vck_supersecret_realvalue";
       process.env.ANTHROPIC_BASE_URL = "https://ai-gateway.vercel.sh";
       const credentials = resolveBrokeredCredentials("claude-agent-sdk");
-      const env = buildSandboxEnv("process", "claude-agent-sdk", credentials);
+      const env = buildSandboxEnv("claude-agent-sdk", credentials);
 
       // The placeholder is set so the SDK can construct, but the real
       // token does not appear anywhere in the env map.
@@ -74,7 +74,7 @@ describe("credential brokering", () => {
       process.env.OPENAI_API_KEY = "sk-real-openai-secret";
       process.env.OPENAI_BASE_URL = "https://api.openai.com";
       const credentials = resolveBrokeredCredentials("codex");
-      const env = buildSandboxEnv("process", "codex", credentials);
+      const env = buildSandboxEnv("codex", credentials);
 
       expect(env.OPENAI_API_KEY).toBeDefined();
       expect(env.OPENAI_API_KEY).not.toBe("sk-real-openai-secret");
@@ -87,7 +87,7 @@ describe("credential brokering", () => {
       // No ANTHROPIC_AUTH_TOKEN set — SDK should fail fast at init rather
       // than 401 from upstream after a brokered placeholder gets through.
       const credentials = resolveBrokeredCredentials("claude-agent-sdk");
-      const env = buildSandboxEnv("process", "claude-agent-sdk", credentials);
+      const env = buildSandboxEnv("claude-agent-sdk", credentials);
       expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
     });
 
@@ -95,7 +95,7 @@ describe("credential brokering", () => {
       process.env.ANTHROPIC_AUTH_TOKEN = "vck_real";
       process.env.ANTHROPIC_BASE_URL = "https://ai-gateway.vercel.sh";
       const credentials = resolveBrokeredCredentials("claude-agent-sdk");
-      const env = buildSandboxEnv("process", "claude-agent-sdk", credentials);
+      const env = buildSandboxEnv("claude-agent-sdk", credentials);
 
       // ANTHROPIC_BASE_URL gets rewritten to the local proxy by buildSandboxEnv
       // so the agent talks to the in-VM proxy. The original is exposed as

--- a/packages/deepsec/src/__tests__/credential-brokering.test.ts
+++ b/packages/deepsec/src/__tests__/credential-brokering.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildSandboxEnv, resolveBrokeredCredentials } from "../sandbox/setup.js";
+
+const TOUCHED_KEYS = [
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+] as const;
+
+describe("credential brokering", () => {
+  let saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of TOUCHED_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of TOUCHED_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  describe("resolveBrokeredCredentials", () => {
+    it("captures ANTHROPIC_AUTH_TOKEN from the orchestrator env", () => {
+      process.env.ANTHROPIC_AUTH_TOKEN = "vck_real";
+      const c = resolveBrokeredCredentials("claude-agent-sdk");
+      expect(c.anthropicToken).toBe("vck_real");
+      expect(c.openaiToken).toBeUndefined();
+    });
+
+    it("falls back to ANTHROPIC token for OpenAI on the codex path", () => {
+      process.env.ANTHROPIC_AUTH_TOKEN = "vck_real";
+      const c = resolveBrokeredCredentials("codex");
+      expect(c.openaiToken).toBe("vck_real");
+    });
+
+    it("does not borrow ANTHROPIC token for OpenAI off the codex path", () => {
+      process.env.ANTHROPIC_AUTH_TOKEN = "vck_real";
+      const c = resolveBrokeredCredentials("claude-agent-sdk");
+      expect(c.openaiToken).toBeUndefined();
+    });
+
+    it("prefers an explicit OPENAI_API_KEY over the anthropic fallback", () => {
+      process.env.ANTHROPIC_AUTH_TOKEN = "vck_anthropic";
+      process.env.OPENAI_API_KEY = "sk-explicit";
+      const c = resolveBrokeredCredentials("codex");
+      expect(c.openaiToken).toBe("sk-explicit");
+    });
+  });
+
+  describe("buildSandboxEnv (the env handed to Sandbox.create)", () => {
+    it("never contains a real ANTHROPIC token", () => {
+      process.env.ANTHROPIC_AUTH_TOKEN = "vck_supersecret_realvalue";
+      process.env.ANTHROPIC_BASE_URL = "https://ai-gateway.vercel.sh";
+      const credentials = resolveBrokeredCredentials("claude-agent-sdk");
+      const env = buildSandboxEnv("process", "claude-agent-sdk", credentials);
+
+      // The placeholder is set so the SDK can construct, but the real
+      // token does not appear anywhere in the env map.
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBeDefined();
+      expect(env.ANTHROPIC_AUTH_TOKEN).not.toBe("vck_supersecret_realvalue");
+      for (const v of Object.values(env)) {
+        expect(v).not.toContain("vck_supersecret_realvalue");
+      }
+    });
+
+    it("never contains a real OPENAI key on the codex path", () => {
+      process.env.OPENAI_API_KEY = "sk-real-openai-secret";
+      process.env.OPENAI_BASE_URL = "https://api.openai.com";
+      const credentials = resolveBrokeredCredentials("codex");
+      const env = buildSandboxEnv("process", "codex", credentials);
+
+      expect(env.OPENAI_API_KEY).toBeDefined();
+      expect(env.OPENAI_API_KEY).not.toBe("sk-real-openai-secret");
+      for (const v of Object.values(env)) {
+        expect(v).not.toContain("sk-real-openai-secret");
+      }
+    });
+
+    it("omits the placeholder when the orchestrator has no token to broker", () => {
+      // No ANTHROPIC_AUTH_TOKEN set — SDK should fail fast at init rather
+      // than 401 from upstream after a brokered placeholder gets through.
+      const credentials = resolveBrokeredCredentials("claude-agent-sdk");
+      const env = buildSandboxEnv("process", "claude-agent-sdk", credentials);
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    });
+
+    it("preserves routing env (base URLs) so the agent knows where to send traffic", () => {
+      process.env.ANTHROPIC_AUTH_TOKEN = "vck_real";
+      process.env.ANTHROPIC_BASE_URL = "https://ai-gateway.vercel.sh";
+      const credentials = resolveBrokeredCredentials("claude-agent-sdk");
+      const env = buildSandboxEnv("process", "claude-agent-sdk", credentials);
+
+      // ANTHROPIC_BASE_URL gets rewritten to the local proxy by buildSandboxEnv
+      // so the agent talks to the in-VM proxy. The original is exposed as
+      // ANTHROPIC_UPSTREAM_BASE_URL for the proxy to forward to.
+      expect(env.ANTHROPIC_UPSTREAM_BASE_URL).toBe("https://ai-gateway.vercel.sh");
+      expect(env.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    });
+  });
+});

--- a/packages/deepsec/src/__tests__/network-policy.test.ts
+++ b/packages/deepsec/src/__tests__/network-policy.test.ts
@@ -1,12 +1,28 @@
+import type { NetworkPolicy, NetworkPolicyRule } from "@vercel/sandbox";
 import { describe, expect, it } from "vitest";
 import { buildWorkerNetworkPolicy } from "../sandbox/setup.js";
 
-function allowed(p: ReturnType<typeof buildWorkerNetworkPolicy>): string[] {
+function policyRecord(p: NetworkPolicy): Record<string, NetworkPolicyRule[]> {
   if (typeof p === "string") throw new Error("expected custom policy, got " + p);
   const a = p.allow;
-  if (!a) throw new Error("expected allow list");
-  if (Array.isArray(a)) return a;
-  return Object.keys(a);
+  if (!a || Array.isArray(a)) throw new Error("expected record-form allow map");
+  return a;
+}
+
+function allowedHosts(p: NetworkPolicy): string[] {
+  return Object.keys(policyRecord(p)).sort();
+}
+
+function bearerFor(p: NetworkPolicy, host: string): string | null {
+  const rules = policyRecord(p)[host];
+  if (!rules) return null;
+  for (const rule of rules) {
+    for (const t of rule.transform ?? []) {
+      const auth = t.headers?.authorization ?? t.headers?.Authorization;
+      if (auth) return auth;
+    }
+  }
+  return null;
 }
 
 describe("buildWorkerNetworkPolicy", () => {
@@ -15,7 +31,7 @@ describe("buildWorkerNetworkPolicy", () => {
       { ANTHROPIC_UPSTREAM_BASE_URL: "https://ai-gateway.vercel.sh" },
       "claude-agent-sdk",
     );
-    expect(allowed(policy)).toEqual(["ai-gateway.vercel.sh"]);
+    expect(allowedHosts(policy)).toEqual(["ai-gateway.vercel.sh"]);
   });
 
   it("uses OPENAI_BASE_URL host on the codex path", () => {
@@ -23,7 +39,7 @@ describe("buildWorkerNetworkPolicy", () => {
       { OPENAI_BASE_URL: "https://ai-gateway.vercel.sh/v1" },
       "codex",
     );
-    expect(allowed(policy)).toEqual(["ai-gateway.vercel.sh"]);
+    expect(allowedHosts(policy)).toEqual(["ai-gateway.vercel.sh"]);
   });
 
   it("ignores ANTHROPIC_UPSTREAM_BASE_URL when agentType is codex", () => {
@@ -34,16 +50,15 @@ describe("buildWorkerNetworkPolicy", () => {
       },
       "codex",
     );
-    expect(allowed(policy)).toEqual(["api.openai.com"]);
+    expect(allowedHosts(policy)).toEqual(["api.openai.com"]);
   });
 
-  it("falls back to documented hosts when no upstream URL is set", () => {
-    const policy = buildWorkerNetworkPolicy({}, "claude-agent-sdk");
-    expect(allowed(policy).sort()).toEqual([
-      "ai-gateway.vercel.sh",
-      "api.anthropic.com",
-      "api.openai.com",
-    ]);
+  it("falls back to the provider default when no upstream URL is set", () => {
+    const claudePolicy = buildWorkerNetworkPolicy({}, "claude-agent-sdk");
+    expect(allowedHosts(claudePolicy)).toEqual(["api.anthropic.com"]);
+
+    const codexPolicy = buildWorkerNetworkPolicy({}, "codex");
+    expect(allowedHosts(codexPolicy)).toEqual(["api.openai.com"]);
   });
 
   it("falls back when the URL is unparseable", () => {
@@ -51,24 +66,77 @@ describe("buildWorkerNetworkPolicy", () => {
       { ANTHROPIC_UPSTREAM_BASE_URL: "not a url" },
       "claude-agent-sdk",
     );
-    expect(allowed(policy)).toContain("ai-gateway.vercel.sh");
+    expect(allowedHosts(policy)).toEqual(["api.anthropic.com"]);
   });
 
   it("merges extraAllowedHosts with the derived host", () => {
     const policy = buildWorkerNetworkPolicy(
       { ANTHROPIC_UPSTREAM_BASE_URL: "https://ai-gateway.vercel.sh" },
       "claude-agent-sdk",
+      {},
       ["telemetry.example.com"],
     );
-    expect(allowed(policy).sort()).toEqual(["ai-gateway.vercel.sh", "telemetry.example.com"]);
+    expect(allowedHosts(policy)).toEqual(["ai-gateway.vercel.sh", "telemetry.example.com"]);
   });
 
   it("dedupes when extras overlap with the derived host", () => {
     const policy = buildWorkerNetworkPolicy(
       { ANTHROPIC_UPSTREAM_BASE_URL: "https://api.anthropic.com" },
       "claude-agent-sdk",
+      {},
       ["api.anthropic.com"],
     );
-    expect(allowed(policy)).toEqual(["api.anthropic.com"]);
+    expect(allowedHosts(policy)).toEqual(["api.anthropic.com"]);
+  });
+
+  describe("credential brokering", () => {
+    it("injects Authorization on the claude AI host when a token is provided", () => {
+      const policy = buildWorkerNetworkPolicy(
+        { ANTHROPIC_UPSTREAM_BASE_URL: "https://ai-gateway.vercel.sh" },
+        "claude-agent-sdk",
+        { anthropicToken: "vck_realtoken" },
+      );
+      expect(bearerFor(policy, "ai-gateway.vercel.sh")).toBe("Bearer vck_realtoken");
+    });
+
+    it("injects Authorization on the codex AI host when an OpenAI token is provided", () => {
+      const policy = buildWorkerNetworkPolicy(
+        { OPENAI_BASE_URL: "https://ai-gateway.vercel.sh/v1" },
+        "codex",
+        { openaiToken: "vck_realtoken" },
+      );
+      expect(bearerFor(policy, "ai-gateway.vercel.sh")).toBe("Bearer vck_realtoken");
+    });
+
+    it("emits no transform when no matching credential is provided", () => {
+      const policy = buildWorkerNetworkPolicy(
+        { ANTHROPIC_UPSTREAM_BASE_URL: "https://ai-gateway.vercel.sh" },
+        "claude-agent-sdk",
+        {},
+      );
+      expect(policyRecord(policy)["ai-gateway.vercel.sh"]).toEqual([]);
+    });
+
+    it("does not inject the anthropic token when running codex without an openai token", () => {
+      // The anthropic-as-openai fallback happens at resolveBrokeredCredentials,
+      // not here — this layer only sees what was passed in.
+      const policy = buildWorkerNetworkPolicy(
+        { OPENAI_BASE_URL: "https://api.openai.com" },
+        "codex",
+        { anthropicToken: "vck_realtoken" },
+      );
+      expect(bearerFor(policy, "api.openai.com")).toBeNull();
+    });
+
+    it("does not attach the transform to extra allowed hosts", () => {
+      const policy = buildWorkerNetworkPolicy(
+        { ANTHROPIC_UPSTREAM_BASE_URL: "https://ai-gateway.vercel.sh" },
+        "claude-agent-sdk",
+        { anthropicToken: "vck_realtoken" },
+        ["telemetry.example.com"],
+      );
+      expect(bearerFor(policy, "ai-gateway.vercel.sh")).toBe("Bearer vck_realtoken");
+      expect(bearerFor(policy, "telemetry.example.com")).toBeNull();
+    });
   });
 });

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { assertAgentCredential, assertSandboxCredential } from "../preflight.js";
+
+describe("assertAgentCredential", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {
+      ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    };
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.OPENAI_API_KEY;
+  });
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("passes for claude-agent-sdk when ANTHROPIC_AUTH_TOKEN is set", () => {
+    process.env.ANTHROPIC_AUTH_TOKEN = "x";
+    expect(() => assertAgentCredential("claude-agent-sdk")).not.toThrow();
+  });
+
+  it("throws actionable message for claude-agent-sdk when no token", () => {
+    expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(/ANTHROPIC_AUTH_TOKEN/);
+    expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(/\.env\.local/);
+  });
+
+  it("passes for codex when OPENAI_API_KEY is set", () => {
+    process.env.OPENAI_API_KEY = "x";
+    expect(() => assertAgentCredential("codex")).not.toThrow();
+  });
+
+  it("passes for codex when only ANTHROPIC token is set (gateway fallback)", () => {
+    process.env.ANTHROPIC_AUTH_TOKEN = "x";
+    expect(() => assertAgentCredential("codex")).not.toThrow();
+  });
+
+  it("throws for codex when no token", () => {
+    expect(() => assertAgentCredential("codex")).toThrow(/OPENAI_API_KEY/);
+  });
+});
+
+describe("assertSandboxCredential", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {
+      VERCEL_OIDC_TOKEN: process.env.VERCEL_OIDC_TOKEN,
+      VERCEL_TOKEN: process.env.VERCEL_TOKEN,
+      VERCEL_TEAM_ID: process.env.VERCEL_TEAM_ID,
+      VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID,
+    };
+    for (const k of Object.keys(saved)) delete process.env[k];
+  });
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("passes when OIDC token is set", () => {
+    process.env.VERCEL_OIDC_TOKEN = "x";
+    expect(() => assertSandboxCredential()).not.toThrow();
+  });
+
+  it("passes when access-token triple is set", () => {
+    process.env.VERCEL_TOKEN = "x";
+    process.env.VERCEL_TEAM_ID = "team_x";
+    process.env.VERCEL_PROJECT_ID = "prj_x";
+    expect(() => assertSandboxCredential()).not.toThrow();
+  });
+
+  it("throws actionable message when nothing is set", () => {
+    expect(() => assertSandboxCredential()).toThrow(/vercel link/);
+    expect(() => assertSandboxCredential()).toThrow(/VERCEL_OIDC_TOKEN/);
+  });
+
+  it("names every missing access-token piece", () => {
+    process.env.VERCEL_TOKEN = "x";
+    expect(() => assertSandboxCredential()).toThrow(/VERCEL_TEAM_ID, VERCEL_PROJECT_ID/);
+  });
+});

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { assertAgentCredential, assertSandboxCredential } from "../preflight.js";
+import {
+  applyAiGatewayDefaults,
+  assertAgentCredential,
+  assertSandboxCredential,
+} from "../preflight.js";
 
 describe("assertAgentCredential", () => {
   let saved: Record<string, string | undefined>;
@@ -81,5 +85,58 @@ describe("assertSandboxCredential", () => {
   it("names every missing access-token piece", () => {
     process.env.VERCEL_TOKEN = "x";
     expect(() => assertSandboxCredential()).toThrow(/VERCEL_TEAM_ID, VERCEL_PROJECT_ID/);
+  });
+});
+
+describe("applyAiGatewayDefaults", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {
+      AI_GATEWAY_API_KEY: process.env.AI_GATEWAY_API_KEY,
+      ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+      OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+    };
+    for (const k of Object.keys(saved)) delete process.env[k];
+  });
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("does nothing when AI_GATEWAY_API_KEY is unset", () => {
+    applyAiGatewayDefaults();
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it("populates all four vars from AI_GATEWAY_API_KEY", () => {
+    process.env.AI_GATEWAY_API_KEY = "gw-key";
+    applyAiGatewayDefaults();
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("gw-key");
+    expect(process.env.OPENAI_API_KEY).toBe("gw-key");
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://ai-gateway.vercel.sh");
+    expect(process.env.OPENAI_BASE_URL).toBe("https://ai-gateway.vercel.sh/v1");
+  });
+
+  it("does not overwrite explicit ANTHROPIC_AUTH_TOKEN", () => {
+    process.env.AI_GATEWAY_API_KEY = "gw-key";
+    process.env.ANTHROPIC_AUTH_TOKEN = "explicit-anthropic";
+    applyAiGatewayDefaults();
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("explicit-anthropic");
+    expect(process.env.OPENAI_API_KEY).toBe("gw-key");
+  });
+
+  it("does not overwrite an explicit ANTHROPIC_BASE_URL pointing direct-to-provider", () => {
+    process.env.AI_GATEWAY_API_KEY = "gw-key";
+    process.env.ANTHROPIC_BASE_URL = "https://api.anthropic.com";
+    applyAiGatewayDefaults();
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://api.anthropic.com");
+    expect(process.env.OPENAI_BASE_URL).toBe("https://ai-gateway.vercel.sh/v1");
   });
 });

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -3,6 +3,13 @@ import { config as dotenvConfig } from "dotenv";
 dotenvConfig({ path: ".env.local" });
 dotenvConfig(); // also load .env as fallback
 
+import { applyAiGatewayDefaults } from "./preflight.js";
+
+// If AI_GATEWAY_API_KEY is set, expand it into ANTHROPIC_AUTH_TOKEN /
+// OPENAI_API_KEY / *_BASE_URL before any agent module reads them. Must
+// run after dotenv and before the command modules import.
+applyAiGatewayDefaults();
+
 import { getRegistry } from "@deepsec/core";
 import { Command } from "commander";
 import { enrichCommand } from "./commands/enrich.js";

--- a/packages/deepsec/src/commands/export.ts
+++ b/packages/deepsec/src/commands/export.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { FileRecord, Finding, Severity } from "@deepsec/core";
-import { dataDir, loadAllFileRecords } from "@deepsec/core";
+import { dataDir, getDataRoot, loadAllFileRecords } from "@deepsec/core";
 import { BOLD, DIM, GREEN, RESET, YELLOW } from "../formatters.js";
 
 const SEVERITY_ORDER: Record<Severity, number> = {
@@ -220,7 +220,7 @@ function startOfTodayLocal(): number {
 }
 
 function listProjectIds(): string[] {
-  const dataDirPath = path.resolve("data");
+  const dataDirPath = path.resolve(getDataRoot());
   if (!fs.existsSync(dataDirPath)) return [];
   return fs
     .readdirSync(dataDirPath, { withFileTypes: true })

--- a/packages/deepsec/src/commands/init-project.ts
+++ b/packages/deepsec/src/commands/init-project.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { dataDir, ensureProject } from "@deepsec/core";
 import { BOLD, DIM, GREEN, RESET, YELLOW } from "../formatters.js";
 import { requireExistingDir } from "../require-dir.js";
+import { validateProjectId } from "../resolve-project-id.js";
 
 export const PROJECTS_INSERT_MARKER = "// <deepsec:projects-insert-above>";
 
@@ -54,7 +55,7 @@ export function registerProject(opts: {
 }): RegisterResult {
   const workspaceDir = fs.realpathSync(path.resolve(opts.workspaceDir));
   const targetAbs = requireExistingDir(opts.targetRoot, "<target-root>");
-  const id = opts.id ?? path.basename(targetAbs);
+  const id = validateProjectId(opts.id ?? path.basename(targetAbs));
   const targetRel = path.relative(workspaceDir, targetAbs);
 
   const configPath = findConfigInWorkspace(workspaceDir);

--- a/packages/deepsec/src/commands/init.ts
+++ b/packages/deepsec/src/commands/init.ts
@@ -77,7 +77,7 @@ export function initCommand(opts: InitOpts) {
   console.log("Next:\n");
   if (wsRel !== ".") console.log(`  cd ${wsRel}`);
   console.log(`  pnpm install                          ${DIM}# installs deepsec${RESET}`);
-  console.log(`  ${DIM}# Set ANTHROPIC_AUTH_TOKEN in .env.local${RESET}`);
+  console.log(`  ${DIM}# Set AI_GATEWAY_API_KEY in .env.local${RESET}`);
   console.log();
   console.log(
     `  ${YELLOW}Paste this into your coding agent${RESET} ${DIM}(Claude Code, Cursor, Codex CLI):${RESET}`,
@@ -262,8 +262,10 @@ The deepsec skill is at \`node_modules/deepsec/SKILL.md\` (after
 }
 
 function envLocal(): string {
-  return `ANTHROPIC_AUTH_TOKEN=
-ANTHROPIC_BASE_URL=https://ai-gateway.vercel.sh
+  // One-line gateway setup. deepsec expands AI_GATEWAY_API_KEY at startup
+  // into ANTHROPIC_AUTH_TOKEN / OPENAI_API_KEY / *_BASE_URL, so a user
+  // who only has a gateway key is fully wired with this single line.
+  return `AI_GATEWAY_API_KEY=
 `;
 }
 

--- a/packages/deepsec/src/commands/metrics.ts
+++ b/packages/deepsec/src/commands/metrics.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { loadAllFileRecords } from "@deepsec/core";
+import { getDataRoot, loadAllFileRecords } from "@deepsec/core";
 import { BOLD, DIM, GREEN, RED, RESET, YELLOW } from "../formatters.js";
 
 const SEVERITY_ORDER: Record<string, number> = {
@@ -25,7 +25,7 @@ interface ProjectMetrics {
 }
 
 function discoverProjects(): string[] {
-  const dataDir = path.resolve("data");
+  const dataDir = path.resolve(getDataRoot());
   if (!fs.existsSync(dataDir)) return [];
   return fs
     .readdirSync(dataDir, { withFileTypes: true })

--- a/packages/deepsec/src/commands/process.ts
+++ b/packages/deepsec/src/commands/process.ts
@@ -2,6 +2,7 @@ import { readProjectConfig } from "@deepsec/core";
 import { process as processRun } from "@deepsec/processor";
 import { defaultModelForAgent } from "../agent-defaults.js";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "../formatters.js";
+import { assertAgentCredential } from "../preflight.js";
 import { resolveProjectId } from "../resolve-project-id.js";
 
 function logProgress(progress: {
@@ -90,6 +91,8 @@ export async function processCommand(opts: {
   const effectiveRoot = opts.root ?? project.rootPath;
   const agentType = opts.agent ?? "claude-agent-sdk";
   const model = opts.model ?? defaultModelForAgent(agentType);
+
+  assertAgentCredential(agentType);
 
   // --reinvestigate  → true (re-investigate all)
   // --reinvestigate 2 → number (only files with < 2 analyses)

--- a/packages/deepsec/src/commands/revalidate.ts
+++ b/packages/deepsec/src/commands/revalidate.ts
@@ -3,6 +3,7 @@ import { readProjectConfig } from "@deepsec/core";
 import { revalidate } from "@deepsec/processor";
 import { defaultModelForAgent } from "../agent-defaults.js";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "../formatters.js";
+import { assertAgentCredential } from "../preflight.js";
 import { resolveProjectId } from "../resolve-project-id.js";
 
 function logProgress(progress: {
@@ -74,6 +75,8 @@ export async function revalidateCommand(opts: {
   const minSeverity = opts.minSeverity as Severity | undefined;
   const onlySlugs = parseCsv(opts.onlySlugs);
   const skipSlugs = parseCsv(opts.skipSlugs);
+
+  assertAgentCredential(agentType);
 
   console.log(`${BOLD}Revalidating${RESET} findings for project ${BOLD}${projectId}${RESET}`);
   console.log(`  Agent: ${agentType} (${model})`);

--- a/packages/deepsec/src/commands/sandbox-all.ts
+++ b/packages/deepsec/src/commands/sandbox-all.ts
@@ -2,10 +2,24 @@ import fs from "node:fs";
 import path from "node:path";
 import { getDataRoot, readProjectConfig } from "@deepsec/core";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET } from "../formatters.js";
+import { assertAgentCredential, assertSandboxCredential } from "../preflight.js";
 import { orchestrate } from "../sandbox/orchestrator.js";
 import { partitionFiles } from "../sandbox/partitioner.js";
 import type { SandboxConfig, SandboxSubcommand } from "../sandbox/types.js";
 import { extractReinvestigate } from "./sandbox-process.js";
+
+// Mirror of VALID_COMMANDS in sandbox-process.ts. Kept in sync by hand —
+// `enrich` is intentionally excluded: it runs locally (git committer
+// lookups, ownership-plugin RPC) and the worker env-forwarding path that
+// used to cover its credentials no longer exists, so a sandboxed enrich
+// would run half-configured rather than fail clearly.
+const VALID_COMMANDS: ReadonlySet<SandboxSubcommand> = new Set([
+  "process",
+  "revalidate",
+  "triage",
+  "scan",
+  "report",
+]);
 
 function extractFlag(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
@@ -55,12 +69,28 @@ export async function sandboxAllCommand(
     args?: string[];
   },
 ) {
+  if (!VALID_COMMANDS.has(subcommand as SandboxSubcommand)) {
+    console.error(`Unknown sandbox-all subcommand: ${subcommand}`);
+    console.error(`Valid commands: ${Array.from(VALID_COMMANDS).join(", ")}`);
+    if (subcommand === "enrich") {
+      console.error(
+        `  enrich runs locally (git history + ownership lookups) and is not sandboxed.\n` +
+          `  Run \`deepsec enrich --project-id <id>\` directly instead.`,
+      );
+    }
+    process.exit(1);
+  }
   const command = subcommand as SandboxSubcommand;
   const passthrough = opts.args ?? [];
   const totalSandboxes = opts.sandboxes ?? 10;
   const concurrency = parseInt(extractFlag(passthrough, "--concurrency") ?? "4", 10) || 4;
   const vcpus = opts.vcpus ?? Math.min(Math.ceil(concurrency / 2) * 2, 8);
   const timeout = opts.timeout ?? 5 * 60 * 60 * 1000;
+  const agentType = extractFlag(passthrough, "--agent") ?? "claude-agent-sdk";
+
+  // Same preflight as sandbox-process — fail fast before fanning out.
+  assertSandboxCredential();
+  assertAgentCredential(agentType);
 
   console.log(`${BOLD}Sandbox All${RESET} — ${CYAN}${command}${RESET}`);
   console.log(`  Total sandboxes: ${totalSandboxes}`);
@@ -147,10 +177,10 @@ export async function sandboxAllCommand(
       limit: undefined,
       concurrency,
       batchSize: parseInt(extractFlag(passthrough, "--batch-size") ?? "5", 10) || 5,
-      agentType: extractFlag(passthrough, "--agent") ?? "claude-agent-sdk",
+      agentType,
       model:
         extractFlag(passthrough, "--model") ??
-        (extractFlag(passthrough, "--agent") === "codex" ? "gpt-5.5" : "claude-opus-4-7"),
+        (agentType === "codex" ? "gpt-5.5" : "claude-opus-4-7"),
       snapshotId: undefined,
       saveSnapshot: false,
       keepAlive: false,

--- a/packages/deepsec/src/commands/sandbox-all.ts
+++ b/packages/deepsec/src/commands/sandbox-all.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { readProjectConfig } from "@deepsec/core";
+import { getDataRoot, readProjectConfig } from "@deepsec/core";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET } from "../formatters.js";
 import { orchestrate } from "../sandbox/orchestrator.js";
 import { partitionFiles } from "../sandbox/partitioner.js";
@@ -20,7 +20,7 @@ function hasFlag(args: string[], flag: string): boolean {
 }
 
 function discoverProjects(): string[] {
-  const dataDir = path.resolve("data");
+  const dataDir = path.resolve(getDataRoot());
   if (!fs.existsSync(dataDir)) return [];
   return fs
     .readdirSync(dataDir, { withFileTypes: true })

--- a/packages/deepsec/src/commands/sandbox-process.ts
+++ b/packages/deepsec/src/commands/sandbox-process.ts
@@ -3,14 +3,7 @@ import { resolveProjectId } from "../resolve-project-id.js";
 import { checkStatus, collect, launch, orchestrate } from "../sandbox/orchestrator.js";
 import type { SandboxConfig, SandboxSubcommand } from "../sandbox/types.js";
 
-const VALID_COMMANDS: SandboxSubcommand[] = [
-  "process",
-  "revalidate",
-  "triage",
-  "enrich",
-  "scan",
-  "report",
-];
+const VALID_COMMANDS: SandboxSubcommand[] = ["process", "revalidate", "triage", "scan", "report"];
 
 interface SandboxOpts {
   projectId?: string;

--- a/packages/deepsec/src/commands/sandbox-process.ts
+++ b/packages/deepsec/src/commands/sandbox-process.ts
@@ -1,4 +1,5 @@
 import { BOLD, CYAN, DIM, GREEN, RED, RESET } from "../formatters.js";
+import { assertAgentCredential, assertSandboxCredential } from "../preflight.js";
 import { resolveProjectId } from "../resolve-project-id.js";
 import { checkStatus, collect, launch, orchestrate } from "../sandbox/orchestrator.js";
 import type { SandboxConfig, SandboxSubcommand } from "../sandbox/types.js";
@@ -139,6 +140,13 @@ export async function sandboxCommand(subcommand: string, opts: SandboxOpts) {
 
   const projectId = resolveProjectId(opts.projectId);
   const config = buildConfig(subcommand as SandboxSubcommand, projectId, opts);
+
+  // Preflight: fail fast with an actionable message before we spend ~30s
+  // on a doomed bootstrap sandbox. The credential brokering path needs
+  // both a Vercel auth token (to create the sandbox) and an AI token (to
+  // inject into the firewall transform).
+  assertSandboxCredential();
+  assertAgentCredential(config.agentType);
 
   console.log(
     `${BOLD}Sandbox${RESET} — ${CYAN}${config.command}${RESET} — ${BOLD}${config.projectId}${RESET}`,

--- a/packages/deepsec/src/commands/triage.ts
+++ b/packages/deepsec/src/commands/triage.ts
@@ -2,6 +2,7 @@ import type { Severity } from "@deepsec/core";
 import { readProjectConfig } from "@deepsec/core";
 import { triage } from "@deepsec/processor";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "../formatters.js";
+import { assertAgentCredential } from "../preflight.js";
 import { resolveProjectId } from "../resolve-project-id.js";
 
 export async function triageCommand(opts: {
@@ -16,6 +17,9 @@ export async function triageCommand(opts: {
   readProjectConfig(projectId);
   const severity = (opts.severity ?? "MEDIUM") as Severity;
   const model = opts.model ?? "claude-sonnet-4-6";
+
+  // Triage uses Anthropic directly — no codex path here.
+  assertAgentCredential("claude-agent-sdk");
 
   console.log(
     `${BOLD}Triaging${RESET} ${severity} findings for project ${BOLD}${projectId}${RESET}`,

--- a/packages/deepsec/src/data-commit.ts
+++ b/packages/deepsec/src/data-commit.ts
@@ -1,8 +1,20 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
+import { getDataRoot } from "@deepsec/core";
 
-const DATA_DIR = path.resolve("data");
-const DATA_BRANCH = process.env.DEEPSEC_DATA_BRANCH ?? "main";
+const DATA_DIR = path.resolve(getDataRoot());
+
+// A git ref name. Validated up front so we can pass DATA_BRANCH to git
+// without the shell interpreting `;`/`$(...)` etc. — git itself rejects
+// many of these but we don't rely on that.
+const REF_RE = /^[A-Za-z0-9._/-]+$/;
+const RAW_BRANCH = process.env.DEEPSEC_DATA_BRANCH ?? "main";
+if (!REF_RE.test(RAW_BRANCH)) {
+  throw new Error(
+    `Invalid DEEPSEC_DATA_BRANCH ${JSON.stringify(RAW_BRANCH)}: must match ${REF_RE}.`,
+  );
+}
+const DATA_BRANCH = RAW_BRANCH;
 
 /**
  * Commit any changes in the data repo and push to origin.
@@ -13,7 +25,7 @@ export function commitAndPushData(message: string): boolean {
   // execSync buffer with a single `git status --porcelain` call.
   const MAX_BUFFER = 256 * 1024 * 1024;
 
-  const status = execSync("git status --porcelain", {
+  const status = execFileSync("git", ["status", "--porcelain"], {
     cwd: DATA_DIR,
     encoding: "utf-8",
     timeout: 10000,
@@ -22,13 +34,15 @@ export function commitAndPushData(message: string): boolean {
 
   if (!status) return false;
 
-  execSync("git add -A", {
+  execFileSync("git", ["add", "-A"], {
     cwd: DATA_DIR,
     encoding: "utf-8",
     timeout: 60000,
     maxBuffer: MAX_BUFFER,
   });
-  execSync(`git commit -m ${JSON.stringify(message)}`, {
+  // argv form so `message` (and any caller-derived value like projectId)
+  // is never re-parsed by a shell.
+  execFileSync("git", ["commit", "-m", message], {
     cwd: DATA_DIR,
     encoding: "utf-8",
     timeout: 60000,
@@ -38,13 +52,13 @@ export function commitAndPushData(message: string): boolean {
   let retries = 3;
   while (retries > 0) {
     try {
-      execSync(`git pull --rebase origin ${DATA_BRANCH}`, {
+      execFileSync("git", ["pull", "--rebase", "origin", DATA_BRANCH], {
         cwd: DATA_DIR,
         encoding: "utf-8",
         timeout: 30000,
         maxBuffer: MAX_BUFFER,
       });
-      execSync(`git push origin HEAD:${DATA_BRANCH}`, {
+      execFileSync("git", ["push", "origin", `HEAD:${DATA_BRANCH}`], {
         cwd: DATA_DIR,
         encoding: "utf-8",
         timeout: 30000,

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -10,6 +10,33 @@
 
 const SETUP_DOC = "docs/vercel-setup.md";
 
+// Vercel AI Gateway endpoints. The Anthropic adapter is at the root; the
+// OpenAI-compatible adapter is at /v1 (codex appends /responses to it).
+const GATEWAY_ANTHROPIC_BASE_URL = "https://ai-gateway.vercel.sh";
+const GATEWAY_OPENAI_BASE_URL = "https://ai-gateway.vercel.sh/v1";
+
+/**
+ * If the user set `AI_GATEWAY_API_KEY`, expand it into the four env vars
+ * the agent SDKs actually read. Lets a user run with a single token
+ * instead of duplicating it across `ANTHROPIC_AUTH_TOKEN` /
+ * `OPENAI_API_KEY` (the gateway accepts the same token for both).
+ *
+ * Existing values always win — this only fills in what's missing, so a
+ * user who has set, say, `ANTHROPIC_BASE_URL=https://api.anthropic.com`
+ * for direct-to-provider access doesn't get silently rerouted.
+ *
+ * Call this once at CLI startup (after dotenv loads .env.local), before
+ * any module reads these vars.
+ */
+export function applyAiGatewayDefaults(): void {
+  const key = process.env.AI_GATEWAY_API_KEY;
+  if (!key) return;
+  if (!process.env.ANTHROPIC_AUTH_TOKEN) process.env.ANTHROPIC_AUTH_TOKEN = key;
+  if (!process.env.OPENAI_API_KEY) process.env.OPENAI_API_KEY = key;
+  if (!process.env.ANTHROPIC_BASE_URL) process.env.ANTHROPIC_BASE_URL = GATEWAY_ANTHROPIC_BASE_URL;
+  if (!process.env.OPENAI_BASE_URL) process.env.OPENAI_BASE_URL = GATEWAY_OPENAI_BASE_URL;
+}
+
 function isCodex(agentType: string | undefined): boolean {
   return agentType === "codex";
 }

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -1,0 +1,73 @@
+// Preflight checks run before we spin up sandboxes or agent SDKs.
+//
+// The motivation: when env vars are missing, the failure surfaces deep in
+// upstream code — Anthropic SDK throws "API key not found" with no hint
+// the issue is on the orchestrator host, the Vercel SDK errors look like
+// auth problems somewhere remote, and the sandbox firewall happily emits
+// `{ allow: { host: [] } }` with no transform rule so requests later 401
+// from upstream as if it were a model issue. Each variant has cost the
+// human time before, so we trade ~20 lines for a clear message up front.
+
+const SETUP_DOC = "docs/vercel-setup.md";
+
+function isCodex(agentType: string | undefined): boolean {
+  return agentType === "codex";
+}
+
+/**
+ * Verify the orchestrator has an AI credential the chosen agent can use.
+ * Throws with a concrete pointer at .env.local when it doesn't — the
+ * sandbox path brokers credentials via firewall header injection, but
+ * that only works if the orchestrator actually has a token to inject.
+ */
+export function assertAgentCredential(agentType: string | undefined): void {
+  const anthropic = process.env.ANTHROPIC_AUTH_TOKEN;
+  const openai = process.env.OPENAI_API_KEY;
+
+  if (isCodex(agentType)) {
+    // Codex prefers OPENAI_API_KEY; AI Gateway issues a single token that
+    // authenticates both backends, so an ANTHROPIC token is also accepted.
+    if (openai || anthropic) return;
+    throw new Error(
+      `Missing AI credentials for --agent codex.\n` +
+        `  Set OPENAI_API_KEY (preferred) or ANTHROPIC_AUTH_TOKEN in .env.local.\n` +
+        `  See ${SETUP_DOC} for AI Gateway setup.`,
+    );
+  }
+
+  if (anthropic) return;
+  throw new Error(
+    `Missing AI credentials for --agent ${agentType ?? "claude-agent-sdk"}.\n` +
+      `  Set ANTHROPIC_AUTH_TOKEN in .env.local.\n` +
+      `  See ${SETUP_DOC} for AI Gateway setup.`,
+  );
+}
+
+/**
+ * Verify the orchestrator has Vercel Sandbox credentials. Inside a Vercel
+ * deployment OIDC is automatic; locally the user runs `vercel link` +
+ * `vercel env pull` to land VERCEL_OIDC_TOKEN in .env.local, OR sets the
+ * three explicit access-token env vars.
+ */
+export function assertSandboxCredential(): void {
+  const oidc = process.env.VERCEL_OIDC_TOKEN;
+  if (oidc) return;
+
+  const token = process.env.VERCEL_TOKEN;
+  const teamId = process.env.VERCEL_TEAM_ID;
+  const projectId = process.env.VERCEL_PROJECT_ID;
+  if (token && teamId && projectId) return;
+
+  const missing: string[] = [];
+  if (!token) missing.push("VERCEL_TOKEN");
+  if (!teamId) missing.push("VERCEL_TEAM_ID");
+  if (!projectId) missing.push("VERCEL_PROJECT_ID");
+
+  throw new Error(
+    `Missing Vercel Sandbox credentials.\n` +
+      `  Recommended: run \`npx vercel link\` then \`npx vercel env pull\` to\n` +
+      `  populate VERCEL_OIDC_TOKEN in .env.local.\n` +
+      `  Alternative: set ${missing.join(", ")} (access-token mode).\n` +
+      `  See ${SETUP_DOC}.`,
+  );
+}

--- a/packages/deepsec/src/resolve-project-id.ts
+++ b/packages/deepsec/src/resolve-project-id.ts
@@ -1,5 +1,22 @@
 import { getConfig } from "@deepsec/core";
 
+// Strict allowlist for project ids. Catches `..`, path separators, shell
+// metacharacters, and whitespace in one place — every CLI entry point and
+// every config-supplied id flows through here, so downstream callers
+// (path joins, sandbox `sh -c` interpolation, git commit messages) can
+// treat the value as opaque.
+const PROJECT_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+function validateProjectId(id: string): string {
+  if (!PROJECT_ID_RE.test(id)) {
+    throw new Error(
+      `Invalid project id ${JSON.stringify(id)}: must match ${PROJECT_ID_RE} ` +
+        `(letters, digits, '.', '_', '-'; up to 64 chars; must not start with a separator).`,
+    );
+  }
+  return id;
+}
+
 /**
  * Resolve a project id from CLI input or the loaded config.
  *
@@ -12,12 +29,12 @@ import { getConfig } from "@deepsec/core";
  * didn't disambiguate.
  */
 export function resolveProjectId(provided: string | undefined): string {
-  if (provided) return provided;
+  if (provided) return validateProjectId(provided);
 
   const config = getConfig();
   const projects = config?.projects ?? [];
 
-  if (projects.length === 1) return projects[0].id;
+  if (projects.length === 1) return validateProjectId(projects[0].id);
 
   if (projects.length === 0) {
     throw new Error(
@@ -32,3 +49,5 @@ export function resolveProjectId(provided: string | undefined): string {
     `Multiple projects in deepsec.config.ts: ${ids}.\n` + `  Pass --project-id <id> to pick one.`,
   );
 }
+
+export { validateProjectId };

--- a/packages/deepsec/src/sandbox/orchestrator.ts
+++ b/packages/deepsec/src/sandbox/orchestrator.ts
@@ -200,7 +200,6 @@ async function bootstrapAndSpawn(
     const bundle = await prepareUploads(config, ctx.mode, ctx.root, onLog);
     snapshotId = await createBootstrapSnapshot({
       projectId: config.projectId,
-      command: config.command,
       agentType: config.agentType,
       vcpus: config.vcpus,
       timeout: config.timeout,
@@ -219,7 +218,6 @@ async function bootstrapAndSpawn(
     try {
       const sandbox = await spawnFromSnapshot({
         snapshotId: snapshotId!,
-        command: config.command,
         agentType: config.agentType,
         vcpus: config.vcpus,
         timeout: config.timeout,

--- a/packages/deepsec/src/sandbox/setup.ts
+++ b/packages/deepsec/src/sandbox/setup.ts
@@ -1,4 +1,4 @@
-import { type NetworkPolicy, Sandbox } from "@vercel/sandbox";
+import { type NetworkPolicy, type NetworkPolicyRule, Sandbox } from "@vercel/sandbox";
 import { markSetupComplete } from "./download.js";
 import { trackSandbox, untrackSandbox } from "./shutdown.js";
 import { extractTarballOnSandbox, type TarballStats, uploadTarballToSandbox } from "./upload.js";
@@ -36,11 +36,13 @@ export interface UploadBundle {
 
 // --- Sandbox env vars ---
 
+// Routing / debug knobs the agent reads inside the sandbox. AI credential
+// env vars (ANTHROPIC_AUTH_TOKEN, OPENAI_API_KEY, AI_GATEWAY_API_KEY) are
+// deliberately absent — they're brokered via firewall header injection
+// (see resolveBrokeredCredentials + buildWorkerNetworkPolicy below) so a
+// compromised in-VM agent can't read them out of /proc/<pid>/environ.
 const BASE_SANDBOX_ENV_KEYS: string[] = [
-  "AI_GATEWAY_API_KEY",
-  "ANTHROPIC_AUTH_TOKEN",
   "ANTHROPIC_BASE_URL",
-  "OPENAI_API_KEY",
   "OPENAI_BASE_URL",
   "DEEPSEC_AGENT_DEBUG",
 ];
@@ -48,6 +50,42 @@ const BASE_SANDBOX_ENV_KEYS: string[] = [
 const COMMAND_ENV_KEYS: Record<string, string[]> = {
   enrich: ["PEOPLE_SH_BYPASS", "OWNERSHIP_AUTH_TOKEN"],
 };
+
+/**
+ * The Anthropic / OpenAI SDKs throw at construction if no auth token is set.
+ * We need *something* in env so the SDK builds, but the value must not be a
+ * real secret — the firewall transform below replaces it on every outbound
+ * request. Deliberately recognizable so a curious greppy reader knows it's
+ * a decoy. Length is set to keep the agent SDK's "looks like a token" sniff
+ * tests happy without resembling any real provider format.
+ */
+const BROKERED_TOKEN_PLACEHOLDER = "deepsec-sandbox-brokered-credential";
+
+/**
+ * Real credentials live on the orchestrator host only. The sandbox sees a
+ * placeholder; the firewall replaces the Authorization header at egress
+ * with the real token.
+ */
+interface BrokeredCredentials {
+  anthropicToken?: string;
+  openaiToken?: string;
+}
+
+/**
+ * Resolve the orchestrator-side AI credentials that will be brokered into
+ * the sandbox. AI Gateway issues one token per team that authenticates both
+ * Claude and OpenAI traffic, so when only ANTHROPIC_AUTH_TOKEN is set and
+ * the worker is going to run codex, fall it back as the OpenAI token.
+ */
+export function resolveBrokeredCredentials(agentType: string | undefined): BrokeredCredentials {
+  const anthropicToken = process.env.ANTHROPIC_AUTH_TOKEN;
+  const explicitOpenai = process.env.OPENAI_API_KEY;
+  // Only borrow ANTHROPIC for OPENAI on the codex path — and only when the
+  // user hasn't pinned an explicit OpenAI key. Outside codex this fallback
+  // would never hit the network anyway, but scoping it keeps intent clear.
+  const openaiToken = explicitOpenai ?? (agentType === "codex" ? anthropicToken : undefined);
+  return { anthropicToken, openaiToken };
+}
 
 const PROXY_PORT = 8787;
 const PROXY_URL = `http://127.0.0.1:${PROXY_PORT}`;
@@ -62,7 +100,11 @@ const PROXY_SCRIPT_BY_MODE: Record<DeepsecMode, string> = {
 };
 const CODEX_HOME = "/vercel/sandbox/.codex";
 
-function buildSandboxEnv(command?: string, agentType?: string): Record<string, string> {
+export function buildSandboxEnv(
+  command: string | undefined,
+  agentType: string | undefined,
+  credentials: BrokeredCredentials,
+): Record<string, string> {
   const env: Record<string, string> = {};
   const keys = new Set([
     ...BASE_SANDBOX_ENV_KEYS,
@@ -70,6 +112,17 @@ function buildSandboxEnv(command?: string, agentType?: string): Record<string, s
   ]);
   for (const key of keys) {
     if (key in process.env) env[key] = process.env[key]!;
+  }
+
+  // Decoy tokens. Real values stay on the orchestrator host; the firewall
+  // transform overwrites Authorization at egress. We only emit a placeholder
+  // when the orchestrator actually has a real token to broker — otherwise
+  // we let the SDK fail loudly at init rather than 401 later from upstream.
+  if (credentials.anthropicToken) {
+    env["ANTHROPIC_AUTH_TOKEN"] = BROKERED_TOKEN_PLACEHOLDER;
+  }
+  if (credentials.openaiToken) {
+    env["OPENAI_API_KEY"] = BROKERED_TOKEN_PLACEHOLDER;
   }
 
   // Belt-and-suspenders alongside the worker egress firewall: the master
@@ -91,9 +144,6 @@ function buildSandboxEnv(command?: string, agentType?: string): Record<string, s
     if (!env["OPENAI_BASE_URL"] && env["ANTHROPIC_BASE_URL"]) {
       env["OPENAI_BASE_URL"] = env["ANTHROPIC_BASE_URL"];
     }
-    if (!env["OPENAI_API_KEY"] && env["ANTHROPIC_AUTH_TOKEN"]) {
-      env["OPENAI_API_KEY"] = env["ANTHROPIC_AUTH_TOKEN"];
-    }
   } else {
     const realBaseUrl = env["ANTHROPIC_BASE_URL"];
     if (realBaseUrl) {
@@ -104,14 +154,27 @@ function buildSandboxEnv(command?: string, agentType?: string): Record<string, s
   return env;
 }
 
-// --- Worker egress firewall ---
+// --- Worker egress firewall + credential brokering ---
 //
 // Workers should only reach the AI host the SDK/proxy actually forwards to.
 // We derive that from the upstream base URL already present in the env, and
 // fall back to the documented hosts when env parsing fails so we never end
 // up applying an effective deny-all by accident.
+//
+// On top of allowlisting, we use the SDK's per-domain `transform.headers`
+// feature to inject the Authorization header at the firewall layer. The
+// real bearer token never enters the VM — code inside the sandbox sees
+// only the BROKERED_TOKEN_PLACEHOLDER. The firewall's egress proxy MITMs
+// TLS using a Vercel-installed CA trusted by the sandbox image, so it can
+// rewrite headers on encrypted requests.
 
-const DEFAULT_AI_HOSTS = ["ai-gateway.vercel.sh", "api.anthropic.com", "api.openai.com"];
+// One default per backend — Claude agents never make OpenAI-host calls and
+// vice versa, so allowing both was over-permissive. Specifically, with
+// brokering on, allowing the off-backend host means the firewall would have
+// no rule to inject credentials there, but a curious agent could still try
+// to reach it; better to deny outright.
+const DEFAULT_ANTHROPIC_HOST = "api.anthropic.com";
+const DEFAULT_OPENAI_HOST = "api.openai.com";
 
 function hostFromUrl(u: string | undefined): string | null {
   if (!u) return null;
@@ -125,23 +188,32 @@ function hostFromUrl(u: string | undefined): string | null {
 export function buildWorkerNetworkPolicy(
   env: Record<string, string>,
   agentType: string | undefined,
+  credentials: BrokeredCredentials = {},
   extraAllow: string[] = [],
 ): NetworkPolicy {
-  const allow = new Set<string>(extraAllow);
+  const isCodex = agentType === "codex";
 
-  if (agentType === "codex") {
-    const h = hostFromUrl(env["OPENAI_BASE_URL"]);
-    if (h) allow.add(h);
-  } else {
-    const h = hostFromUrl(env["ANTHROPIC_UPSTREAM_BASE_URL"]);
-    if (h) allow.add(h);
+  // Single AI host per backend. Prefer derived from the base URL the agent
+  // will actually use; fall back to the provider's documented default when
+  // the user hasn't configured one.
+  const aiHost = isCodex
+    ? (hostFromUrl(env["OPENAI_BASE_URL"]) ?? DEFAULT_OPENAI_HOST)
+    : (hostFromUrl(env["ANTHROPIC_UPSTREAM_BASE_URL"]) ?? DEFAULT_ANTHROPIC_HOST);
+
+  // The fallback flips at resolveBrokeredCredentials — by here, openaiToken
+  // already carries the ANTHROPIC gateway token if the user only set that
+  // one and is running codex.
+  const injectToken = isCodex ? credentials.openaiToken : credentials.anthropicToken;
+
+  const allow: Record<string, NetworkPolicyRule[]> = {
+    [aiHost]: injectToken
+      ? [{ transform: [{ headers: { authorization: `Bearer ${injectToken}` } }] }]
+      : [],
+  };
+  for (const h of extraAllow) {
+    if (!(h in allow)) allow[h] = [];
   }
-
-  if (allow.size === 0) {
-    for (const h of DEFAULT_AI_HOSTS) allow.add(h);
-  }
-
-  return { allow: [...allow] };
+  return { allow };
 }
 
 // --- Bootstrap: one sandbox does full setup, snapshots, stops ---
@@ -168,7 +240,11 @@ interface BootstrapOptions {
 export async function createBootstrapSnapshot(opts: BootstrapOptions): Promise<string> {
   const command = opts.command ?? "process";
   const agentType = opts.agentType ?? "claude-agent-sdk";
-  const sandboxEnv = buildSandboxEnv(command, agentType);
+  // Bootstrap doesn't make AI calls — it just installs deps and snapshots.
+  // We pass empty credentials so no placeholder tokens are written into the
+  // snapshot env; workers spawned from the snapshot get fresh placeholders
+  // tied to whatever the orchestrator's credentials are at spawn time.
+  const sandboxEnv = buildSandboxEnv(command, agentType, {});
 
   opts.onLog("Creating bootstrap sandbox...");
   let sandbox: Sandbox;
@@ -281,8 +357,19 @@ interface SpawnOptions {
  * request-proxy that mediates outbound API traffic for the active agent.
  */
 export async function spawnFromSnapshot(opts: SpawnOptions): Promise<Sandbox> {
-  const sandboxEnv = buildSandboxEnv(opts.command, opts.agentType);
-  const networkPolicy = buildWorkerNetworkPolicy(sandboxEnv, opts.agentType, opts.allowedHosts);
+  // Resolve once. The same `credentials` object is the source of truth for
+  // (a) what placeholders to expose in the sandbox env (so the SDK builds)
+  // and (b) which Authorization header the firewall transform should inject.
+  // Reading process.env directly here keeps the real token out of any data
+  // structure that's later passed to Sandbox.create({ env }).
+  const credentials = resolveBrokeredCredentials(opts.agentType);
+  const sandboxEnv = buildSandboxEnv(opts.command, opts.agentType, credentials);
+  const networkPolicy = buildWorkerNetworkPolicy(
+    sandboxEnv,
+    opts.agentType,
+    credentials,
+    opts.allowedHosts,
+  );
 
   let sandbox: Sandbox;
   try {

--- a/packages/deepsec/src/sandbox/setup.ts
+++ b/packages/deepsec/src/sandbox/setup.ts
@@ -41,15 +41,7 @@ export interface UploadBundle {
 // deliberately absent — they're brokered via firewall header injection
 // (see resolveBrokeredCredentials + buildWorkerNetworkPolicy below) so a
 // compromised in-VM agent can't read them out of /proc/<pid>/environ.
-const BASE_SANDBOX_ENV_KEYS: string[] = [
-  "ANTHROPIC_BASE_URL",
-  "OPENAI_BASE_URL",
-  "DEEPSEC_AGENT_DEBUG",
-];
-
-const COMMAND_ENV_KEYS: Record<string, string[]> = {
-  enrich: ["PEOPLE_SH_BYPASS", "OWNERSHIP_AUTH_TOKEN"],
-};
+const SANDBOX_ENV_KEYS: string[] = ["ANTHROPIC_BASE_URL", "OPENAI_BASE_URL", "DEEPSEC_AGENT_DEBUG"];
 
 /**
  * The Anthropic / OpenAI SDKs throw at construction if no auth token is set.
@@ -101,16 +93,11 @@ const PROXY_SCRIPT_BY_MODE: Record<DeepsecMode, string> = {
 const CODEX_HOME = "/vercel/sandbox/.codex";
 
 export function buildSandboxEnv(
-  command: string | undefined,
   agentType: string | undefined,
   credentials: BrokeredCredentials,
 ): Record<string, string> {
   const env: Record<string, string> = {};
-  const keys = new Set([
-    ...BASE_SANDBOX_ENV_KEYS,
-    ...(command ? (COMMAND_ENV_KEYS[command] ?? []) : []),
-  ]);
-  for (const key of keys) {
+  for (const key of SANDBOX_ENV_KEYS) {
     if (key in process.env) env[key] = process.env[key]!;
   }
 
@@ -220,7 +207,6 @@ export function buildWorkerNetworkPolicy(
 
 interface BootstrapOptions {
   projectId: string;
-  command?: string;
   /** Which agent backend the workers will run — drives which native binary we install */
   agentType?: string;
   vcpus: number;
@@ -238,13 +224,12 @@ interface BootstrapOptions {
  * to avoid leaking compute.
  */
 export async function createBootstrapSnapshot(opts: BootstrapOptions): Promise<string> {
-  const command = opts.command ?? "process";
   const agentType = opts.agentType ?? "claude-agent-sdk";
   // Bootstrap doesn't make AI calls — it just installs deps and snapshots.
   // We pass empty credentials so no placeholder tokens are written into the
   // snapshot env; workers spawned from the snapshot get fresh placeholders
   // tied to whatever the orchestrator's credentials are at spawn time.
-  const sandboxEnv = buildSandboxEnv(command, agentType, {});
+  const sandboxEnv = buildSandboxEnv(agentType, {});
 
   opts.onLog("Creating bootstrap sandbox...");
   let sandbox: Sandbox;
@@ -338,7 +323,6 @@ export async function createBootstrapSnapshot(opts: BootstrapOptions): Promise<s
 
 interface SpawnOptions {
   snapshotId: string;
-  command?: string;
   /** Drives which API base URL gets rewritten to the local proxy */
   agentType?: string;
   vcpus: number;
@@ -363,7 +347,7 @@ export async function spawnFromSnapshot(opts: SpawnOptions): Promise<Sandbox> {
   // Reading process.env directly here keeps the real token out of any data
   // structure that's later passed to Sandbox.create({ env }).
   const credentials = resolveBrokeredCredentials(opts.agentType);
-  const sandboxEnv = buildSandboxEnv(opts.command, opts.agentType, credentials);
+  const sandboxEnv = buildSandboxEnv(opts.agentType, credentials);
   const networkPolicy = buildWorkerNetworkPolicy(
     sandboxEnv,
     opts.agentType,

--- a/packages/deepsec/src/sandbox/state.ts
+++ b/packages/deepsec/src/sandbox/state.ts
@@ -16,14 +16,24 @@ function runPath(projectId: string, runId: string): string {
 
 export function generateRunId(): string {
   const ts = new Date().toISOString().replace(/[-:T]/g, "").slice(0, 14);
-  const suffix = crypto.randomBytes(2).toString("hex");
+  const suffix = crypto.randomBytes(8).toString("hex"); // 16 hex chars / 64 bits
   return `sbx-${ts}-${suffix}`;
 }
 
 export function saveRunState(state: SandboxRunState): void {
   const dir = runsDir(state.projectId);
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(runPath(state.projectId, state.runId), JSON.stringify(state, null, 2) + "\n");
+  const dest = runPath(state.projectId, state.runId);
+  // saveRunState is called once per run today (orchestrator.ts:335). With
+  // a fresh 64-bit suffix collisions are vanishingly unlikely — but if it
+  // happens we want a loud failure instead of silently destroying the
+  // earlier run's manifest. Use O_EXCL so the kernel enforces it.
+  const fd = fs.openSync(dest, "wx");
+  try {
+    fs.writeFileSync(fd, JSON.stringify(state, null, 2) + "\n");
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 export function loadRunState(projectId: string, runId: string): SandboxRunState {

--- a/packages/deepsec/src/sandbox/types.ts
+++ b/packages/deepsec/src/sandbox/types.ts
@@ -1,7 +1,9 @@
 import type { Sandbox } from "@vercel/sandbox";
 
-/** Supported subcommands for sandbox execution */
-export type SandboxSubcommand = "process" | "revalidate" | "triage" | "enrich" | "scan" | "report";
+/** Supported subcommands for sandbox execution. `enrich` is intentionally
+ * absent — enrichment runs locally (git committer lookups + plugin ownership
+ * calls) and isn't AI-bound, so the fan-out cost outweighs the benefit. */
+export type SandboxSubcommand = "process" | "revalidate" | "triage" | "scan" | "report";
 
 export interface SandboxConfig {
   projectId: string;
@@ -29,7 +31,7 @@ export interface SandboxConfig {
   keepAlive: boolean;
   /** Re-investigate already-analyzed files. `true` = all, number = files with < N analyses */
   reinvestigate: boolean | number;
-  /** Force re-check (for revalidate, triage, enrich) */
+  /** Force re-check (for revalidate, triage) */
   force: boolean;
   /** Min severity filter (for revalidate, triage) */
   minSeverity?: string;

--- a/packages/processor/src/agents/codex-sdk.ts
+++ b/packages/processor/src/agents/codex-sdk.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as os from "node:os";
@@ -57,18 +58,31 @@ const CUSTOM_PROVIDER_ID = "ai_gateway";
  * a counter + random bytes. Tempdirs auto-cleanup on process exit; even if
  * a few leak they're tiny.
  */
-let codexHomeCounter = 0;
-
+// mkdtempSync creates a 0700 directory atomically (and refuses if the
+// target already exists), which closes the symlink-clobber race a
+// pre-creating local attacker would otherwise win.
 function makeCodexHome(): string {
-  const id = `${process.pid}-${++codexHomeCounter}-${Math.random().toString(36).slice(2, 10)}`;
-  const dir = path.join(os.tmpdir(), `codex-home-${id}`);
-  fs.mkdirSync(dir, { recursive: true });
-  return dir;
+  return fs.mkdtempSync(path.join(os.tmpdir(), "codex-home-"));
 }
 
+// Create the stderr log atomically with O_EXCL + 0600 so a pre-created
+// symlink at the chosen path causes failure rather than redirecting our
+// writes through it. The 16-byte CSPRNG suffix replaces Math.random(),
+// whose internal state is recoverable from a small number of observed
+// outputs.
 function makeStderrLog(): string {
-  const id = `${process.pid}-${codexHomeCounter}-${Math.random().toString(36).slice(2, 10)}`;
-  return path.join(os.tmpdir(), `codex-stderr-${id}.log`);
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const id = crypto.randomBytes(16).toString("hex");
+    const p = path.join(os.tmpdir(), `codex-stderr-${id}.log`);
+    try {
+      const fd = fs.openSync(p, "wx", 0o600);
+      fs.closeSync(fd);
+      return p;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    }
+  }
+  throw new Error("Failed to create stderr log after 5 attempts");
 }
 
 /**

--- a/packages/processor/src/agents/shared.ts
+++ b/packages/processor/src/agents/shared.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import type { FileRecord, Finding, RefusalReport } from "@deepsec/core";
 import type { InvestigateResult, RevalidateVerdict } from "./types.js";
 
@@ -207,20 +207,25 @@ export function buildRevalidatePrompt(params: {
       .join("\n\n");
 
     let gitContext = "";
-    try {
-      const gitLog = execSync(
-        `git log --oneline --since="3 months ago" -n 10 -- "${file.filePath}"`,
-        {
-          cwd: projectRoot,
-          encoding: "utf-8",
-          timeout: 10_000,
-          stdio: ["ignore", "pipe", "ignore"],
-        },
-      ).trim();
+    // argv form (no shell) — file.filePath comes from glob output and may
+    // contain shell metacharacters (`;`, `$`, backticks). Passing it as a
+    // single argv slot keeps it from being re-parsed as a command.
+    const gitResult = spawnSync(
+      "git",
+      ["log", "--oneline", "--since=3 months ago", "-n", "10", "--", file.filePath],
+      {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        timeout: 10_000,
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+    if (gitResult.status === 0) {
+      const gitLog = (gitResult.stdout ?? "").trim();
       if (gitLog) {
         gitContext = `\n**Recent git history:**\n\`\`\`\n${gitLog}\n\`\`\`\n`;
       }
-    } catch {}
+    }
 
     fileSections.push(`## File: ${file.filePath}\n\n${findingsList}\n${gitContext}`);
   }

--- a/packages/processor/src/enrich.ts
+++ b/packages/processor/src/enrich.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import path from "node:path";
 import type { FileRecord, Severity } from "@deepsec/core";
 import {
@@ -61,29 +61,34 @@ export function enrichFileRecord(record: FileRecord, rootPath: string): void {
 
 function getRecentCommitters(rootPath: string, filePath: string, count: number = 5): Committer[] {
   const absPath = path.join(rootPath, filePath);
-  try {
-    const output = execSync(`git log --pretty=format:"%an\t%ae\t%aI" -n ${count} -- "${absPath}"`, {
+  // argv form (no shell). filePath comes from glob output and may contain
+  // shell metacharacters; absPath inherits them. Passing as a single argv
+  // slot keeps it from being re-parsed as a command.
+  const result = spawnSync(
+    "git",
+    ["log", "--pretty=format:%an\t%ae\t%aI", "-n", String(count), "--", absPath],
+    {
       cwd: rootPath,
       encoding: "utf-8",
       timeout: 10_000,
       // Silence stderr — on sandboxes we strip .git so every call fails;
-      // the catch below handles the empty result cleanly.
+      // empty output below handles cleanly.
       stdio: ["ignore", "pipe", "ignore"],
-    });
-    if (!output.trim()) return [];
+    },
+  );
+  if (result.status !== 0) return [];
+  const output = result.stdout ?? "";
+  if (!output.trim()) return [];
 
-    // Dedupe by email, keep most recent
-    const seen = new Map<string, Committer>();
-    for (const line of output.trim().split("\n")) {
-      const [name, email, date] = line.split("\t");
-      if (name && email && date && !seen.has(email)) {
-        seen.set(email, { name, email, date });
-      }
+  // Dedupe by email, keep most recent
+  const seen = new Map<string, Committer>();
+  for (const line of output.trim().split("\n")) {
+    const [name, email, date] = line.split("\t");
+    if (name && email && date && !seen.has(email)) {
+      seen.set(email, { name, email, date });
     }
-    return Array.from(seen.values()).slice(0, count);
-  } catch {
-    return [];
   }
+  return Array.from(seen.values()).slice(0, count);
 }
 
 /**
@@ -98,21 +103,22 @@ function buildGitCommitterIndex(
   const index = new Map<string, Committer[]>();
   const count = opts.count ?? 5;
   const since = opts.since ?? "1 year ago";
-  let output: string;
-  try {
-    output = execSync(
-      `git log --since=${JSON.stringify(since)} --pretty=format:"COMMIT%x09%an%x09%ae%x09%aI" --name-only -- .`,
-      {
-        cwd: rootPath,
-        encoding: "utf-8",
-        maxBuffer: 2 * 1024 * 1024 * 1024, // 2 GB — large monorepos push past the default 1 MB
-        timeout: 5 * 60 * 1000,
-        stdio: ["ignore", "pipe", "ignore"],
-      },
-    );
-  } catch {
-    return index;
-  }
+  // argv form (no shell). The `since` value is hardcoded today, but a
+  // future caller passing user input would otherwise inject through the
+  // template literal.
+  const result = spawnSync(
+    "git",
+    ["log", `--since=${since}`, "--pretty=format:COMMIT\t%an\t%ae\t%aI", "--name-only", "--", "."],
+    {
+      cwd: rootPath,
+      encoding: "utf-8",
+      maxBuffer: 2 * 1024 * 1024 * 1024, // 2 GB — large monorepos push past the default 1 MB
+      timeout: 5 * 60 * 1000,
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  );
+  if (result.status !== 0) return index;
+  const output = result.stdout ?? "";
   let cur: Committer | null = null;
   for (const line of output.split("\n")) {
     if (line.startsWith("COMMIT\t")) {

--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -5,6 +5,7 @@ import type { FileRecord } from "@deepsec/core";
 import {
   completeRun,
   createRunMeta,
+  dataDir,
   ensureProject,
   getRegistry,
   readFileRecord,
@@ -257,7 +258,7 @@ export async function scan(params: {
   let ignorePaths = params.ignorePaths;
   if (!ignorePaths) {
     try {
-      const cfgPath = path.resolve(`data/${params.projectId}/config.json`);
+      const cfgPath = path.resolve(dataDir(params.projectId), "config.json");
       if (fs.existsSync(cfgPath)) {
         const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
         if (Array.isArray(cfg.ignorePaths)) ignorePaths = cfg.ignorePaths;


### PR DESCRIPTION
      HIGH severity (3):
      - packages/processor/src/agents/shared.ts:211 — switched execSync template literal to spawnSync argv form for git log (file.filePath no longer shell-interpreted).
      - packages/processor/src/enrich.ts:65,104 — same fix on both git log shell-outs.
      - .github/workflows/release.yml — pinned actions/checkout, pnpm/action-setup, actions/setup-node to commit SHAs; moved id-token: write from workflow-level to job-level.
    
      MEDIUM severity (5):
      - .github/workflows/ci.yml — pinned same three actions to SHAs.
      - packages/core/src/paths.ts — added assertSafeSegment / assertSafeFilePath; called from dataDir, fileRecordPath, runMetaPath, and report*Path so ../absolute/null-byte segments throw at
      the path-construction layer (closes both paths.ts and run.ts writeFileRecord/writeRunMeta findings). Also exposed getDataRoot().
      - packages/deepsec/src/resolve-project-id.ts — added strict ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ validation at the CLI boundary; both --project-id and config-supplied ids flow through it.
      Also called from init-project.ts.
      - packages/deepsec/src/data-commit.ts — switched all execSync template literals to execFileSync argv form; validated DEEPSEC_DATA_BRANCH against ^[A-Za-z0-9._/-]+$ at module load.
    
      BUG (5):
      - packages/scanner/src/index.ts:260 — replaced hardcoded data/ with dataDir(params.projectId).
      - packages/deepsec/src/commands/{metrics,export,sandbox-all}.ts and data-commit.ts — now use getDataRoot() so DEEPSEC_DATA_ROOT is honored.
      - packages/processor/src/agents/codex-sdk.ts — makeCodexHome uses fs.mkdtempSync (atomic, 0700); makeStderrLog uses crypto.randomBytes(16) + O_EXCL/0600.
      - packages/core/src/run.ts and packages/deepsec/src/sandbox/state.ts — generateRunId now uses 8 bytes (64 bits) of entropy. saveRunState opens with O_EXCL so a runId collision throws
      instead of silently overwriting.
