### PR TITLE
fix(scanner): normalize Windows path separators from glob

### DIFF
--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -135,7 +135,10 @@ export class RegexScannerDriver implements ScannerDriver {
       const key = patternKey(matcher.filePatterns);
       const files = globCache.get(key) ?? [];
 
-      for (const relPath of files) {
+      for (const relPathRaw of files) {
+        // On Windows, glob can return "\"-separated relative paths.
+        // Deepsec stores file records with POSIX separators.
+        const relPath = relPathRaw.replaceAll("\\", "/");
         let content = contentCache.get(relPath);
         if (content === undefined) {
           try {


### PR DESCRIPTION
## What
Normalize scanner glob file paths to POSIX separators before record read/write.

## Why
On Windows, `glob` can return `\`-separated relative paths. Deepsec record path validation requires `/`, so scan can fail with:

`Invalid filePath: contains backslash`

## Repro
- Run `deepsec scan` on Windows in a normal project.
- Scan crashes when a matcher starts writing file records.

## Fix
In `packages/scanner/src/index.ts`, normalize each glob path:
- from raw `relPathRaw`
- to `relPath = relPathRaw.replaceAll(\, /)`

Closes #37