### PR TITLE
Improve windows compat and make tar usage more robust

### DIFF
--- a/e2e/pipeline-sandbox.test.ts
+++ b/e2e/pipeline-sandbox.test.ts
@@ -193,6 +193,24 @@ function fingerprint(value: string | undefined): string {
 }
 
 /**
+ * List `deepsec-tar-*` temp files currently in `os.tmpdir()`. Used as a
+ * before/after snapshot around sandbox invocations: makeTarball writes
+ * each upload bundle to a path under os.tmpdir(), and either the
+ * uploader or the orchestrator's finally block is supposed to unlink
+ * the file when the bundle is no longer needed. A leak here would mean
+ * a long-running orchestrator slowly fills /tmp — invisible from the
+ * unit tests, which only verify a single makeTarball call.
+ *
+ * We diff before/after rather than asserting an empty set so concurrent
+ * CI jobs on the same runner don't cause false positives.
+ */
+function listDeepsecTarballs(): string[] {
+  return fs
+    .readdirSync(os.tmpdir())
+    .filter((n) => n.startsWith("deepsec-tar-") && n.endsWith(".tar.gz"));
+}
+
+/**
  * Pack the local `packages/deepsec` into a `.tgz` tarball — same format
  * `npm publish` would ship. Returns the absolute path to the produced
  * file. Used by the live-sandbox test to substitute the local source
@@ -290,6 +308,15 @@ describe.skipIf(!SHOULD_RUN)("pipeline e2e — live sandbox", () => {
         // proxy is skipped for non-claude-agent-sdk agents (see
         // setup.ts), so no AI credentials needed. Bootstrap + worker
         // is ~3-5 min — most of that is bootstrap snapshot creation.
+        //
+        // Snapshot /tmp before/after to verify the disk-backed tarball
+        // path cleans up after itself. Each `sandbox process` builds
+        // three upload bundles (app + target + data) into os.tmpdir()
+        // and is supposed to unlink them after upload completes (the
+        // uploader does it on success, the orchestrator's finally
+        // block sweeps any survivors). A regression that holds onto
+        // those files would slowly fill /tmp on long-running invokers.
+        const tarsBeforeProc = listDeepsecTarballs();
         const proc = runBundle(
           [
             "sandbox",
@@ -310,6 +337,12 @@ describe.skipIf(!SHOULD_RUN)("pipeline e2e — live sandbox", () => {
           tmp,
         );
         expect(proc.status).toBe(0);
+        const tarsAfterProc = listDeepsecTarballs();
+        const leakedProc = tarsAfterProc.filter((n) => !tarsBeforeProc.includes(n));
+        expect(
+          leakedProc,
+          `sandbox process leaked tarballs in os.tmpdir(): ${leakedProc.join(", ")}`,
+        ).toEqual([]);
 
         // Findings should be on disk, populated by the stub agent
         // running INSIDE the sandbox and merged back via the result
@@ -322,6 +355,7 @@ describe.skipIf(!SHOULD_RUN)("pipeline e2e — live sandbox", () => {
         expect(withFindings[0].analysisHistory.some((h) => h.agentType === "stub")).toBe(true);
 
         // 5. sandbox revalidate over the same findings.
+        const tarsBeforeReval = listDeepsecTarballs();
         const reval = runBundle(
           [
             "sandbox",
@@ -342,6 +376,12 @@ describe.skipIf(!SHOULD_RUN)("pipeline e2e — live sandbox", () => {
           tmp,
         );
         expect(reval.status).toBe(0);
+        const tarsAfterReval = listDeepsecTarballs();
+        const leakedReval = tarsAfterReval.filter((n) => !tarsBeforeReval.includes(n));
+        expect(
+          leakedReval,
+          `sandbox revalidate leaked tarballs in os.tmpdir(): ${leakedReval.join(", ")}`,
+        ).toEqual([]);
 
         const after = readAllRecords(filesDir);
         const verdicts = after.flatMap((r) => r.findings.filter((f) => f.revalidation));

--- a/packages/core/src/__tests__/paths.test.ts
+++ b/packages/core/src/__tests__/paths.test.ts
@@ -1,23 +1,26 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { dataDir, fileRecordPath, filesDir, runMetaPath, runsDir } from "../paths.js";
 
 describe("paths", () => {
+  // path.join uses native separators (\\ on Windows, / elsewhere). Build
+  // expected values with path.join so the asserts hold on every platform.
   it("filesDir follows convention", () => {
-    expect(filesDir("myapp")).toBe("data/myapp/files");
+    expect(filesDir("myapp")).toBe(path.join("data", "myapp", "files"));
   });
 
   it("fileRecordPath follows convention", () => {
     expect(fileRecordPath("myapp", "src/api/users.ts")).toBe(
-      "data/myapp/files/src/api/users.ts.json",
+      path.join("data", "myapp", "files", "src", "api", "users.ts.json"),
     );
   });
 
   it("runsDir follows convention", () => {
-    expect(runsDir("myapp")).toBe("data/myapp/runs");
+    expect(runsDir("myapp")).toBe(path.join("data", "myapp", "runs"));
   });
 
   it("runMetaPath is flat file", () => {
-    expect(runMetaPath("myapp", "run1")).toBe("data/myapp/runs/run1.json");
+    expect(runMetaPath("myapp", "run1")).toBe(path.join("data", "myapp", "runs", "run1.json"));
   });
 
   // Path-traversal protection — any segment that could escape the per-project

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "1.1.15",
+  "version": "1.1.17",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -36,7 +36,8 @@
     "@openai/codex": "^0.125.0",
     "@openai/codex-sdk": "^0.125.0",
     "@vercel/sandbox": "^1.9.0",
-    "jiti": "^2.4.0"
+    "jiti": "^2.4.0",
+    "tar": "^7.5.13"
   },
   "devDependencies": {
     "@deepsec/core": "workspace:*",

--- a/packages/deepsec/src/__tests__/tarball.test.ts
+++ b/packages/deepsec/src/__tests__/tarball.test.ts
@@ -1,0 +1,125 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extractTarballLocally } from "../sandbox/download.js";
+import { makeTarball } from "../sandbox/upload.js";
+
+describe("makeTarball — symlink filtering (git branch)", () => {
+  let tmp: string;
+  const createdTars: string[] = [];
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-upload-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    for (const p of createdTars.splice(0)) {
+      try {
+        fs.unlinkSync(p);
+      } catch {}
+    }
+  });
+
+  it("git: skips symlinks while archiving regular files", async () => {
+    // `git init` is enough to put makeTarball on the git branch.
+    // No commit is required: `git ls-files --others --exclude-standard`
+    // reports untracked-not-ignored files, which is what the upload
+    // path actually relies on. Avoiding `git commit` also avoids
+    // triggering GPG-signing prompts on dev machines that have
+    // `commit.gpgsign=true` set globally.
+    execSync("git init -q", { cwd: tmp });
+
+    fs.writeFileSync(path.join(tmp, "ok.json"), '{"v":1}');
+    fs.symlinkSync("/etc/passwd", path.join(tmp, "evil.link"));
+
+    const stats = await makeTarball(tmp, []);
+    createdTars.push(stats.tarPath);
+    const entries = await listTarballEntriesFromFile(stats.tarPath);
+
+    expect(entries.some((e) => e.path.endsWith("ok.json") && e.type === "File")).toBe(true);
+    expect(entries.some((e) => e.path.includes("evil.link"))).toBe(false);
+    expect(entries.some((e) => e.type === "SymbolicLink")).toBe(false);
+  });
+
+  it("returns bytes matching the on-disk tarball size", async () => {
+    execSync("git init -q", { cwd: tmp });
+    fs.writeFileSync(path.join(tmp, "a.json"), "{}");
+    const stats = await makeTarball(tmp, []);
+    createdTars.push(stats.tarPath);
+    expect(fs.statSync(stats.tarPath).size).toBe(stats.bytes);
+  });
+});
+
+describe("extractTarballLocally — strict allowlist", () => {
+  let tarballDir: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    tarballDir = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-extract-src-"));
+    destDir = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-extract-dst-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tarballDir, { recursive: true, force: true });
+    fs.rmSync(destDir, { recursive: true, force: true });
+  });
+
+  it("accepts a tarball of allowed extensions", async () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-tar-good-"));
+    fs.writeFileSync(path.join(src, "record.json"), '{"v":1}');
+    fs.writeFileSync(path.join(src, "report.md"), "# r");
+    const stats = await makeTarball(src, []);
+    fs.rmSync(src, { recursive: true, force: true });
+
+    const count = await extractTarballLocally(stats.tarPath, destDir);
+    fs.unlinkSync(stats.tarPath);
+    expect(count).toBe(2);
+    expect(fs.existsSync(path.join(destDir, "record.json"))).toBe(true);
+    expect(fs.existsSync(path.join(destDir, "report.md"))).toBe(true);
+  });
+
+  it("refuses a tarball with a disallowed extension and writes nothing", async () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-tar-bad-"));
+    fs.writeFileSync(path.join(src, "record.json"), '{"v":1}');
+    fs.writeFileSync(path.join(src, "secret.txt"), "uh oh");
+    const stats = await makeTarball(src, []);
+    fs.rmSync(src, { recursive: true, force: true });
+
+    await expect(extractTarballLocally(stats.tarPath, destDir)).rejects.toThrow(/extension/);
+    fs.unlinkSync(stats.tarPath);
+    // All-or-nothing: even the otherwise-allowed record.json must not land.
+    expect(fs.readdirSync(destDir)).toEqual([]);
+  });
+
+  it("refuses a tarball containing a symlink entry", async () => {
+    // Build a tarball directly via tar.create that intentionally
+    // includes a symlink — bypassing makeTarball's own filter — so
+    // we exercise the download-side strict filter in isolation.
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-tar-sym-"));
+    fs.writeFileSync(path.join(src, "record.json"), '{"v":1}');
+    fs.symlinkSync("/etc/passwd", path.join(src, "leak.json"));
+    const tarPath = path.join(tarballDir, "in.tgz");
+    await tar.create({ gzip: true, cwd: src, file: tarPath, portable: true }, [
+      "record.json",
+      "leak.json",
+    ]);
+    fs.rmSync(src, { recursive: true, force: true });
+
+    await expect(extractTarballLocally(tarPath, destDir)).rejects.toThrow(/SymbolicLink|type/);
+  });
+});
+
+async function listTarballEntriesFromFile(
+  tarPath: string,
+): Promise<{ path: string; type: string }[]> {
+  const entries: { path: string; type: string }[] = [];
+  await tar.list({
+    file: tarPath,
+    onentry: (e) => entries.push({ path: e.path, type: e.type as string }),
+  });
+  return entries;
+}

--- a/packages/deepsec/src/commands/init-project.ts
+++ b/packages/deepsec/src/commands/init-project.ts
@@ -56,7 +56,12 @@ export function registerProject(opts: {
   const workspaceDir = fs.realpathSync(path.resolve(opts.workspaceDir));
   const targetAbs = requireExistingDir(opts.targetRoot, "<target-root>");
   const id = validateProjectId(opts.id ?? path.basename(targetAbs));
-  const targetRel = path.relative(workspaceDir, targetAbs);
+  // Normalize to POSIX separators: `targetRel` gets written into
+  // deepsec.config.ts (committed to VCS) and SETUP.md, so a Windows
+  // contributor adding a project would otherwise produce `..\foo\bar`
+  // that's ugly cross-platform and noisy in diffs. Both Node path APIs
+  // accept "/" on Windows.
+  const targetRel = path.relative(workspaceDir, targetAbs).split(path.sep).join("/");
 
   const configPath = findConfigInWorkspace(workspaceDir);
   if (!configPath) {

--- a/packages/deepsec/src/sandbox/download.ts
+++ b/packages/deepsec/src/sandbox/download.ts
@@ -1,9 +1,15 @@
-import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { dataDir } from "@deepsec/core";
 import type { Sandbox } from "@vercel/sandbox";
+import * as tar from "tar";
 import { DATA_DIR } from "./setup.js";
+
+// Sandbox results are JSON file records, run metadata, and reports —
+// nothing else. Lock the extract to these extensions so a tampered or
+// buggy tarball can't smuggle anything else onto the host. If the
+// sandbox legitimately needs to return a new file type, add it here.
+const ALLOWED_EXTENSIONS = new Set([".json", ".md", ".csv"]);
 
 const SETUP_MARKER = "/tmp/deepsec-setup-done";
 
@@ -115,32 +121,45 @@ export async function downloadResults(
   return count;
 }
 
-async function extractTarballLocally(tarPath: string, destDir: string): Promise<number> {
-  // Use `tar -xzvf` and count emitted lines for "files extracted" feedback.
-  return await new Promise<number>((resolve, reject) => {
-    const child = spawn("tar", ["-xzvf", tarPath, "-C", destDir], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let extracted = 0;
-    let stderr = "";
-    let stdoutBuf = "";
-    child.stdout.on("data", (c: Buffer) => {
-      stdoutBuf += c.toString();
-      let nl: number;
-      while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
-        const line = stdoutBuf.slice(0, nl);
-        stdoutBuf = stdoutBuf.slice(nl + 1);
-        if (line && !line.endsWith("/")) extracted++;
+export async function extractTarballLocally(tarPath: string, destDir: string): Promise<number> {
+  // Two-pass: list to validate, then extract. The list pass is hard
+  // "all or nothing" — if any entry is disallowed (wrong type or
+  // extension), we throw before a single byte hits disk, so callers
+  // never see a half-populated destDir on rejection. Cost is reading
+  // the gzip stream twice; sandbox-result tarballs are small, so this
+  // is negligible vs. the upload/download time.
+  //
+  // `strict: true` upgrades parser warnings (absolute paths, `..`
+  // segments, malformed pax headers) into thrown errors, so the list
+  // pass also catches anything tar's own safety would otherwise just
+  // log-and-skip. The extract pass runs with default safety; we know
+  // the archive is clean by then.
+  const violations: string[] = [];
+  let fileCount = 0;
+  await tar.list({
+    file: tarPath,
+    strict: true,
+    onentry: (entry) => {
+      if (entry.type === "Directory") return;
+      if (entry.type !== "File") {
+        violations.push(`"${entry.path}" has type ${entry.type}`);
+        return;
       }
-    });
-    child.stderr.on("data", (c: Buffer) => (stderr += c.toString()));
-    child.on("error", reject);
-    child.on("close", (code) => {
-      if (code !== 0) {
-        reject(new Error(`tar -xzf exited ${code}: ${stderr.slice(0, 500)}`));
-      } else {
-        resolve(extracted);
+      const ext = path.extname(entry.path).toLowerCase();
+      if (!ALLOWED_EXTENSIONS.has(ext)) {
+        violations.push(`"${entry.path}" has extension ${ext || "(none)"}`);
+        return;
       }
-    });
+      fileCount++;
+    },
   });
+  if (violations.length > 0) {
+    const preview = violations.slice(0, 5).join("\n  ");
+    const more = violations.length > 5 ? `\n  …and ${violations.length - 5} more` : "";
+    throw new Error(
+      `Refusing sandbox results tarball: ${violations.length} disallowed entr${violations.length === 1 ? "y" : "ies"}:\n  ${preview}${more}\nAllowed: regular files with extensions ${[...ALLOWED_EXTENSIONS].sort().join(", ")}.`,
+    );
+  }
+  await tar.extract({ file: tarPath, cwd: destDir });
+  return fileCount;
 }

--- a/packages/deepsec/src/sandbox/orchestrator.ts
+++ b/packages/deepsec/src/sandbox/orchestrator.ts
@@ -198,15 +198,27 @@ async function bootstrapAndSpawn(
   let snapshotId = config.snapshotId ?? null;
   if (!snapshotId) {
     const bundle = await prepareUploads(config, ctx.mode, ctx.root, onLog);
-    snapshotId = await createBootstrapSnapshot({
-      projectId: config.projectId,
-      agentType: config.agentType,
-      vcpus: config.vcpus,
-      timeout: config.timeout,
-      mode: ctx.mode,
-      bundle,
-      onLog,
-    });
+    try {
+      snapshotId = await createBootstrapSnapshot({
+        projectId: config.projectId,
+        agentType: config.agentType,
+        vcpus: config.vcpus,
+        timeout: config.timeout,
+        mode: ctx.mode,
+        bundle,
+        onLog,
+      });
+    } finally {
+      // Belt-and-suspenders: uploadTarballToSandbox unlinks each tarball on
+      // success, but if snapshot creation throws before all three uploads
+      // have run we'd leak the rest in os.tmpdir(). Best-effort sweep so
+      // long-running orchestrators don't accumulate stale temp files.
+      for (const t of [bundle.app.tarPath, bundle.target.tarPath, bundle.data.tarPath]) {
+        try {
+          fs.unlinkSync(t);
+        } catch {}
+      }
+    }
   } else {
     onLog(`Using provided snapshot: ${snapshotId}`);
   }

--- a/packages/deepsec/src/sandbox/setup.ts
+++ b/packages/deepsec/src/sandbox/setup.ts
@@ -281,17 +281,20 @@ export async function createBootstrapSnapshot(opts: BootstrapOptions): Promise<s
     const dataTar = "/tmp/deepsec-data.tar.gz";
     const projectDataDir = `${DATA_DIR}/${opts.projectId}`;
 
+    // Each uploadTarballToSandbox call frees the local temp tarball as soon
+    // as the upload completes, so peak host-side memory is bounded by the
+    // largest single tarball (not the sum of all three).
     await Promise.all([
       (async () => {
-        await uploadTarballToSandbox(sandbox, appTar, opts.bundle.app.buffer, opts.onLog);
+        await uploadTarballToSandbox(sandbox, appTar, opts.bundle.app.tarPath, opts.onLog);
         await extractTarballOnSandbox(sandbox, appTar, DEEPSEC_DIR, opts.onLog);
       })(),
       (async () => {
-        await uploadTarballToSandbox(sandbox, targetTar, opts.bundle.target.buffer, opts.onLog);
+        await uploadTarballToSandbox(sandbox, targetTar, opts.bundle.target.tarPath, opts.onLog);
         await extractTarballOnSandbox(sandbox, targetTar, TARGET_DIR, opts.onLog);
       })(),
       (async () => {
-        await uploadTarballToSandbox(sandbox, dataTar, opts.bundle.data.buffer, opts.onLog);
+        await uploadTarballToSandbox(sandbox, dataTar, opts.bundle.data.tarPath, opts.onLog);
         await extractTarballOnSandbox(sandbox, dataTar, projectDataDir, opts.onLog);
       })(),
     ]);

--- a/packages/deepsec/src/sandbox/upload.ts
+++ b/packages/deepsec/src/sandbox/upload.ts
@@ -1,7 +1,10 @@
 import { execSync, spawn } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import type { Sandbox } from "@vercel/sandbox";
 
 export const TARGET_EXCLUDES = [
@@ -32,13 +35,22 @@ export const DEEPSEC_APP_EXCLUDES = [
 ];
 
 export interface TarballStats {
-  buffer: Buffer;
+  /**
+   * Absolute path to a temp file holding the gzipped tar. The caller owns
+   * cleanup — once the upload (or whatever else needs the bytes) is done,
+   * unlink this file. We hand back a path instead of a Buffer so the three
+   * bundle tarballs (app/target/data) don't all sit in RAM at once: prior
+   * to this change a 3×500 MB upload bundle held ~1.5 GB of resident memory
+   * across the entire bootstrap; now each tarball is held in memory only
+   * for the duration of its own writeFiles call.
+   */
+  tarPath: string;
   bytes: number;
   sha256: string;
 }
 
 /**
- * Tar + gzip `sourceDir` contents into a Buffer.
+ * Tar + gzip `sourceDir` contents into a temp file on disk.
  *
  * If `sourceDir` is a git repository, honors `.gitignore` by feeding tar
  * the file list from `git ls-files --cached --others --exclude-standard`.
@@ -47,6 +59,14 @@ export interface TarballStats {
  * on real projects.
  *
  * If not a git repo, falls back to the provided exclude list.
+ *
+ * Spawns the system `tar` rather than going through the `tar` npm package:
+ * for many-small-files repos that's 2-3x faster on the archive step,
+ * which on cold uploads is enough wall time to notice.
+ *
+ * The gzipped stream is piped through a SHA256 transform straight to disk
+ * so we never hold a full-size Buffer in memory. Caller gets a path and
+ * owns cleanup (uploadTarballToSandbox unlinks by default).
  */
 export async function makeTarball(
   sourceDir: string,
@@ -63,100 +83,197 @@ export async function makeTarball(
   const absSourceDir = path.resolve(sourceDir);
   const isGit = fs.existsSync(path.join(absSourceDir, ".git"));
 
+  // Use a per-call unique filename so parallel makeTarball calls (the
+  // orchestrator fires three at once) can't collide.
+  const tarPath = path.join(
+    os.tmpdir(),
+    `deepsec-tar-${process.pid}-${Date.now()}-${crypto.randomBytes(4).toString("hex")}.tar.gz`,
+  );
+
   if (isGit) {
-    onLog?.(`Tarballing ${sourceDir} (using git ls-files)...`);
+    onLog?.(`Tarballing ${sourceDir} → ${path.basename(tarPath)} (using git ls-files)...`);
   } else {
-    onLog?.(`Tarballing ${sourceDir} (no .git — using exclude list)...`);
+    onLog?.(`Tarballing ${sourceDir} → ${path.basename(tarPath)} (no .git — exclude list)...`);
   }
 
-  return await new Promise<TarballStats>((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    let stderr = "";
-
-    const onDone = (code: number | null) => {
-      if (code !== 0) {
-        reject(new Error(`tar exited ${code}: ${stderr.slice(0, 500)}`));
-        return;
-      }
-      const buffer = Buffer.concat(chunks);
-      const sha256 = crypto.createHash("sha256").update(buffer).digest("hex");
-      const mb = (buffer.length / 1024 / 1024).toFixed(1);
-      const secs = ((Date.now() - started) / 1000).toFixed(1);
-      onLog?.(`Tarballed ${sourceDir} → ${mb}MB in ${secs}s (sha256:${sha256.slice(0, 12)}...)`);
-      resolve({ buffer, bytes: buffer.length, sha256 });
-    };
-
-    if (isGit) {
-      // git ls-files -z emits NUL-separated paths. Tracked + untracked-not-ignored.
-      // ls-files includes tracked-but-deleted entries (ones the user removed
-      // locally without committing), so we filter by fs.existsSync before
-      // handing the list to tar — otherwise tar errors on the missing files.
-      const raw = execSync("git ls-files --cached --others --exclude-standard -z", {
-        cwd: absSourceDir,
-        maxBuffer: 512 * 1024 * 1024,
-      });
-      const paths = raw.toString("utf8").split("\0").filter(Boolean);
-      const existing = paths.filter((p) => fs.existsSync(path.join(absSourceDir, p)));
-      const skipped = paths.length - existing.length;
-      if (skipped > 0) {
-        onLog?.(`  (skipped ${skipped} tracked-but-deleted file(s))`);
-      }
-      const filtered = Buffer.from(existing.join("\0") + "\0");
-
-      // Set both `cwd: absSourceDir` AND `-C absSourceDir`. They're
-      // equivalent when production hits the non-git branch (where `-C`
-      // is processed before the `.` file arg), but in the git branch
-      // GNU tar reads paths from `-T -` in argv order — if `-C` lands
-      // AFTER `-T -`, tar starts statting paths against the inherited
-      // cwd before the chdir takes effect. Setting `cwd` on the spawn
-      // fixes the initial dir; the `-C` arg stays as a redundant safety
-      // net. Both must be absolute so a relative sourceDir doesn't
-      // double-apply (spawn cwd resolves `data/x` against process.cwd
-      // → relative `-C data/x` would then chdir again).
-      const tar = spawn("tar", ["-czf", "-", "--null", "-T", "-", "-C", absSourceDir], {
-        cwd: absSourceDir,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      tar.stdout.on("data", (c: Buffer) => chunks.push(c));
-      tar.stderr.on("data", (c: Buffer) => (stderr += c.toString()));
-      tar.on("error", reject);
-      tar.on("close", onDone);
-      tar.stdin.write(filtered);
-      tar.stdin.end();
-    } else {
-      // Same belt-and-suspenders pairing as the git branch above. Here
-      // `-C` already runs before `.` so the initial cwd never mattered
-      // for production — adding `cwd` doesn't change anything but keeps
-      // the two branches symmetric. Absolute paths everywhere (see
-      // absSourceDir comment above) so relative sourceDirs don't
-      // double-apply.
-      const tar = spawn("tar", ["-czf", "-", ...excludes, "-C", absSourceDir, "."], {
-        cwd: absSourceDir,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-      tar.stdout.on("data", (c: Buffer) => chunks.push(c));
-      tar.stderr.on("data", (c: Buffer) => (stderr += c.toString()));
-      tar.on("error", reject);
-      tar.on("close", onDone);
-    }
+  // SHA256-then-write transform: update the hash on each chunk, count
+  // bytes, pass through to disk. Avoids an extra re-read pass.
+  const hash = crypto.createHash("sha256");
+  let bytes = 0;
+  const sha256Tap = new Transform({
+    transform(chunk: Buffer, _enc, cb) {
+      hash.update(chunk);
+      bytes += chunk.length;
+      cb(null, chunk);
+    },
   });
+
+  let tar: ReturnType<typeof spawn>;
+  let filteredList: Buffer | null = null;
+
+  if (isGit) {
+    // git ls-files -z emits NUL-separated paths. Tracked + untracked-not-ignored.
+    // Filter via lstat: drop tracked-but-deleted (would error tar) and
+    // symlinks (a tracked link → /Users/foo/secret would land in the
+    // sandbox as a dangling pointer; harmless but a needless surprise
+    // for matchers, and not something the user expects to upload).
+    const raw = execSync("git ls-files --cached --others --exclude-standard -z", {
+      cwd: absSourceDir,
+      maxBuffer: 512 * 1024 * 1024,
+    });
+    const candidates = raw.toString("utf8").split("\0").filter(Boolean);
+    let skippedDeleted = 0;
+    let skippedSymlink = 0;
+    const existing: string[] = [];
+    for (const p of candidates) {
+      let st: fs.Stats;
+      try {
+        st = fs.lstatSync(path.join(absSourceDir, p));
+      } catch {
+        skippedDeleted++;
+        continue;
+      }
+      if (st.isSymbolicLink()) {
+        skippedSymlink++;
+        continue;
+      }
+      existing.push(p);
+    }
+    if (skippedDeleted > 0) {
+      onLog?.(`  (skipped ${skippedDeleted} tracked-but-deleted file(s))`);
+    }
+    if (skippedSymlink > 0) {
+      onLog?.(`  (skipped ${skippedSymlink} symlink(s))`);
+    }
+    filteredList = Buffer.from(`${existing.join("\0")}\0`);
+
+    // Set both `cwd: absSourceDir` AND `-C absSourceDir`. They're
+    // equivalent when production hits the non-git branch (where `-C`
+    // is processed before the `.` file arg), but in the git branch
+    // GNU tar reads paths from `-T -` in argv order — if `-C` lands
+    // AFTER `-T -`, tar starts statting paths against the inherited
+    // cwd before the chdir takes effect. Setting `cwd` on the spawn
+    // fixes the initial dir; the `-C` arg stays as a redundant safety
+    // net. Both must be absolute so a relative sourceDir doesn't
+    // double-apply (spawn cwd resolves `data/x` against process.cwd
+    // → relative `-C data/x` would then chdir again).
+    tar = spawn("tar", ["-czf", "-", "--null", "-T", "-", "-C", absSourceDir], {
+      cwd: absSourceDir,
+      stdio: ["pipe", "pipe", "pipe"],
+      // macOS tar adds AppleDouble `._<file>` metadata entries by default.
+      // Suppress so the sandbox doesn't see them — and so the host-side
+      // strict extract on the return trip doesn't refuse them.
+      env: { ...process.env, COPYFILE_DISABLE: "1" },
+    });
+  } else {
+    // Same belt-and-suspenders pairing as the git branch above. Here
+    // `-C` already runs before `.` so the initial cwd never mattered
+    // for production — adding `cwd` doesn't change anything but keeps
+    // the two branches symmetric. Absolute paths everywhere (see
+    // absSourceDir comment above) so relative sourceDirs don't
+    // double-apply. Only caller of this branch today is the data dir
+    // (our own JSON output) which never has symlinks, so we don't
+    // pre-filter here — tar would archive symlinks-as-links by default
+    // anyway, which is safe; the host-side strict extract would
+    // refuse them on the way back if any ever appeared.
+    tar = spawn("tar", ["-czf", "-", ...excludes, "-C", absSourceDir, "."], {
+      cwd: absSourceDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, COPYFILE_DISABLE: "1" },
+    });
+  }
+
+  // Capture stderr for error reporting. It's bounded (tar emits at most
+  // a few KB of warnings/errors) so a plain accumulator is fine.
+  const stderrChunks: Buffer[] = [];
+  tar.stderr?.on("data", (c: Buffer) => stderrChunks.push(c));
+
+  // Wait for tar to exit; pipeline alone won't tell us a non-zero exit.
+  const exitPromise = new Promise<number>((resolve, reject) => {
+    tar.once("error", reject);
+    tar.once("close", resolve);
+  });
+
+  // Feed the git branch's path list via stdin before piping stdout.
+  // `tar.stdin.end(buf)` writes and closes atomically.
+  if (filteredList !== null && tar.stdin) {
+    tar.stdin.end(filteredList);
+  }
+
+  // pipeline: tar.stdout → sha256Tap → disk. If any stage errors,
+  // pipeline propagates it and the tar child is killed via its stdout
+  // closing. On success, all three streams close cleanly.
+  const fileOut = fs.createWriteStream(tarPath);
+  try {
+    await pipeline(tar.stdout!, sha256Tap, fileOut);
+  } catch (err) {
+    // If the pipeline fails, the temp file may be partial — nuke it.
+    try {
+      fs.unlinkSync(tarPath);
+    } catch {}
+    throw err;
+  }
+  const exitCode = await exitPromise;
+  if (exitCode !== 0) {
+    try {
+      fs.unlinkSync(tarPath);
+    } catch {}
+    throw new Error(
+      `tar exited ${exitCode}: ${Buffer.concat(stderrChunks).toString().slice(0, 500)}`,
+    );
+  }
+
+  const sha256 = hash.digest("hex");
+  const mb = (bytes / 1024 / 1024).toFixed(1);
+  const secs = ((Date.now() - started) / 1000).toFixed(1);
+  onLog?.(`Tarballed ${sourceDir} → ${mb}MB in ${secs}s (sha256:${sha256.slice(0, 12)}...)`);
+  return { tarPath, bytes, sha256 };
 }
 
 /**
- * Upload a tarball buffer to a path on the sandbox.
- * writeFiles accepts a single Uint8Array; for very large buffers the SDK
- * handles chunking internally.
+ * Upload a local tarball file to a path on the sandbox.
+ *
+ * Reads the local tarball into memory only at upload time and frees it
+ * (along with the local temp file) immediately after, so callers that
+ * build several tarballs in parallel don't keep all of them resident.
+ *
+ * The SDK's `writeFiles` API accepts only `string | Uint8Array` for
+ * `content` — there's no public streaming-upload path in `@vercel/sandbox`
+ * today, so we still hold one full Buffer for the duration of this call.
+ * That's the smallest memory footprint achievable through the SDK; the
+ * win vs. the previous design is that the Buffer's lifetime is now
+ * scoped to a single call instead of the entire orchestration window.
+ *
+ * Pass `keepLocal: true` if the caller wants to retain the local file
+ * (e.g. for retries). Default is to unlink on success.
  */
 export async function uploadTarballToSandbox(
   sandbox: Sandbox,
   remoteTarPath: string,
-  buffer: Buffer,
+  localTarPath: string,
   onLog?: (msg: string) => void,
+  opts: { keepLocal?: boolean } = {},
 ): Promise<void> {
-  const mb = (buffer.length / 1024 / 1024).toFixed(1);
+  const size = fs.statSync(localTarPath).size;
+  const mb = (size / 1024 / 1024).toFixed(1);
   onLog?.(`Uploading ${remoteTarPath} (${mb}MB)...`);
   const started = Date.now();
-  await sandbox.writeFiles([{ path: remoteTarPath, content: buffer }]);
+  // Read just-in-time so that, in the parallel-upload case, only the
+  // tarball currently in flight is resident in this process. (The SDK
+  // internally re-tars+gzips into a second buffer; that's its concern.)
+  const buffer = fs.readFileSync(localTarPath);
+  try {
+    await sandbox.writeFiles([{ path: remoteTarPath, content: buffer }]);
+  } finally {
+    // Buffer goes out of scope here; explicit `= null` would help GC
+    // earlier but V8's escape analysis already does this. The local
+    // file is the only thing left to clean up.
+    if (!opts.keepLocal) {
+      try {
+        fs.unlinkSync(localTarPath);
+      } catch {}
+    }
+  }
   onLog?.(`Uploaded ${remoteTarPath} in ${((Date.now() - started) / 1000).toFixed(1)}s`);
 }
 

--- a/packages/deepsec/src/sandbox/upload.ts
+++ b/packages/deepsec/src/sandbox/upload.ts
@@ -147,17 +147,19 @@ export async function makeTarball(
     }
     filteredList = Buffer.from(`${existing.join("\0")}\0`);
 
-    // Set both `cwd: absSourceDir` AND `-C absSourceDir`. They're
-    // equivalent when production hits the non-git branch (where `-C`
-    // is processed before the `.` file arg), but in the git branch
-    // GNU tar reads paths from `-T -` in argv order — if `-C` lands
-    // AFTER `-T -`, tar starts statting paths against the inherited
-    // cwd before the chdir takes effect. Setting `cwd` on the spawn
-    // fixes the initial dir; the `-C` arg stays as a redundant safety
-    // net. Both must be absolute so a relative sourceDir doesn't
+    // `-C` MUST come before `-T -` in GNU tar. -T reads filenames from
+    // stdin, and tar processes positional opts in argv order: anything
+    // after -T - is treated as additional file specs, not options.
+    // Recent GNU tar (≥1.35 on Linux CI) makes this a hard error
+    // ("tar: -C '...' has no effect, exit 2") instead of the earlier
+    // silent ignore. macOS bsdtar accepts both orders. We also set
+    // `cwd: absSourceDir` on the spawn as a belt-and-suspenders for
+    // the same reason — paths in the stdin list are relative, so the
+    // initial cwd has to be right even before `-C` is parsed.
+    // Both args must be absolute so a relative sourceDir doesn't
     // double-apply (spawn cwd resolves `data/x` against process.cwd
     // → relative `-C data/x` would then chdir again).
-    tar = spawn("tar", ["-czf", "-", "--null", "-T", "-", "-C", absSourceDir], {
+    tar = spawn("tar", ["-czf", "-", "-C", absSourceDir, "--null", "-T", "-"], {
       cwd: absSourceDir,
       stdio: ["pipe", "pipe", "pipe"],
       // macOS tar adds AppleDouble `._<file>` metadata entries by default.

--- a/packages/scanner/src/__tests__/windows-paths.test.ts
+++ b/packages/scanner/src/__tests__/windows-paths.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { MatcherPlugin } from "@deepsec/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock glob before importing the scanner so the driver picks up the mock.
+vi.mock("glob", () => ({
+  glob: vi.fn(),
+}));
+
+const { glob } = await import("glob");
+const { RegexScannerDriver } = await import("../index.js");
+
+describe("RegexScannerDriver — Windows path normalization", () => {
+  let tmpRoot: string;
+  let dataRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-scan-"));
+    dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-data-"));
+    process.env.DEEPSEC_DATA_ROOT = dataRoot;
+
+    fs.mkdirSync(path.join(tmpRoot, "src", "api"), { recursive: true });
+    fs.writeFileSync(path.join(tmpRoot, "src", "api", "foo.ts"), "eval(userInput);\n");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    fs.rmSync(dataRoot, { recursive: true, force: true });
+    delete process.env.DEEPSEC_DATA_ROOT;
+    vi.clearAllMocks();
+  });
+
+  it("normalizes backslash-separated glob output to POSIX before record write", async () => {
+    // Simulate Windows glob output (backslash separators).
+    vi.mocked(glob).mockResolvedValueOnce(["src\\api\\foo.ts"] as never);
+
+    const matcher: MatcherPlugin = {
+      slug: "test-eval",
+      noiseTier: "normal",
+      description: "test matcher",
+      filePatterns: ["**/*.ts"],
+      match(content) {
+        return /eval\s*\(/.test(content)
+          ? [
+              {
+                vulnSlug: "test-eval",
+                lineNumbers: [1],
+                snippet: content,
+                matchedPattern: "eval",
+              },
+            ]
+          : [];
+      },
+    };
+
+    const driver = new RegexScannerDriver();
+    const gen = driver.scan({
+      root: tmpRoot,
+      matchers: [matcher],
+      projectId: "winproj",
+      runId: "run-1",
+    });
+
+    let result = await gen.next();
+    while (!result.done) result = await gen.next();
+    const records = result.value;
+
+    expect(records).toHaveLength(1);
+    expect(records[0].filePath).toBe("src/api/foo.ts");
+
+    // The record should land on disk under the POSIX-normalized path.
+    const recordPath = path.join(dataRoot, "winproj", "files", "src", "api", "foo.ts.json");
+    expect(fs.existsSync(recordPath)).toBe(true);
+  });
+});

--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -106,12 +106,16 @@ export class RegexScannerDriver implements ScannerDriver {
         message: `Globbing pattern ${globsDone}/${uniquePatterns.length}: ${group[0].filePatterns.slice(0, 3).join(", ")}${group[0].filePatterns.length > 3 ? "..." : ""}`,
         matcherSlug: "glob",
       };
-      const files = await glob(group[0].filePatterns, {
+      const rawFiles = await glob(group[0].filePatterns, {
         cwd: root,
         ignore,
         nodir: true,
         absolute: false,
       });
+      // glob returns native separators on Windows ("src\api\foo.ts").
+      // Record paths require POSIX separators (assertSafeFilePath rejects
+      // "\"), so normalize once here before anything reads or writes records.
+      const files = rawFiles.map((f) => f.replaceAll("\\", "/"));
       globCache.set(key, files);
       yield {
         type: "matcher_done" as const,
@@ -139,7 +143,14 @@ export class RegexScannerDriver implements ScannerDriver {
         let content = contentCache.get(relPath);
         if (content === undefined) {
           try {
-            content = fs.readFileSync(path.join(root, relPath), "utf-8");
+            // Normalize CRLF → LF so matchers that split on "\n" don't see
+            // a trailing "\r" on every line. Without this, regexes anchored
+            // with `$` silently fail to match on Windows-checked-out files
+            // (and any mixed-EOL repo). Note: byte offsets reported by
+            // matchers are now into the normalized content, not the raw
+            // file on disk — line numbers stay correct, but if a matcher
+            // ever needs raw byte offsets it has to redo the read itself.
+            content = fs.readFileSync(path.join(root, relPath), "utf-8").replaceAll("\r\n", "\n");
             contentCache.set(relPath, content);
           } catch {
             contentCache.set(relPath, "");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       jiti:
         specifier: ^2.4.0
         version: 2.6.1
+      tar:
+        specifier: ^7.5.13
+        version: 7.5.13
     devDependencies:
       '@deepsec/core':
         specifier: workspace:*
@@ -798,6 +801,13 @@ packages:
   /@isaacs/cliui@9.0.0:
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
+    dev: false
+
+  /@isaacs/fs-minipass@4.0.1:
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      minipass: 7.1.3
     dev: false
 
   /@jridgewell/sourcemap-codec@1.5.5:
@@ -1721,6 +1731,11 @@ packages:
     engines: {node: '>= 16'}
     dev: true
 
+  /chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+    dev: false
+
   /commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
@@ -2291,6 +2306,13 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dev: false
 
+  /minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      minipass: 7.1.3
+    dev: false
+
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2694,6 +2716,17 @@ packages:
       - react-native-b4a
     dev: false
 
+  /tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+    dev: false
+
   /text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
     dependencies:
@@ -2980,6 +3013,11 @@ packages:
     engines: {node: '>= 6.0'}
     dependencies:
       os-paths: 4.4.0
+    dev: false
+
+  /yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
     dev: false
 
   /yaml@2.8.3:


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
