### PR TITLE
fix: unify `SEVERITY_ORDER` across commands

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -92,6 +92,16 @@ export interface AnalysisEntry {
 export type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "HIGH_BUG" | "BUG" | "LOW";
 export type Confidence = "high" | "medium" | "low";
 
+/** Severity rank, lower is more severe. Used by `--min-severity` filter and severity sort. */
+export const SEVERITY_ORDER: Record<Severity, number> = {
+  CRITICAL: 0,
+  HIGH: 1,
+  MEDIUM: 2,
+  HIGH_BUG: 3,
+  BUG: 4,
+  LOW: 5,
+};
+
 export type RevalidationVerdict = "true-positive" | "false-positive" | "fixed" | "uncertain";
 
 export interface Revalidation {

--- a/packages/deepsec/src/commands/export.ts
+++ b/packages/deepsec/src/commands/export.ts
@@ -2,17 +2,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { FileRecord, Finding, Severity } from "@deepsec/core";
-import { dataDir, getDataRoot, loadAllFileRecords } from "@deepsec/core";
+import { dataDir, getDataRoot, loadAllFileRecords, SEVERITY_ORDER } from "@deepsec/core";
 import { BOLD, DIM, GREEN, RESET, YELLOW } from "../formatters.js";
-
-const SEVERITY_ORDER: Record<Severity, number> = {
-  CRITICAL: 0,
-  HIGH: 1,
-  HIGH_BUG: 2,
-  MEDIUM: 3,
-  BUG: 4,
-  LOW: 5,
-};
 
 interface OwnerSummary {
   assignee?: string;

--- a/packages/deepsec/src/commands/metrics.ts
+++ b/packages/deepsec/src/commands/metrics.ts
@@ -1,16 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import { getDataRoot, loadAllFileRecords } from "@deepsec/core";
+import type { Severity } from "@deepsec/core";
+import { getDataRoot, loadAllFileRecords, SEVERITY_ORDER } from "@deepsec/core";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "../formatters.js";
-
-const SEVERITY_ORDER: Record<string, number> = {
-  CRITICAL: 0,
-  HIGH: 1,
-  MEDIUM: 2,
-  HIGH_BUG: 3,
-  BUG: 4,
-  LOW: 5,
-};
 
 interface TokenStats {
   input: number;
@@ -59,7 +51,7 @@ function discoverProjects(): string[] {
 }
 
 function getMetrics(projectId: string, minSeverity?: string): ProjectMetrics {
-  const minOrder = minSeverity ? (SEVERITY_ORDER[minSeverity] ?? 2) : 99;
+  const minOrder = minSeverity ? (SEVERITY_ORDER[minSeverity as Severity] ?? 2) : 99;
   const records = loadAllFileRecords(projectId);
 
   const m: ProjectMetrics = {

--- a/packages/deepsec/src/sandbox/partitioner.ts
+++ b/packages/deepsec/src/sandbox/partitioner.ts
@@ -1,17 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { FileRecord } from "@deepsec/core";
-import { dataDir, loadAllFileRecords } from "@deepsec/core";
+import type { FileRecord, Severity } from "@deepsec/core";
+import { dataDir, loadAllFileRecords, SEVERITY_ORDER } from "@deepsec/core";
 import { noiseScore } from "@deepsec/scanner";
 import type { PartitionResult, SandboxSubcommand } from "./types.js";
-
-const SEVERITY_ORDER: Record<string, number> = {
-  CRITICAL: 0,
-  HIGH: 1,
-  MEDIUM: 2,
-  HIGH_BUG: 3,
-  BUG: 4,
-};
 
 /**
  * Load eligible files for the given command and split into N disjoint partitions.
@@ -60,18 +52,19 @@ export function partitionFiles(
       }
       break;
 
-    case "revalidate":
+    case "revalidate": {
+      const minSev = opts.minSeverity ? SEVERITY_ORDER[opts.minSeverity as Severity] : undefined;
       eligible = allRecords.filter((r) => {
         if (r.findings.length === 0) return false;
         const unrevalidated = r.findings.filter((f) => {
           if (!opts.force && f.revalidation) return false;
-          if (opts.minSeverity && SEVERITY_ORDER[f.severity] > SEVERITY_ORDER[opts.minSeverity])
-            return false;
+          if (minSev !== undefined && SEVERITY_ORDER[f.severity] > minSev) return false;
           return true;
         });
         return unrevalidated.length > 0;
       });
       break;
+    }
 
     default:
       eligible = allRecords;

--- a/packages/processor/src/enrich.ts
+++ b/packages/processor/src/enrich.ts
@@ -6,6 +6,7 @@ import {
   getRegistry,
   loadAllFileRecords,
   readProjectConfig,
+  SEVERITY_ORDER,
   writeFileRecord,
 } from "@deepsec/core";
 
@@ -151,15 +152,6 @@ interface EnrichProgress {
   current?: number;
   total?: number;
 }
-
-const SEVERITY_ORDER: Record<Severity, number> = {
-  CRITICAL: 0,
-  HIGH: 1,
-  HIGH_BUG: 2,
-  MEDIUM: 3,
-  BUG: 4,
-  LOW: 5,
-};
 
 export async function enrich(params: {
   projectId: string;

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -10,6 +10,7 @@ import {
   loadAllFileRecords,
   readProjectConfig,
   readRunMeta,
+  SEVERITY_ORDER,
   writeFileRecord,
   writeRunMeta,
 } from "@deepsec/core";
@@ -576,15 +577,6 @@ export async function process(params: {
 }
 
 // --- Revalidation ---
-
-const SEVERITY_ORDER: Record<Severity, number> = {
-  CRITICAL: 0,
-  HIGH: 1,
-  MEDIUM: 2,
-  HIGH_BUG: 3,
-  BUG: 4,
-  LOW: 5,
-};
 
 export async function revalidate(params: {
   projectId: string;


### PR DESCRIPTION
## What changed
Create a single source of truth for severity ordering, align it to `Severity` type order of:

`CRITICAL | HIGH | MEDIUM | HIGH_BUG | BUG | LOW`

## Why
closes #48

There are 5 copies of `SEVERITY_ORDER` that had drifted. 2 swap `MEDIUM` and `HIGH_BUG`, and one is missing `LOW` so LOW findings sneak past `sandbox --min-severity` no matter what threshold you pass.

## Verification

- [x] `pnpm test` passes (besides the broken test on macos on main, yah)
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

Slight refactor for clarity in the `revalidate` switch statement, compacting an if statement via an intermediate variable, not needed but did it while I was there.
