### PR TITLE
Fix sandbox e2e tests

### DIFF
--- a/e2e/pipeline-sandbox.test.ts
+++ b/e2e/pipeline-sandbox.test.ts
@@ -181,6 +181,17 @@ function runBundleCapture(args: string[], cwd: string, timeoutMs: number, tmp: s
   };
 }
 
+/**
+ * Truncate a credential to its first 4 chars (or shorter) for log
+ * lines. Lets us assert in CI logs that the right secret made it
+ * through without leaking the rest. Returns "<unset>" when missing
+ * so a typo in secret naming surfaces visibly.
+ */
+function fingerprint(value: string | undefined): string {
+  if (!value) return "<unset>";
+  return `${value.slice(0, 4)}…`;
+}
+
 describe.skipIf(!SHOULD_RUN)("pipeline e2e — live sandbox", () => {
   beforeAll(() => {
     const realBundle = path.join(ROOT, "packages/deepsec/dist/cli.mjs");
@@ -190,6 +201,14 @@ describe.skipIf(!SHOULD_RUN)("pipeline e2e — live sandbox", () => {
     if (LIVE && !HAS_SANDBOX_KEY) {
       console.warn("DEEPSEC_E2E_LIVE_SANDBOX=1 but no Vercel Sandbox key — skipping.");
     }
+    // Fingerprint the Vercel creds so CI logs confirm we got the
+    // right secrets without exposing them. First 4 chars only.
+    console.log(
+      `[live-sandbox] creds: teamId=${fingerprint(process.env.VERCEL_TEAM_ID)} ` +
+        `projectId=${fingerprint(process.env.VERCEL_PROJECT_ID)} ` +
+        `token=${fingerprint(process.env.VERCEL_TOKEN)} ` +
+        `oidc=${fingerprint(process.env.VERCEL_OIDC_TOKEN)}`,
+    );
   });
 
   it(

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -5,5 +5,20 @@ export default defineConfig({
     name: "e2e",
     include: ["**/*.test.ts"],
     testTimeout: 30_000,
+    // The live-sandbox test spawns the bundled CLI for ~5+ minutes
+    // with `stdio: inherit` so the operator can watch sandbox bootstrap
+    // progress. With the default `forks` pool, that subprocess output
+    // goes worker→pipe→main, sharing the same channel as vitest's
+    // worker-to-main RPC. The RPC has a hardcoded 60s timeout (in
+    // `birpc`); on a long, log-heavy run, periodic `onTaskUpdate`
+    // calls back up behind the inherited stdio and time out, surfacing
+    // as a noisy `[vitest-worker]: Timeout calling "onTaskUpdate"`
+    // unhandled error AFTER the test passes.
+    //
+    // `threads` uses Node `worker_threads`, which share file
+    // descriptors with the main process — child stdout/stderr inherit
+    // straight to the user's terminal without going through vitest's
+    // RPC pipe, so RPC stays unsaturated.
+    pool: "threads",
   },
 });


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
