### PR TITLE
Make pnpm install just work even if there is a parent yarn workspace

### DIFF
--- a/e2e/bundle.test.ts
+++ b/e2e/bundle.test.ts
@@ -201,6 +201,9 @@ export default defineConfig({
         fs.readFileSync(path.join(ROOT, "packages/deepsec/package.json"), "utf-8"),
       );
       expect(pkg.dependencies.deepsec).toBe(`^${deepsecPkg.version}`);
+      // packageManager: pinned to pnpm so a parent repo's `packageManager`
+      // (e.g. yarn) doesn't make pnpm refuse to install in `.deepsec/`.
+      expect(pkg.packageManager).toMatch(/^pnpm@\d+\.\d+\.\d+$/);
 
       // config.ts: minimal — id + root only, plus the insert marker.
       const configSrc = fs.readFileSync(path.join(workspace, "deepsec.config.ts"), "utf-8");

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/src/commands/init.ts
+++ b/packages/deepsec/src/commands/init.ts
@@ -155,11 +155,38 @@ function packageJson(name: string): string {
       // declares `workspaces`, and stop at the first hit. Without this, a
       // parent monorepo's workspace would absorb `.deepsec/`.
       workspaces: [],
+      // Pin the package manager for this workspace. Without this, pnpm
+      // walks up looking for a `packageManager` field and adopts whatever
+      // it finds in an ancestor — so a parent repo declaring
+      // `"packageManager": "yarn@..."` makes `pnpm install` from
+      // `.deepsec/` refuse to run. Setting it here stops the walk at the
+      // workspace root.
+      packageManager: detectPackageManager(),
       dependencies: { deepsec: deepsecVersion },
     },
     null,
     2,
   )}\n`;
+}
+
+/**
+ * Best-effort `packageManager` value for the scaffolded package.json.
+ *
+ * Tries the running pnpm/npm/yarn version (via `npm_config_user_agent`,
+ * which all three set when they spawn child processes). Falls back to a
+ * known-stable pnpm version so the resulting package.json is always
+ * valid even when init is run from a bare shell. The README / printed
+ * Next steps assume pnpm, so we always emit a `pnpm@*` value.
+ */
+function detectPackageManager(): string {
+  const ua = process.env.npm_config_user_agent;
+  if (ua) {
+    const m = ua.match(/pnpm\/(\d+\.\d+\.\d+)/);
+    if (m) return `pnpm@${m[1]}`;
+  }
+  // Recent pnpm 9 LTS — kept conservative; users with a newer pnpm
+  // installed will see a Corepack mismatch warning but installs work.
+  return "pnpm@9.15.4";
 }
 
 function pnpmWorkspaceYaml(): string {


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
