### PR TITLE
Add support for using claude and codex subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,14 @@ goes to `.deepsec/data/<id>/`; everything except curated
 - [samples/](samples/) — copy-paste starting points (currently: `webapp/`)
 - [CONTRIBUTING.md](CONTRIBUTING.md) — repo layout, dev workflow
 
-## AI provider — Vercel AI Gateway
+## AI provider
 
-Both agent backends route through Vercel AI Gateway by default, but you can provide
-your own API keys, of course. The AI Gateway has default quotas suitable for highly concurrent research.
+When running locally, `deepsec` attempts to use your existing subscriptions
+when invoking claude or codex.
+
+For scaled usage on large code bases we recommend using Vercel AI Gateway or
+provider API keys. The AI Gateway has default quotas suitable for highly 
+concurrent research.
 
 ```
 AI_GATEWAY_API_KEY=vck_...
@@ -104,6 +108,12 @@ getting a key and for the Vercel Sandbox setup. To bypass the
 gateway, set `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL` (or the
 OpenAI pair) explicitly — explicit values always win over the
 `AI_GATEWAY_API_KEY` expansion.
+
+For local-only runs (`process` / `revalidate` / `triage`, not
+`sandbox …`), deepsec also picks up an existing Claude Code or Codex
+subscription on the laptop — `claude login` / `codex login` is enough,
+no API key required. See [docs/vercel-setup.md § Use your Claude Code
+or Codex subscription](docs/vercel-setup.md#use-your-claude-code-or-codex-subscription-non-sandbox-only).
 
 ## Severity levels
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,9 +114,6 @@ backend you're using.
 |---|---|---|
 | `OPENAI_API_KEY` | `--agent codex` | Codex SDK token. Unset is fine if `AI_GATEWAY_API_KEY` is set, or if Codex routes through AI Gateway with the Anthropic token. |
 | `OPENAI_BASE_URL` | `--agent codex` | Default (when `AI_GATEWAY_API_KEY` is set): `https://ai-gateway.vercel.sh/v1`. |
-| `CLAUDE_CODE_OAUTH_TOKEN` | `--agent claude-agent-sdk`, non-sandbox | Long-lived subscription token from `claude setup-token`. When set (or when `~/.claude/.credentials.json` exists from `claude login`) the orchestrator can run without an Anthropic API token. Sandbox runs still need a real token. See [vercel-setup.md § Use your Claude Code or Codex subscription](vercel-setup.md#use-your-claude-code-or-codex-subscription-non-sandbox-only). |
-| `CLAUDE_HOME` | `--agent claude-agent-sdk`, non-sandbox | Override Claude Code's data dir (default `~/.claude`) for subscription auto-detection. |
-| `CODEX_HOME` | `--agent codex`, non-sandbox | Override Codex's data dir (default `~/.codex`) for subscription auto-detection. When `auth.json` is found there and no API key is set, deepsec mirrors it into a per-invocation tempdir and uses the built-in openai provider. |
 | `DEEPSEC_AGENT_DEBUG` | both backends | Set to `1` to enable verbose agent logging. |
 | `DEEPSEC_DATA_ROOT` | core | Override the data directory location. Equivalent to `dataDir` in config. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,6 +114,9 @@ backend you're using.
 |---|---|---|
 | `OPENAI_API_KEY` | `--agent codex` | Codex SDK token. Unset is fine if `AI_GATEWAY_API_KEY` is set, or if Codex routes through AI Gateway with the Anthropic token. |
 | `OPENAI_BASE_URL` | `--agent codex` | Default (when `AI_GATEWAY_API_KEY` is set): `https://ai-gateway.vercel.sh/v1`. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `--agent claude-agent-sdk`, non-sandbox | Long-lived subscription token from `claude setup-token`. When set (or when `~/.claude/.credentials.json` exists from `claude login`) the orchestrator can run without an Anthropic API token. Sandbox runs still need a real token. See [vercel-setup.md § Use your Claude Code or Codex subscription](vercel-setup.md#use-your-claude-code-or-codex-subscription-non-sandbox-only). |
+| `CLAUDE_HOME` | `--agent claude-agent-sdk`, non-sandbox | Override Claude Code's data dir (default `~/.claude`) for subscription auto-detection. |
+| `CODEX_HOME` | `--agent codex`, non-sandbox | Override Codex's data dir (default `~/.codex`) for subscription auto-detection. When `auth.json` is found there and no API key is set, deepsec mirrors it into a per-invocation tempdir and uses the built-in openai provider. |
 | `DEEPSEC_AGENT_DEBUG` | both backends | Set to `1` to enable verbose agent logging. |
 | `DEEPSEC_DATA_ROOT` | core | Override the data directory location. Equivalent to `dataDir` in config. |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -78,10 +78,8 @@ ANTHROPIC_AUTH_TOKEN=vck_...
 ANTHROPIC_BASE_URL=https://ai-gateway.vercel.sh
 ```
 
-For local-only scans (`process` / `revalidate` / `triage`, not
-`sandbox …`) you can also reuse a Claude Code or Codex subscription
-already on the laptop — no API key needed. See
-[vercel-setup.md § Use your Claude Code or Codex subscription](vercel-setup.md#use-your-claude-code-or-codex-subscription-non-sandbox-only).
+If `claude` or `codex` is already logged in on this machine, non-sandbox
+runs reuse that subscription — no API key needed.
 
 See [vercel-setup.md](vercel-setup.md) for how to get a gateway key
 and how to wire up Vercel Sandbox auth (OIDC or access token).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -78,6 +78,11 @@ ANTHROPIC_AUTH_TOKEN=vck_...
 ANTHROPIC_BASE_URL=https://ai-gateway.vercel.sh
 ```
 
+For local-only scans (`process` / `revalidate` / `triage`, not
+`sandbox …`) you can also reuse a Claude Code or Codex subscription
+already on the laptop — no API key needed. See
+[vercel-setup.md § Use your Claude Code or Codex subscription](vercel-setup.md#use-your-claude-code-or-codex-subscription-non-sandbox-only).
+
 See [vercel-setup.md](vercel-setup.md) for how to get a gateway key
 and how to wire up Vercel Sandbox auth (OIDC or access token).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,10 +30,9 @@ Open `.env.local` and fill in `AI_GATEWAY_API_KEY`. Get one from
 [Vercel AI Gateway](https://vercel.com/ai-gateway) — one token covers
 both Claude and Codex. Prefer Anthropic directly? Set
 `ANTHROPIC_AUTH_TOKEN=sk-ant-…` and `ANTHROPIC_BASE_URL=https://api.anthropic.com`
-instead. Or, for local-only runs (`process` / `revalidate` / `triage`,
-not `sandbox …`), reuse your Claude Code or Codex subscription — see
-[vercel-setup.md § Use your Claude Code or Codex subscription](vercel-setup.md#use-your-claude-code-or-codex-subscription-non-sandbox-only).
-See [vercel-setup.md](vercel-setup.md).
+instead. If `claude` or `codex` is already logged in on this machine,
+non-sandbox runs (`process` / `revalidate` / `triage`) skip the token
+and reuse the subscription. See [vercel-setup.md](vercel-setup.md).
 
 To scan a *different* codebase from the same `.deepsec/`, run
 `pnpm deepsec init-project <path>` — relative paths resolve against

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,10 @@ Open `.env.local` and fill in `AI_GATEWAY_API_KEY`. Get one from
 [Vercel AI Gateway](https://vercel.com/ai-gateway) — one token covers
 both Claude and Codex. Prefer Anthropic directly? Set
 `ANTHROPIC_AUTH_TOKEN=sk-ant-…` and `ANTHROPIC_BASE_URL=https://api.anthropic.com`
-instead. See [vercel-setup.md](vercel-setup.md).
+instead. Or, for local-only runs (`process` / `revalidate` / `triage`,
+not `sandbox …`), reuse your Claude Code or Codex subscription — see
+[vercel-setup.md § Use your Claude Code or Codex subscription](vercel-setup.md#use-your-claude-code-or-codex-subscription-non-sandbox-only).
+See [vercel-setup.md](vercel-setup.md).
 
 To scan a *different* codebase from the same `.deepsec/`, run
 `pnpm deepsec init-project <path>` — relative paths resolve against

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -126,5 +126,6 @@ vars (access token).
 |---|---|
 | `401` from `process` / `revalidate` | `AI_GATEWAY_API_KEY` (or `ANTHROPIC_AUTH_TOKEN`) not loaded — confirm `.env.local` is in the cwd deepsec runs from. |
 | Sandbox spawn fails with auth error | OIDC token expired (12 h) — re-run `vercel env pull`. Or fall back to access-token mode. |
-| `Missing AI credentials for --agent codex` | Set `AI_GATEWAY_API_KEY` (covers both backends) or `OPENAI_API_KEY` directly. |
+| `Missing AI credentials for --agent claude-agent-sdk` | Set `AI_GATEWAY_API_KEY` / `ANTHROPIC_AUTH_TOKEN`, or run `claude login` (Linux) / `claude setup-token` (macOS, sets `CLAUDE_CODE_OAUTH_TOKEN`). Local-only — sandbox runs still need a token. |
+| `Missing AI credentials for --agent codex` | Set `AI_GATEWAY_API_KEY` / `OPENAI_API_KEY`, or run `codex login` for subscription auth. Local-only — sandbox runs still need a token. |
 | Findings missing cost in the log | Pricing entry missing for a non-default Codex model. See [models.md](models.md#future-models-eg-anthropic-mythos). |

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -126,6 +126,6 @@ vars (access token).
 |---|---|
 | `401` from `process` / `revalidate` | `AI_GATEWAY_API_KEY` (or `ANTHROPIC_AUTH_TOKEN`) not loaded — confirm `.env.local` is in the cwd deepsec runs from. |
 | Sandbox spawn fails with auth error | OIDC token expired (12 h) — re-run `vercel env pull`. Or fall back to access-token mode. |
-| `Missing AI credentials for --agent claude-agent-sdk` | Set `AI_GATEWAY_API_KEY` / `ANTHROPIC_AUTH_TOKEN`, or run `claude login` (Linux) / `claude setup-token` (macOS, sets `CLAUDE_CODE_OAUTH_TOKEN`). Local-only — sandbox runs still need a token. |
-| `Missing AI credentials for --agent codex` | Set `AI_GATEWAY_API_KEY` / `OPENAI_API_KEY`, or run `codex login` for subscription auth. Local-only — sandbox runs still need a token. |
+| `Missing AI credentials for --agent claude-agent-sdk` | Set `AI_GATEWAY_API_KEY` / `ANTHROPIC_AUTH_TOKEN` in `.env.local`, or `claude login` for non-sandbox subscription auth. |
+| `Missing AI credentials for --agent codex` | Set `AI_GATEWAY_API_KEY` / `OPENAI_API_KEY` in `.env.local`, or `codex login` for non-sandbox subscription auth. |
 | Findings missing cost in the log | Pricing entry missing for a non-default Codex model. See [models.md](models.md#future-models-eg-anthropic-mythos). |

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "MIT",
   "repository": {

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   applyAiGatewayDefaults,
@@ -7,19 +10,35 @@ import {
 
 describe("assertAgentCredential", () => {
   let saved: Record<string, string | undefined>;
+  let emptyClaudeHome: string;
+  let emptyCodexHome: string;
   beforeEach(() => {
     saved = {
       ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
       OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+      CLAUDE_HOME: process.env.CLAUDE_HOME,
+      CODEX_HOME: process.env.CODEX_HOME,
     };
     delete process.env.ANTHROPIC_AUTH_TOKEN;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    // Point CLAUDE_HOME / CODEX_HOME at empty tmp dirs so the suite is
+    // hermetic — the dev running tests may have a real
+    // ~/.claude/.credentials.json or ~/.codex/auth.json from local
+    // logins, which would cause "no token" tests to incorrectly pass.
+    emptyClaudeHome = mkdtempSync(join(tmpdir(), "deepsec-claude-home-"));
+    emptyCodexHome = mkdtempSync(join(tmpdir(), "deepsec-codex-home-"));
+    process.env.CLAUDE_HOME = emptyClaudeHome;
+    process.env.CODEX_HOME = emptyCodexHome;
   });
   afterEach(() => {
     for (const [k, v] of Object.entries(saved)) {
       if (v === undefined) delete process.env[k];
       else process.env[k] = v;
     }
+    rmSync(emptyClaudeHome, { recursive: true, force: true });
+    rmSync(emptyCodexHome, { recursive: true, force: true });
   });
 
   it("passes for claude-agent-sdk when ANTHROPIC_AUTH_TOKEN is set", () => {
@@ -36,6 +55,37 @@ describe("assertAgentCredential", () => {
     );
   });
 
+  it("passes for claude-agent-sdk when CLAUDE_CODE_OAUTH_TOKEN is set", () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth-token";
+    expect(() => assertAgentCredential("claude-agent-sdk")).not.toThrow();
+  });
+
+  it("passes for claude-agent-sdk when ~/.claude/.credentials.json exists", () => {
+    writeFileSync(join(emptyClaudeHome, ".credentials.json"), "{}");
+    expect(() => assertAgentCredential("claude-agent-sdk")).not.toThrow();
+  });
+
+  it("ignores subscription auth in sandbox mode (worker VM has no claude CLI)", () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth-token";
+    expect(() => assertAgentCredential("claude-agent-sdk", { inSandbox: true })).toThrow(
+      /AI_GATEWAY_API_KEY/,
+    );
+    writeFileSync(join(emptyClaudeHome, ".credentials.json"), "{}");
+    expect(() => assertAgentCredential("claude-agent-sdk", { inSandbox: true })).toThrow(
+      /AI_GATEWAY_API_KEY/,
+    );
+  });
+
+  it("omits the subscription hint from the sandbox-mode error message", () => {
+    expect(() => assertAgentCredential("claude-agent-sdk", { inSandbox: true })).not.toThrow(
+      /CLAUDE_CODE_OAUTH_TOKEN/,
+    );
+    expect(() => assertAgentCredential("claude-agent-sdk", { inSandbox: true })).not.toThrow(
+      /claude login/,
+    );
+    expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(/CLAUDE_CODE_OAUTH_TOKEN/);
+  });
+
   it("passes for codex when OPENAI_API_KEY is set", () => {
     process.env.OPENAI_API_KEY = "x";
     expect(() => assertAgentCredential("codex")).not.toThrow();
@@ -46,7 +96,28 @@ describe("assertAgentCredential", () => {
     expect(() => assertAgentCredential("codex")).not.toThrow();
   });
 
-  it("throws for codex when no token", () => {
+  it("passes for codex when ~/.codex/auth.json exists (subscription mode)", () => {
+    writeFileSync(join(emptyCodexHome, "auth.json"), "{}");
+    expect(() => assertAgentCredential("codex")).not.toThrow();
+  });
+
+  it("ignores codex subscription auth in sandbox mode", () => {
+    writeFileSync(join(emptyCodexHome, "auth.json"), "{}");
+    // With auth.json present, non-sandbox passes — sandbox still throws.
+    expect(() => assertAgentCredential("codex")).not.toThrow();
+    expect(() => assertAgentCredential("codex", { inSandbox: true })).toThrow(/OPENAI_API_KEY/);
+    expect(() => assertAgentCredential("codex", { inSandbox: true })).not.toThrow(/codex login/);
+  });
+
+  it("mentions `codex login` only in the non-sandbox error message", () => {
+    expect(() => assertAgentCredential("codex")).toThrow(/codex login/);
+    expect(() => assertAgentCredential("codex", { inSandbox: true })).not.toThrow(/codex login/);
+  });
+
+  it("does not let a Claude subscription unlock codex", () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth-token";
+    writeFileSync(join(emptyClaudeHome, ".credentials.json"), "{}");
+    // Empty CODEX_HOME → no codex login → still throws.
     expect(() => assertAgentCredential("codex")).toThrow(/OPENAI_API_KEY/);
     expect(() => assertAgentCredential("codex")).toThrow(/AI_GATEWAY_API_KEY/);
     expect(() => assertAgentCredential("codex")).toThrow(

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -12,25 +12,27 @@ describe("assertAgentCredential", () => {
   let saved: Record<string, string | undefined>;
   let emptyClaudeHome: string;
   let emptyCodexHome: string;
+  let emptyPathDir: string;
   beforeEach(() => {
     saved = {
       ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
       OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-      CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
       CLAUDE_HOME: process.env.CLAUDE_HOME,
       CODEX_HOME: process.env.CODEX_HOME,
+      PATH: process.env.PATH,
     };
     delete process.env.ANTHROPIC_AUTH_TOKEN;
     delete process.env.OPENAI_API_KEY;
-    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
-    // Point CLAUDE_HOME / CODEX_HOME at empty tmp dirs so the suite is
-    // hermetic — the dev running tests may have a real
-    // ~/.claude/.credentials.json or ~/.codex/auth.json from local
-    // logins, which would cause "no token" tests to incorrectly pass.
+    // Point CLAUDE_HOME / CODEX_HOME and PATH at empty tmp dirs so the
+    // suite is hermetic — the dev running tests may have a real
+    // ~/.codex/auth.json or `claude` on $PATH, which would cause
+    // "no token" tests to incorrectly pass.
     emptyClaudeHome = mkdtempSync(join(tmpdir(), "deepsec-claude-home-"));
     emptyCodexHome = mkdtempSync(join(tmpdir(), "deepsec-codex-home-"));
+    emptyPathDir = mkdtempSync(join(tmpdir(), "deepsec-empty-path-"));
     process.env.CLAUDE_HOME = emptyClaudeHome;
     process.env.CODEX_HOME = emptyCodexHome;
+    process.env.PATH = emptyPathDir;
   });
   afterEach(() => {
     for (const [k, v] of Object.entries(saved)) {
@@ -39,6 +41,7 @@ describe("assertAgentCredential", () => {
     }
     rmSync(emptyClaudeHome, { recursive: true, force: true });
     rmSync(emptyCodexHome, { recursive: true, force: true });
+    rmSync(emptyPathDir, { recursive: true, force: true });
   });
 
   it("passes for claude-agent-sdk when ANTHROPIC_AUTH_TOKEN is set", () => {
@@ -46,44 +49,24 @@ describe("assertAgentCredential", () => {
     expect(() => assertAgentCredential("claude-agent-sdk")).not.toThrow();
   });
 
-  it("throws actionable message for claude-agent-sdk when no token", () => {
+  it("throws actionable message for claude-agent-sdk when no token and no claude CLI", () => {
     expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(/ANTHROPIC_AUTH_TOKEN/);
-    expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(/\.env\.local/);
     expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(/AI_GATEWAY_API_KEY/);
     expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(
       /https:\/\/github\.com\/vercel-labs\/deepsec\/blob\/main\/docs\/vercel-setup\.md/,
     );
   });
 
-  it("passes for claude-agent-sdk when CLAUDE_CODE_OAUTH_TOKEN is set", () => {
-    process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth-token";
+  it("passes for claude-agent-sdk when `claude` is on PATH (subscription mode)", () => {
+    writeFileSync(join(emptyPathDir, "claude"), "#!/bin/sh\n", { mode: 0o755 });
     expect(() => assertAgentCredential("claude-agent-sdk")).not.toThrow();
   });
 
-  it("passes for claude-agent-sdk when ~/.claude/.credentials.json exists", () => {
-    writeFileSync(join(emptyClaudeHome, ".credentials.json"), "{}");
-    expect(() => assertAgentCredential("claude-agent-sdk")).not.toThrow();
-  });
-
-  it("ignores subscription auth in sandbox mode (worker VM has no claude CLI)", () => {
-    process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth-token";
+  it("ignores claude subscription auth in sandbox mode", () => {
+    writeFileSync(join(emptyPathDir, "claude"), "#!/bin/sh\n", { mode: 0o755 });
     expect(() => assertAgentCredential("claude-agent-sdk", { inSandbox: true })).toThrow(
       /AI_GATEWAY_API_KEY/,
     );
-    writeFileSync(join(emptyClaudeHome, ".credentials.json"), "{}");
-    expect(() => assertAgentCredential("claude-agent-sdk", { inSandbox: true })).toThrow(
-      /AI_GATEWAY_API_KEY/,
-    );
-  });
-
-  it("omits the subscription hint from the sandbox-mode error message", () => {
-    expect(() => assertAgentCredential("claude-agent-sdk", { inSandbox: true })).not.toThrow(
-      /CLAUDE_CODE_OAUTH_TOKEN/,
-    );
-    expect(() => assertAgentCredential("claude-agent-sdk", { inSandbox: true })).not.toThrow(
-      /claude login/,
-    );
-    expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(/CLAUDE_CODE_OAUTH_TOKEN/);
   });
 
   it("passes for codex when OPENAI_API_KEY is set", () => {
@@ -106,23 +89,13 @@ describe("assertAgentCredential", () => {
     // With auth.json present, non-sandbox passes — sandbox still throws.
     expect(() => assertAgentCredential("codex")).not.toThrow();
     expect(() => assertAgentCredential("codex", { inSandbox: true })).toThrow(/OPENAI_API_KEY/);
-    expect(() => assertAgentCredential("codex", { inSandbox: true })).not.toThrow(/codex login/);
   });
 
-  it("mentions `codex login` only in the non-sandbox error message", () => {
-    expect(() => assertAgentCredential("codex")).toThrow(/codex login/);
-    expect(() => assertAgentCredential("codex", { inSandbox: true })).not.toThrow(/codex login/);
-  });
-
-  it("does not let a Claude subscription unlock codex", () => {
-    process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth-token";
-    writeFileSync(join(emptyClaudeHome, ".credentials.json"), "{}");
-    // Empty CODEX_HOME → no codex login → still throws.
+  it("does not let claude subscription unlock codex", () => {
+    writeFileSync(join(emptyPathDir, "claude"), "#!/bin/sh\n", { mode: 0o755 });
+    // No codex auth.json → still throws.
     expect(() => assertAgentCredential("codex")).toThrow(/OPENAI_API_KEY/);
     expect(() => assertAgentCredential("codex")).toThrow(/AI_GATEWAY_API_KEY/);
-    expect(() => assertAgentCredential("codex")).toThrow(
-      /https:\/\/github\.com\/vercel-labs\/deepsec\/blob\/main\/docs\/vercel-setup\.md/,
-    );
   });
 
   it("skips the credential check for custom plugin agents", () => {

--- a/packages/deepsec/src/commands/init.ts
+++ b/packages/deepsec/src/commands/init.ts
@@ -86,7 +86,9 @@ export function initCommand(opts: InitOpts) {
   console.log("Next:\n");
   if (wsRel !== ".") console.log(`  cd ${wsRel}`);
   console.log(`  pnpm install                          ${DIM}# installs deepsec${RESET}`);
-  console.log(`  ${DIM}# Set AI_GATEWAY_API_KEY in .env.local${RESET}`);
+  console.log(
+    `  ${DIM}# Set AI_GATEWAY_API_KEY in .env.local (or skip if claude/codex CLI is logged in)${RESET}`,
+  );
   console.log();
   console.log(
     `  ${YELLOW}Paste this into your coding agent${RESET} ${DIM}(Claude Code, Cursor, Codex, OpenCode, Pi, etc.):${RESET}`,
@@ -195,7 +197,11 @@ Currently configured project: \`${id}\` (target: \`${targetRel}\`).
 ## Setup
 
 1. \`pnpm install\` — installs deepsec.
-2. Add your AI Gateway token to \`.env.local\`. See
+2. Add an AI Gateway / Anthropic / OpenAI token to \`.env.local\`. If
+   you already have \`claude\` or \`codex\` CLI logged in on this
+   machine, you can skip the token for non-sandbox runs (\`process\` /
+   \`revalidate\` / \`triage\`); deepsec auto-detects and reuses the
+   subscription. See
    \`node_modules/deepsec/dist/docs/vercel-setup.md\` after install.
 3. Open the parent repo in your coding agent (Claude Code, Cursor, …)
    and have it follow \`data/${id}/SETUP.md\` to fill in
@@ -292,6 +298,8 @@ function envLocal(): string {
   // One-line gateway setup. deepsec expands AI_GATEWAY_API_KEY at startup
   // into ANTHROPIC_AUTH_TOKEN / OPENAI_API_KEY / *_BASE_URL, so a user
   // who only has a gateway key is fully wired with this single line.
+  // Users with claude/codex CLI logged in locally can leave this empty
+  // for non-sandbox runs — deepsec auto-detects.
   return `AI_GATEWAY_API_KEY=
 `;
 }

--- a/packages/deepsec/src/commands/sandbox-all.ts
+++ b/packages/deepsec/src/commands/sandbox-all.ts
@@ -90,7 +90,7 @@ export async function sandboxAllCommand(
 
   // Same preflight as sandbox-process — fail fast before fanning out.
   assertSandboxCredential();
-  assertAgentCredential(agentType);
+  assertAgentCredential(agentType, { inSandbox: true });
 
   console.log(`${BOLD}Sandbox All${RESET} — ${CYAN}${command}${RESET}`);
   console.log(`  Total sandboxes: ${totalSandboxes}`);

--- a/packages/deepsec/src/commands/sandbox-process.ts
+++ b/packages/deepsec/src/commands/sandbox-process.ts
@@ -146,7 +146,7 @@ export async function sandboxCommand(subcommand: string, opts: SandboxOpts) {
   // both a Vercel auth token (to create the sandbox) and an AI token (to
   // inject into the firewall transform).
   assertSandboxCredential();
-  assertAgentCredential(config.agentType);
+  assertAgentCredential(config.agentType, { inSandbox: true });
 
   console.log(
     `${BOLD}Sandbox${RESET} — ${CYAN}${config.command}${RESET} — ${BOLD}${config.projectId}${RESET}`,

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -51,40 +51,54 @@ function isCodex(agentType: string | undefined): boolean {
 }
 
 /**
- * Detect a local Claude Code subscription login. The Claude Agent SDK
- * spawns the `claude` CLI as a subprocess, so any auth that CLI accepts
- * (Linux file-based credentials, a long-lived OAuth token from
- * `claude setup-token`) lets the SDK run without an API key on the
- * orchestrator's env.
+ * Walk `$PATH` looking for a binary. Used as a positive signal that an
+ * agent CLI (`claude`, `codex`) is set up on this host — if it's
+ * installed, the user almost certainly logged in too, and the SDK will
+ * use whatever auth that CLI manages (Keychain on macOS, file on Linux,
+ * OAuth token env var, etc.). If they happen to be installed but not
+ * logged in, the SDK errors clearly at first call — better than us
+ * pre-blocking with a verbose pile of options.
  *
- * macOS users authenticate Claude Code via Keychain — there's no file
- * marker we can read without spawning `security` and racing against
- * permission prompts. For that path we ask the user to run
- * `claude setup-token` once and put the resulting token in
- * `CLAUDE_CODE_OAUTH_TOKEN`; that's the cross-platform escape hatch the
- * SDK already understands.
- *
- * Only relevant for non-sandbox runs. The sandbox path runs in a worker
- * VM that has no claude binary and no keychain access; it must ship a
- * real API token through the firewall header rewrite, so this helper is
- * never consulted there.
+ * Synchronous PATH walk is cheap enough for preflight; using `execSync`
+ * would also work but adds a fork.
  */
-function hasLocalClaudeLogin(): boolean {
-  if (process.env.CLAUDE_CODE_OAUTH_TOKEN) return true;
-  const claudeHome = process.env.CLAUDE_HOME || join(homedir(), ".claude");
-  return existsSync(join(claudeHome, ".credentials.json"));
+function whichSync(bin: string): boolean {
+  const pathEnv = process.env.PATH || "";
+  const sep = process.platform === "win32" ? ";" : ":";
+  for (const dir of pathEnv.split(sep)) {
+    if (!dir) continue;
+    if (existsSync(join(dir, bin))) return true;
+    if (process.platform === "win32") {
+      if (existsSync(join(dir, `${bin}.exe`))) return true;
+      if (existsSync(join(dir, `${bin}.cmd`))) return true;
+    }
+  }
+  return false;
 }
 
 /**
- * Detect a local Codex subscription login. `codex login` writes
- * `auth.json` into `$CODEX_HOME` (defaulting to `~/.codex`) on every
- * platform deepsec supports — Codex doesn't use Keychain on macOS — so
- * a single file check suffices.
+ * "Likely to just work" signal for the Claude subscription path. The
+ * Claude Agent SDK spawns the `claude` CLI as a subprocess; if that
+ * binary is on PATH the SDK can use whatever auth it manages (Keychain
+ * on macOS, ~/.claude/.credentials.json on Linux, CLAUDE_CODE_OAUTH_TOKEN
+ * env var). We don't try to verify the user is actually logged in — if
+ * not, the SDK's own error at first call is clearer than ours.
  *
- * Same non-sandbox restriction as the Claude variant: the codex binary
- * lives on the orchestrator's host, not in the sandbox worker VM.
+ * Only consulted in non-sandbox runs. The sandbox worker VM has no
+ * claude binary, so this helper is irrelevant there.
  */
-function hasLocalCodexLogin(): boolean {
+function hasLocalClaudeAgent(): boolean {
+  return whichSync("claude");
+}
+
+/**
+ * Same idea for Codex, but stricter: codex-sdk.ts mirrors the user's
+ * `auth.json` into a per-invocation tempdir, so we need that file to
+ * actually exist. `which codex` alone isn't enough — a logged-out
+ * codex CLI would fall through to gateway mode without an API key and
+ * 401. Honors `CODEX_HOME`.
+ */
+function hasLocalCodexAgent(): boolean {
   const codexHome = process.env.CODEX_HOME || join(homedir(), ".codex");
   return existsSync(join(codexHome, "auth.json"));
 }
@@ -123,52 +137,22 @@ export function assertAgentCredential(
     // Codex prefers OPENAI_API_KEY; AI Gateway issues a single token that
     // authenticates both backends, so an ANTHROPIC token is also accepted.
     if (openai || anthropic) return;
-    if (!options.inSandbox && hasLocalCodexLogin()) return;
-    const codexSubscriptionHint = options.inSandbox
-      ? ""
-      : `\n` +
-        `  Local-only alternative — use your Codex / ChatGPT subscription:\n` +
-        `    Run \`codex login\` on this machine. deepsec mirrors the\n` +
-        `    resulting ~/.codex/auth.json into a per-invocation tempdir\n` +
-        `    so concurrent batches don't stomp on the session DB.\n`;
+    if (!options.inSandbox && hasLocalCodexAgent()) return;
     throw new Error(
       `Missing AI credentials for --agent codex.\n` +
         `\n` +
-        `  Quickest fix — get a Vercel AI Gateway key (covers both Claude\n` +
-        `  and Codex with one token) and add it to .env.local:\n` +
-        `\n` +
-        `      AI_GATEWAY_API_KEY=vck_…\n` +
-        `\n` +
-        `  Or set OPENAI_API_KEY directly.\n` +
-        codexSubscriptionHint +
-        `\n` +
-        `  Full setup: ${SETUP_DOC_URL}`,
+        `  Add to .env.local:    AI_GATEWAY_API_KEY=vck_…   (or OPENAI_API_KEY=…)\n` +
+        `  Setup: ${SETUP_DOC_URL}`,
     );
   }
 
   if (anthropic) return;
-  if (!options.inSandbox && hasLocalClaudeLogin()) return;
-  const subscriptionHint = options.inSandbox
-    ? ""
-    : `\n` +
-      `  Local-only alternative — use your Claude Code subscription:\n` +
-      `    Linux: \`claude login\` writes ~/.claude/.credentials.json and\n` +
-      `      deepsec picks it up automatically.\n` +
-      `    macOS: run \`claude setup-token\` and add the printed token to\n` +
-      `      .env.local as CLAUDE_CODE_OAUTH_TOKEN=… (the Keychain login\n` +
-      `      that Claude Code uses isn't readable from a Node process).\n`;
+  if (!options.inSandbox && hasLocalClaudeAgent()) return;
   throw new Error(
     `Missing AI credentials for --agent ${agentType ?? "claude-agent-sdk"}.\n` +
       `\n` +
-      `  Quickest fix — get a Vercel AI Gateway key (covers both Claude\n` +
-      `  and Codex with one token) and add it to .env.local:\n` +
-      `\n` +
-      `      AI_GATEWAY_API_KEY=vck_…\n` +
-      `\n` +
-      `  Or set ANTHROPIC_AUTH_TOKEN directly.\n` +
-      subscriptionHint +
-      `\n` +
-      `  Full setup: ${SETUP_DOC_URL}`,
+      `  Add to .env.local:    AI_GATEWAY_API_KEY=vck_…   (or ANTHROPIC_AUTH_TOKEN=…)\n` +
+      `  Setup: ${SETUP_DOC_URL}`,
   );
 }
 

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -8,6 +8,10 @@
 // from upstream as if it were a model issue. Each variant has cost the
 // human time before, so we trade ~20 lines for a clear message up front.
 
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 // Linkable URL — printed in error messages so users can paste the
 // URL into a browser instead of hunting through the repo. Points at
 // the rendered `main` version on github.com so it works whether the
@@ -46,6 +50,45 @@ function isCodex(agentType: string | undefined): boolean {
   return agentType === "codex";
 }
 
+/**
+ * Detect a local Claude Code subscription login. The Claude Agent SDK
+ * spawns the `claude` CLI as a subprocess, so any auth that CLI accepts
+ * (Linux file-based credentials, a long-lived OAuth token from
+ * `claude setup-token`) lets the SDK run without an API key on the
+ * orchestrator's env.
+ *
+ * macOS users authenticate Claude Code via Keychain — there's no file
+ * marker we can read without spawning `security` and racing against
+ * permission prompts. For that path we ask the user to run
+ * `claude setup-token` once and put the resulting token in
+ * `CLAUDE_CODE_OAUTH_TOKEN`; that's the cross-platform escape hatch the
+ * SDK already understands.
+ *
+ * Only relevant for non-sandbox runs. The sandbox path runs in a worker
+ * VM that has no claude binary and no keychain access; it must ship a
+ * real API token through the firewall header rewrite, so this helper is
+ * never consulted there.
+ */
+function hasLocalClaudeLogin(): boolean {
+  if (process.env.CLAUDE_CODE_OAUTH_TOKEN) return true;
+  const claudeHome = process.env.CLAUDE_HOME || join(homedir(), ".claude");
+  return existsSync(join(claudeHome, ".credentials.json"));
+}
+
+/**
+ * Detect a local Codex subscription login. `codex login` writes
+ * `auth.json` into `$CODEX_HOME` (defaulting to `~/.codex`) on every
+ * platform deepsec supports — Codex doesn't use Keychain on macOS — so
+ * a single file check suffices.
+ *
+ * Same non-sandbox restriction as the Claude variant: the codex binary
+ * lives on the orchestrator's host, not in the sandbox worker VM.
+ */
+function hasLocalCodexLogin(): boolean {
+  const codexHome = process.env.CODEX_HOME || join(homedir(), ".codex");
+  return existsSync(join(codexHome, "auth.json"));
+}
+
 // Built-in backends we know how to credential-check. Agents registered
 // via plugins (deepsec.config.ts → plugins: [{ agents: [...] }]) handle
 // their own credential resolution, so we skip the check for anything
@@ -58,11 +101,19 @@ const KNOWN_BACKENDS = new Set<string>(["claude-agent-sdk", "codex"]);
  * sandbox path brokers credentials via firewall header injection, but
  * that only works if the orchestrator actually has a token to inject.
  *
+ * Pass `inSandbox: true` from sandbox commands. Subscription auth (a
+ * local `claude login`) is only honored when this is false — the
+ * sandbox worker has no `claude` CLI and no Keychain, so it must ship a
+ * real API token through the firewall header rewrite.
+ *
  * Skipped for plugin-supplied agents (`agentType` not in `KNOWN_BACKENDS`):
  * those backends own their credential story. Tests use this to plug in a
  * stub agent without setting fake env vars.
  */
-export function assertAgentCredential(agentType: string | undefined): void {
+export function assertAgentCredential(
+  agentType: string | undefined,
+  options: { inSandbox?: boolean } = {},
+): void {
   if (agentType !== undefined && !KNOWN_BACKENDS.has(agentType)) return;
 
   const anthropic = process.env.ANTHROPIC_AUTH_TOKEN;
@@ -72,6 +123,14 @@ export function assertAgentCredential(agentType: string | undefined): void {
     // Codex prefers OPENAI_API_KEY; AI Gateway issues a single token that
     // authenticates both backends, so an ANTHROPIC token is also accepted.
     if (openai || anthropic) return;
+    if (!options.inSandbox && hasLocalCodexLogin()) return;
+    const codexSubscriptionHint = options.inSandbox
+      ? ""
+      : `\n` +
+        `  Local-only alternative — use your Codex / ChatGPT subscription:\n` +
+        `    Run \`codex login\` on this machine. deepsec mirrors the\n` +
+        `    resulting ~/.codex/auth.json into a per-invocation tempdir\n` +
+        `    so concurrent batches don't stomp on the session DB.\n`;
     throw new Error(
       `Missing AI credentials for --agent codex.\n` +
         `\n` +
@@ -80,12 +139,24 @@ export function assertAgentCredential(agentType: string | undefined): void {
         `\n` +
         `      AI_GATEWAY_API_KEY=vck_…\n` +
         `\n` +
-        `  Or set OPENAI_API_KEY directly. Full setup:\n` +
-        `      ${SETUP_DOC_URL}`,
+        `  Or set OPENAI_API_KEY directly.\n` +
+        codexSubscriptionHint +
+        `\n` +
+        `  Full setup: ${SETUP_DOC_URL}`,
     );
   }
 
   if (anthropic) return;
+  if (!options.inSandbox && hasLocalClaudeLogin()) return;
+  const subscriptionHint = options.inSandbox
+    ? ""
+    : `\n` +
+      `  Local-only alternative — use your Claude Code subscription:\n` +
+      `    Linux: \`claude login\` writes ~/.claude/.credentials.json and\n` +
+      `      deepsec picks it up automatically.\n` +
+      `    macOS: run \`claude setup-token\` and add the printed token to\n` +
+      `      .env.local as CLAUDE_CODE_OAUTH_TOKEN=… (the Keychain login\n` +
+      `      that Claude Code uses isn't readable from a Node process).\n`;
   throw new Error(
     `Missing AI credentials for --agent ${agentType ?? "claude-agent-sdk"}.\n` +
       `\n` +
@@ -94,8 +165,10 @@ export function assertAgentCredential(agentType: string | undefined): void {
       `\n` +
       `      AI_GATEWAY_API_KEY=vck_…\n` +
       `\n` +
-      `  Or set ANTHROPIC_AUTH_TOKEN directly. Full setup:\n` +
-      `      ${SETUP_DOC_URL}`,
+      `  Or set ANTHROPIC_AUTH_TOKEN directly.\n` +
+      subscriptionHint +
+      `\n` +
+      `  Full setup: ${SETUP_DOC_URL}`,
   );
 }
 

--- a/packages/processor/src/agents/codex-sdk.ts
+++ b/packages/processor/src/agents/codex-sdk.ts
@@ -65,6 +65,48 @@ function makeCodexHome(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "codex-home-"));
 }
 
+/**
+ * Locate a usable `~/.codex/auth.json` for subscription-mode auth (the user
+ * has run `codex login` on the laptop and we want to reuse that session
+ * instead of forcing them to set OPENAI_API_KEY).
+ *
+ * Returns the parent dir (the "user codex home"), or null if no auth file
+ * is present. Honors `CODEX_HOME` for users who run codex with a
+ * non-default data dir; we look for auth.json in that override before
+ * falling back to `$HOME/.codex`.
+ */
+function findCodexSubscriptionAuth(): string | null {
+  const candidates: string[] = [];
+  if (process.env.CODEX_HOME) candidates.push(process.env.CODEX_HOME);
+  candidates.push(path.join(os.homedir(), ".codex"));
+  for (const dir of candidates) {
+    if (fs.existsSync(path.join(dir, "auth.json"))) return dir;
+  }
+  return null;
+}
+
+/**
+ * Mirror the user's auth.json into our per-invocation CODEX_HOME so the
+ * codex CLI sees their subscription credentials while still writing
+ * sessions/* into the isolated tempdir. We prefer a symlink so token
+ * refresh writes propagate back to the user's real auth.json — only fall
+ * back to copy on platforms/filesystems that can't symlink (e.g. some
+ * Windows configurations).
+ *
+ * config.toml is intentionally NOT mirrored: a user-supplied
+ * `model_provider = "..."` could conflict with our defaults, and we
+ * specifically want the built-in `openai` provider in subscription mode.
+ */
+function mirrorCodexAuthJson(userCodexHome: string, codexHome: string): void {
+  const src = path.join(userCodexHome, "auth.json");
+  const dst = path.join(codexHome, "auth.json");
+  try {
+    fs.symlinkSync(src, dst);
+  } catch {
+    fs.copyFileSync(src, dst);
+  }
+}
+
 // Create the stderr log atomically with O_EXCL + 0600 so a pre-created
 // symlink at the chosen path causes failure rather than redirecting our
 // writes through it. The 16-byte CSPRNG suffix replaces Math.random(),
@@ -143,8 +185,58 @@ interface CodexInvocation {
 }
 
 function buildCodexInvocation(): CodexInvocation {
-  // AI Gateway exposes an OpenAI-compatible endpoint. Both vars are honored;
-  // OPENAI_BASE_URL takes precedence when both are set.
+  // Decide between gateway mode (orchestrator has an API token, we route
+  // through Vercel AI Gateway via a custom provider) and subscription mode
+  // (no token but the user has run `codex login` on this machine — let
+  // codex use its default openai provider against their session). Sandbox
+  // workers always go gateway; the preflight ensures a token is present
+  // before we ever get here in that path.
+  const haveApiToken = !!(process.env.OPENAI_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN);
+  const subscriptionHome = haveApiToken ? null : findCodexSubscriptionAuth();
+
+  const codexHome = makeCodexHome();
+  if (subscriptionHome) {
+    mirrorCodexAuthJson(subscriptionHome, codexHome);
+  }
+
+  const extras: Record<string, string> = { CODEX_HOME: codexHome };
+
+  // Wrap codex with our stderr-capturing shim so we can diagnose silent
+  // failures (codex CLI exits clean with empty turns and the SDK swallows
+  // stderr on exit=0). Only enables if the wrapper resolves cleanly.
+  let stderrLog: string | null = null;
+  let codexPathOverride: string | undefined;
+  const paths = resolveCodexPaths();
+  if (paths) {
+    stderrLog = makeStderrLog();
+    extras.CODEX_REAL_BIN = paths.realBin;
+    extras.CODEX_STDERR_LOG = stderrLog;
+    codexPathOverride = paths.wrapper;
+    // RUST_LOG turns on tracing in the codex Rust binary so the captured
+    // stderr actually contains useful info (HTTP status, retry attempts).
+    if (!process.env.RUST_LOG) extras.RUST_LOG = "info";
+  }
+
+  if (subscriptionHome) {
+    const env = buildCodexEnv(extras);
+    // Strip gateway-routing env so the built-in openai provider talks to
+    // api.openai.com using the auth.json we just mirrored — a stray
+    // OPENAI_BASE_URL or token from .env.local would otherwise override
+    // the subscription session and either 401 or route through the
+    // gateway with a missing key.
+    delete env.OPENAI_BASE_URL;
+    delete env.ANTHROPIC_BASE_URL;
+    delete env.OPENAI_API_KEY;
+    delete env.ANTHROPIC_AUTH_TOKEN;
+
+    const options: CodexOptions = { env };
+    if (codexPathOverride) options.codexPathOverride = codexPathOverride;
+    return { options, stderrLog, codexHome };
+  }
+
+  // Gateway mode (default): AI Gateway exposes an OpenAI-compatible
+  // endpoint. Both vars are honored; OPENAI_BASE_URL takes precedence
+  // when both are set.
   const baseUrl = process.env.OPENAI_BASE_URL ?? process.env.ANTHROPIC_BASE_URL ?? undefined;
   const apiKey = process.env.OPENAI_API_KEY ?? process.env.ANTHROPIC_AUTH_TOKEN ?? undefined;
 
@@ -168,25 +260,6 @@ function buildCodexInvocation(): CodexInvocation {
       [CUSTOM_PROVIDER_ID]: providerConfig,
     },
   };
-
-  const codexHome = makeCodexHome();
-  const extras: Record<string, string> = { CODEX_HOME: codexHome };
-
-  // Wrap codex with our stderr-capturing shim so we can diagnose silent
-  // failures (codex CLI exits clean with empty turns and the SDK swallows
-  // stderr on exit=0). Only enables if the wrapper resolves cleanly.
-  let stderrLog: string | null = null;
-  let codexPathOverride: string | undefined;
-  const paths = resolveCodexPaths();
-  if (paths) {
-    stderrLog = makeStderrLog();
-    extras.CODEX_REAL_BIN = paths.realBin;
-    extras.CODEX_STDERR_LOG = stderrLog;
-    codexPathOverride = paths.wrapper;
-    // RUST_LOG turns on tracing in the codex Rust binary so the captured
-    // stderr actually contains useful info (HTTP status, retry attempts).
-    if (!process.env.RUST_LOG) extras.RUST_LOG = "info";
-  }
 
   // Don't pass baseUrl as an SDK option — that would emit
   // `openai_base_url=...` which only affects the built-in openai provider


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
