### PR TITLE
fix: Fail scan when --matchers contains unknown slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # deepsec
 
-`deepsec` an agent-powered vulnerability scanner that you can run in your own infrastructure, optimized to perform on-demand review of all code in existing 
+`deepsec` is an agent-powered vulnerability scanner that you can run in your own infrastructure, optimized to perform on-demand review of all code in existing 
 large-scale repos.
 
 `deepsec` is designed to surface hard-to-find issues that have been lurking in applications for a long time. It is configured to use the best models at maximum thinking levels, meaning scans can cost thousands or even tens-of-thousands of dollars for large codebases. Our customers have found the cost worth it for how quickly they were able to patch vulnerabilities that would have otherwise gone unfixed.

--- a/e2e/scan.test.ts
+++ b/e2e/scan.test.ts
@@ -86,4 +86,14 @@ describe("scan e2e", () => {
     const meta = JSON.parse(fs.readFileSync(runPath, "utf-8"));
     expect(meta.scannerConfig.matcherSlugs).toEqual(["xss", "rce"]);
   });
+
+  it("throws when matcher filter includes an unknown slug", async () => {
+    await expect(
+      scan({
+        projectId: PROJECT_ID,
+        root: FIXTURES,
+        matcherSlugs: ["xss", "does-not-exist"],
+      }),
+    ).rejects.toThrow(/Unknown matcher slug\(s\): does-not-exist/);
+  });
 });

--- a/packages/scanner/src/matcher-registry.ts
+++ b/packages/scanner/src/matcher-registry.ts
@@ -16,9 +16,11 @@ export class MatcherRegistry {
   }
 
   getBySlugs(slugs: string[]): MatcherPlugin[] {
-    return slugs
-      .map((s) => this.matchers.get(s))
-      .filter((m): m is MatcherPlugin => m !== undefined);
+    const missing = slugs.filter((slug) => !this.matchers.has(slug));
+    if (missing.length > 0) {
+      throw new Error(`Unknown matcher slug(s): ${missing.join(", ")}`);
+    }
+    return slugs.map((slug) => this.matchers.get(slug)!);
   }
 
   slugs(): string[] {


### PR DESCRIPTION
fixes #34

## What changed

Changed matcher slug lookup so `deepsec scan --matchers` fails when any requested slug is unknown instead of silently dropping missing slugs. Added e2e coverage for a mixed valid/invalid matcher list.

## Why

When `deepsec scan --matchers` includes an unknown matcher slug, deepsec silently ignores the unknown slug and scans with only the known matchers. This makes an invalid scan request look successful.

## Verification

- [x] `pnpm test` passes
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [x] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane
- [x] Reproduced old behavior: invalid matcher was silently ignored and exited 0
- [x] Verified new behavior: invalid matcher prints `Unknown matcher slug(s): does-not-exist` and exits 1

## Notes for reviewer
Before:
<img width="863" height="293" alt="image" src="https://github.com/user-attachments/assets/4c88f92f-7d5b-45c1-a659-497927644e81" />
After:
<img width="868" height="181" alt="image" src="https://github.com/user-attachments/assets/823712c9-b50b-4368-9c0c-5c2be6bf3ff3" />

### Environment
deepsec version: 1.1.13
Node version (node --version): v24.14.0
OS: Linux (Ubuntu) through WSL (Win 11)