### PR TITLE
Use the vercel OIDC token for the gateway if no primary API token is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ next-env.d.ts
 .claude
 linear-*
 .deepsec
+plans/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,7 @@ backend you're using.
 
 | Var | Used by | Purpose |
 |---|---|---|
-| `AI_GATEWAY_API_KEY` | all AI commands | Shortcut. Expands at CLI startup into `ANTHROPIC_AUTH_TOKEN` / `OPENAI_API_KEY` / `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` — one key covers both Claude and Codex through Vercel AI Gateway. Any of those four vars set explicitly takes precedence. |
+| `AI_GATEWAY_API_KEY` | all AI commands | Shortcut. Expands at CLI startup into `ANTHROPIC_AUTH_TOKEN` / `OPENAI_API_KEY` / `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` — one key covers both Claude and Codex through Vercel AI Gateway. Any of those four vars set explicitly takes precedence. Falls back to `VERCEL_OIDC_TOKEN` (from `vercel env pull`) when unset, so users already authenticated for Sandbox don't need a separate gateway key. |
 | `ANTHROPIC_AUTH_TOKEN` | `process`, `revalidate`, `triage` (Claude backend) | API token for the Claude Agent SDK. AI Gateway-issued or Anthropic-issued. Set this if you don't use `AI_GATEWAY_API_KEY`. |
 | `ANTHROPIC_BASE_URL` | same | Default (when `AI_GATEWAY_API_KEY` is set): `https://ai-gateway.vercel.sh`. Set to `https://api.anthropic.com` for direct Anthropic. |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,13 +26,22 @@ prompt), workspace-level `AGENTS.md`, `.env.local`, `.gitignore`. No
 custom matchers in the scaffold — add those later, only when a real
 finding shapes one for you.
 
-Open `.env.local` and fill in `AI_GATEWAY_API_KEY`. Get one from
-[Vercel AI Gateway](https://vercel.com/ai-gateway) — one token covers
-both Claude and Codex. Prefer Anthropic directly? Set
-`ANTHROPIC_AUTH_TOKEN=sk-ant-…` and `ANTHROPIC_BASE_URL=https://api.anthropic.com`
-instead. If `claude` or `codex` is already logged in on this machine,
-non-sandbox runs (`process` / `revalidate` / `triage`) skip the token
-and reuse the subscription. See [vercel-setup.md](vercel-setup.md).
+Open `.env.local` and pick one of:
+
+- **AI Gateway API key** — set `AI_GATEWAY_API_KEY=vck_…`. Get a key
+  from [Vercel AI Gateway](https://vercel.com/ai-gateway). One key
+  covers both Claude and Codex.
+- **Vercel OIDC token** — run `npx vercel link && npx vercel env pull`
+  in this workspace. That writes `VERCEL_OIDC_TOKEN` to `.env.local`,
+  which deepsec uses as the gateway credential automatically. The token
+  expires after 12 hours; re-pull when you hit auth errors. Convenient
+  if you're already using Vercel Sandbox (same token unlocks both).
+
+Prefer Anthropic directly? Set `ANTHROPIC_AUTH_TOKEN=sk-ant-…` and
+`ANTHROPIC_BASE_URL=https://api.anthropic.com` instead. If `claude` or
+`codex` is already logged in on this machine, non-sandbox runs
+(`process` / `revalidate` / `triage`) skip the token and reuse the
+subscription. See [vercel-setup.md](vercel-setup.md).
 
 To scan a *different* codebase from the same `.deepsec/`, run
 `pnpm deepsec init-project <path>` — relative paths resolve against

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -13,7 +13,34 @@ Both are usable on the free tier for evaluation.
 
 ## AI Gateway
 
-### Get a key
+Two ways to authenticate. Pick whichever fits — both produce the same
+runtime behavior.
+
+| Where you're running | Use this |
+|---|---|
+| Local development, already linked to Vercel | OIDC token (Option A) |
+| CI, external infra, or anywhere `vercel env pull` isn't practical | API key (Option B) |
+
+Full reference:
+[AI Gateway authentication](https://vercel.com/docs/ai-gateway/authentication-and-byok#quick-start).
+
+### Option A: OIDC token
+
+If you're already using Vercel Sandbox, this is automatic — the same
+`vercel env pull` that authenticates the sandbox also authenticates
+the gateway. Otherwise:
+
+```bash
+# In your scanning workspace:
+npx vercel link              # link this directory to a Vercel project
+npx vercel env pull          # writes VERCEL_OIDC_TOKEN to .env.local
+```
+
+deepsec auto-refreshes the token when it's near expiry (via
+`@vercel/oidc`), but the underlying refresh requires `.vercel/project.json`
+in the workspace — so re-run `vercel env pull` if refresh fails.
+
+### Option B: API key
 
 1. Open the [AI Gateway API Keys page](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai-gateway%2Fapi-keys&title=AI+Gateway+API+Keys)
    in your Vercel dashboard.
@@ -21,24 +48,22 @@ Both are usable on the free tier for evaluation.
 3. Copy the key (it starts with `vck_…`). Keys never expire unless
    you revoke them.
 
-Full reference:
-[AI Gateway authentication](https://vercel.com/docs/ai-gateway/authentication-and-byok#quick-start).
-
-### Wire it into deepsec
-
 Edit `.env.local` in your scanning workspace:
 
 ```bash
 AI_GATEWAY_API_KEY=vck_…
 ```
 
-That's it. deepsec expands this at startup into the four vars the
-agent SDKs read (`ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`,
-`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`), so the same key covers both
-Claude (`--agent claude-agent-sdk`, the default) and Codex
-(`--agent codex`). Any of those four vars you set explicitly takes
-precedence over the gateway expansion — useful for mixing direct
-Anthropic with gateway-routed OpenAI, etc.
+### How it works
+
+deepsec expands whichever credential it finds (the API key first, the
+OIDC token as fallback) at startup into the four vars the agent SDKs
+read (`ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`, `ANTHROPIC_BASE_URL`,
+`OPENAI_BASE_URL`), so a single credential covers both Claude
+(`--agent claude-agent-sdk`, the default) and Codex (`--agent codex`).
+Any of those four vars you set explicitly takes precedence over the
+expansion — useful for mixing direct Anthropic with gateway-routed
+OpenAI, etc.
 
 ### BYOK (optional)
 
@@ -85,6 +110,10 @@ The token expires after **12 hours**; re-run `vercel env pull` when
 you hit auth errors. The Vercel project you link to is just the auth
 scope — it can be any project on your team.
 
+If you go this route, you don't need a separate AI Gateway API key:
+the same OIDC token authenticates the gateway automatically. See
+[AI Gateway → Option A](#option-a-oidc-token).
+
 ### Option B: access token (API key)
 
 Use when OIDC isn't viable: external CI/CD, non-Vercel hosting, jobs
@@ -124,7 +153,7 @@ vars (access token).
 
 | Symptom | Likely cause |
 |---|---|
-| `401` from `process` / `revalidate` | `AI_GATEWAY_API_KEY` (or `ANTHROPIC_AUTH_TOKEN`) not loaded — confirm `.env.local` is in the cwd deepsec runs from. |
+| `401` from `process` / `revalidate` | No gateway credential loaded — set `AI_GATEWAY_API_KEY` (or `ANTHROPIC_AUTH_TOKEN`), or run `vercel env pull` to get a `VERCEL_OIDC_TOKEN`. Confirm `.env.local` is in the cwd deepsec runs from. If you're using OIDC, the token may have expired (12 h) — re-pull. |
 | Sandbox spawn fails with auth error | OIDC token expired (12 h) — re-run `vercel env pull`. Or fall back to access-token mode. |
 | `Missing AI credentials for --agent claude-agent-sdk` | Set `AI_GATEWAY_API_KEY` / `ANTHROPIC_AUTH_TOKEN` in `.env.local`, or `claude login` for non-sandbox subscription auth. |
 | `Missing AI credentials for --agent codex` | Set `AI_GATEWAY_API_KEY` / `OPENAI_API_KEY` in `.env.local`, or `codex login` for non-sandbox subscription auth. |

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -35,6 +35,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.119",
     "@openai/codex": "^0.125.0",
     "@openai/codex-sdk": "^0.125.0",
+    "@vercel/oidc": "^3.4.0",
     "@vercel/sandbox": "^1.9.0",
     "jiti": "^2.4.0",
     "tar": "^7.5.13"

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -155,6 +155,7 @@ describe("applyAiGatewayDefaults", () => {
   beforeEach(() => {
     saved = {
       AI_GATEWAY_API_KEY: process.env.AI_GATEWAY_API_KEY,
+      VERCEL_OIDC_TOKEN: process.env.VERCEL_OIDC_TOKEN,
       ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
       OPENAI_API_KEY: process.env.OPENAI_API_KEY,
       ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
@@ -200,5 +201,24 @@ describe("applyAiGatewayDefaults", () => {
     applyAiGatewayDefaults();
     expect(process.env.ANTHROPIC_BASE_URL).toBe("https://api.anthropic.com");
     expect(process.env.OPENAI_BASE_URL).toBe("https://ai-gateway.vercel.sh/v1");
+  });
+
+  it("falls back to VERCEL_OIDC_TOKEN when AI_GATEWAY_API_KEY is unset", () => {
+    process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
+    applyAiGatewayDefaults();
+    expect(process.env.AI_GATEWAY_API_KEY).toBe("oidc-tok");
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("oidc-tok");
+    expect(process.env.OPENAI_API_KEY).toBe("oidc-tok");
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://ai-gateway.vercel.sh");
+    expect(process.env.OPENAI_BASE_URL).toBe("https://ai-gateway.vercel.sh/v1");
+  });
+
+  it("prefers an explicit AI_GATEWAY_API_KEY over VERCEL_OIDC_TOKEN", () => {
+    process.env.AI_GATEWAY_API_KEY = "gw-key";
+    process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
+    applyAiGatewayDefaults();
+    expect(process.env.AI_GATEWAY_API_KEY).toBe("gw-key");
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("gw-key");
+    expect(process.env.OPENAI_API_KEY).toBe("gw-key");
   });
 });

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -1,7 +1,23 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub @vercel/oidc so the preflight suite is hermetic: the real
+// implementation decodes VERCEL_OIDC_TOKEN as a JWT and, on failure,
+// falls back to reading `.vercel/project.json` and hitting Vercel. That
+// would leak the dev's local project state into the test and 401 on CI
+// (and the synthetic strings we use below aren't valid JWTs). Treating
+// the env var as the source of truth matches what applyAiGatewayDefaults
+// relies on: a token populated by `vercel env pull`.
+vi.mock("@vercel/oidc", () => ({
+  getVercelOidcToken: async () => {
+    const token = process.env.VERCEL_OIDC_TOKEN;
+    if (!token) throw new Error("no VERCEL_OIDC_TOKEN");
+    return token;
+  },
+}));
+
 import {
   applyAiGatewayDefaults,
   assertAgentCredential,
@@ -170,42 +186,42 @@ describe("applyAiGatewayDefaults", () => {
     }
   });
 
-  it("does nothing when AI_GATEWAY_API_KEY is unset", () => {
-    applyAiGatewayDefaults();
+  it("does nothing when AI_GATEWAY_API_KEY is unset", async () => {
+    await applyAiGatewayDefaults();
     expect(process.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
     expect(process.env.OPENAI_API_KEY).toBeUndefined();
     expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
     expect(process.env.OPENAI_BASE_URL).toBeUndefined();
   });
 
-  it("populates all four vars from AI_GATEWAY_API_KEY", () => {
+  it("populates all four vars from AI_GATEWAY_API_KEY", async () => {
     process.env.AI_GATEWAY_API_KEY = "gw-key";
-    applyAiGatewayDefaults();
+    await applyAiGatewayDefaults();
     expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("gw-key");
     expect(process.env.OPENAI_API_KEY).toBe("gw-key");
     expect(process.env.ANTHROPIC_BASE_URL).toBe("https://ai-gateway.vercel.sh");
     expect(process.env.OPENAI_BASE_URL).toBe("https://ai-gateway.vercel.sh/v1");
   });
 
-  it("does not overwrite explicit ANTHROPIC_AUTH_TOKEN", () => {
+  it("does not overwrite explicit ANTHROPIC_AUTH_TOKEN", async () => {
     process.env.AI_GATEWAY_API_KEY = "gw-key";
     process.env.ANTHROPIC_AUTH_TOKEN = "explicit-anthropic";
-    applyAiGatewayDefaults();
+    await applyAiGatewayDefaults();
     expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("explicit-anthropic");
     expect(process.env.OPENAI_API_KEY).toBe("gw-key");
   });
 
-  it("does not overwrite an explicit ANTHROPIC_BASE_URL pointing direct-to-provider", () => {
+  it("does not overwrite an explicit ANTHROPIC_BASE_URL pointing direct-to-provider", async () => {
     process.env.AI_GATEWAY_API_KEY = "gw-key";
     process.env.ANTHROPIC_BASE_URL = "https://api.anthropic.com";
-    applyAiGatewayDefaults();
+    await applyAiGatewayDefaults();
     expect(process.env.ANTHROPIC_BASE_URL).toBe("https://api.anthropic.com");
     expect(process.env.OPENAI_BASE_URL).toBe("https://ai-gateway.vercel.sh/v1");
   });
 
-  it("falls back to VERCEL_OIDC_TOKEN when AI_GATEWAY_API_KEY is unset", () => {
+  it("falls back to VERCEL_OIDC_TOKEN when AI_GATEWAY_API_KEY is unset", async () => {
     process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
-    applyAiGatewayDefaults();
+    await applyAiGatewayDefaults();
     expect(process.env.AI_GATEWAY_API_KEY).toBe("oidc-tok");
     expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("oidc-tok");
     expect(process.env.OPENAI_API_KEY).toBe("oidc-tok");
@@ -213,10 +229,10 @@ describe("applyAiGatewayDefaults", () => {
     expect(process.env.OPENAI_BASE_URL).toBe("https://ai-gateway.vercel.sh/v1");
   });
 
-  it("prefers an explicit AI_GATEWAY_API_KEY over VERCEL_OIDC_TOKEN", () => {
+  it("prefers an explicit AI_GATEWAY_API_KEY over VERCEL_OIDC_TOKEN", async () => {
     process.env.AI_GATEWAY_API_KEY = "gw-key";
     process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
-    applyAiGatewayDefaults();
+    await applyAiGatewayDefaults();
     expect(process.env.AI_GATEWAY_API_KEY).toBe("gw-key");
     expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("gw-key");
     expect(process.env.OPENAI_API_KEY).toBe("gw-key");

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -345,6 +345,11 @@ process.on("unhandledRejection", printFatal);
 process.on("uncaughtException", printFatal);
 
 async function main() {
+  // Expand AI_GATEWAY_API_KEY (or fall back to a Vercel OIDC token) into
+  // the per-SDK env vars before any command handler instantiates an agent.
+  // Must run before loadConfig in case the user's deepsec.config.ts reads
+  // these vars at module load.
+  await applyAiGatewayDefaults();
   await loadConfig();
   // Plugins may register their own subcommands.
   for (const register of getRegistry().commands) {

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -3,13 +3,6 @@ import { config as dotenvConfig } from "dotenv";
 dotenvConfig({ path: ".env.local" });
 dotenvConfig(); // also load .env as fallback
 
-import { applyAiGatewayDefaults } from "./preflight.js";
-
-// If AI_GATEWAY_API_KEY is set, expand it into ANTHROPIC_AUTH_TOKEN /
-// OPENAI_API_KEY / *_BASE_URL before any agent module reads them. Must
-// run after dotenv and before the command modules import.
-applyAiGatewayDefaults();
-
 import { getRegistry } from "@deepsec/core";
 import { Command } from "commander";
 import { enrichCommand } from "./commands/enrich.js";
@@ -26,6 +19,7 @@ import { scanCommand } from "./commands/scan.js";
 import { statusCommand } from "./commands/status.js";
 import { triageCommand } from "./commands/triage.js";
 import { loadConfig } from "./load-config.js";
+import { applyAiGatewayDefaults } from "./preflight.js";
 import { getDeepsecVersion } from "./version.js";
 
 const program = new Command();

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -11,6 +11,7 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { getVercelOidcToken } from "@vercel/oidc";
 
 // Linkable URL — printed in error messages so users can paste the
 // URL into a browser instead of hunting through the repo. Points at
@@ -24,11 +25,23 @@ const SETUP_DOC_URL = "https://github.com/vercel-labs/deepsec/blob/main/docs/ver
 const GATEWAY_ANTHROPIC_BASE_URL = "https://ai-gateway.vercel.sh";
 const GATEWAY_OPENAI_BASE_URL = "https://ai-gateway.vercel.sh/v1";
 
+// Refresh the OIDC token if it would expire within the next hour. Bounds the
+// risk that a token resolved at CLI startup expires mid-run — sandbox jobs
+// and long process/revalidate runs routinely take longer than a few minutes,
+// and the gateway will 401 the moment the JWT lapses.
+const OIDC_EXPIRATION_BUFFER_MS = 60 * 60 * 1000;
+
 /**
  * If the user set `AI_GATEWAY_API_KEY`, expand it into the four env vars
  * the agent SDKs actually read. Lets a user run with a single token
  * instead of duplicating it across `ANTHROPIC_AUTH_TOKEN` /
  * `OPENAI_API_KEY` (the gateway accepts the same token for both).
+ *
+ * Falls back to a Vercel OIDC token (via `@vercel/oidc`) when
+ * `AI_GATEWAY_API_KEY` is unset. The AI Gateway accepts OIDC tokens
+ * issued by `vercel env pull`, so a user who's already linked the project
+ * doesn't need a separate gateway key. `getVercelOidcToken` also refreshes
+ * the token in development when it's expired or near expiry.
  *
  * Existing values always win — this only fills in what's missing, so a
  * user who has set, say, `ANTHROPIC_BASE_URL=https://api.anthropic.com`
@@ -37,7 +50,18 @@ const GATEWAY_OPENAI_BASE_URL = "https://ai-gateway.vercel.sh/v1";
  * Call this once at CLI startup (after dotenv loads .env.local), before
  * any module reads these vars.
  */
-export function applyAiGatewayDefaults(): void {
+export async function applyAiGatewayDefaults(): Promise<void> {
+  if (!process.env.AI_GATEWAY_API_KEY) {
+    try {
+      process.env.AI_GATEWAY_API_KEY = await getVercelOidcToken({
+        expirationBufferMs: OIDC_EXPIRATION_BUFFER_MS,
+      });
+    } catch {
+      // No OIDC token available (no env var, no linked project, or refresh
+      // failed). Fall through — assertAgentCredential will emit a clearer
+      // error pointing at .env.local if a credential is actually required.
+    }
+  }
   const key = process.env.AI_GATEWAY_API_KEY;
   if (!key) return;
   if (!process.env.ANTHROPIC_AUTH_TOKEN) process.env.ANTHROPIC_AUTH_TOKEN = key;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@openai/codex-sdk':
         specifier: ^0.125.0
         version: 0.125.0
+      '@vercel/oidc':
+        specifier: ^3.4.0
+        version: 3.4.0
       '@vercel/sandbox':
         specifier: ^1.9.0
         version: 1.10.0
@@ -1515,6 +1518,11 @@ packages:
 
   /@vercel/oidc@3.2.0:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+    dev: false
+
+  /@vercel/oidc@3.4.0:
+    resolution: {integrity: sha512-p0sKfHkfRmMaqqDwNL4tjnX9TgRrLMlEtUjIxfrEns8pOxz1R9ztqOVI+ehqiq93/2/HnfPe/UBZkfAZwnx0UA==}
     engines: {node: '>= 20'}
     dev: false
 


### PR DESCRIPTION
…

## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
