### PR TITLE
fix(test): use `unlinkSync` to clean up `samples/webapp` symlink

### DIFF
--- a/e2e/bundle.test.ts
+++ b/e2e/bundle.test.ts
@@ -152,7 +152,9 @@ export default defineConfig({
       expect(stdout).toContain("webapp-debug-flag");
       expect(stdout).toContain("webapp-route-no-rate-limit");
     } finally {
-      fs.rmSync(link, { force: true });
+      try {
+        fs.unlinkSync(link);
+      } catch {}
       fs.rmSync(path.join(sampleDir, "data"), { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## What changed

Use `fs.unlinkSync` to remove the symlink, to avoid mac os error on trying to `rmSync` a dir without `recursive: true`.

Wrap `fs.unlinkSync` in try/catch to preserve the previous idempotent behavior of `rmSync(link, {force: true})` (swallow any errors if the link is already gone)

## Why
closes #51 

**The tests currently fail on mac os with an uncaught error during cleanup.**

`Error: Path is a directory`

Mac is choking on the symlink resolving to a dir, so doesnt like `fs.rmSync` without `{recursive: true}`.
```
 FAIL   e2e  bundle.test.ts > bundle e2e > samples/webapp/ — config loads and custom matchers register
Error: Path is a directory: ~/Forks/deepsec/samples/webapp/node_modules
 ❯ bundle.test.ts:155:10
    153|       expect(stdout).toContain("webapp-route-no-rate-limit");
    154|     } finally {
    155|       fs.rmSync(link, { force: true });
       |          ^
    156|       fs.rmSync(path.join(sampleDir, "data"), { recursive: true, force: true });
    157|     }
```
## Verification

- [x] `pnpm test` passes
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane
