### PR TITLE
Properly merge runs data on concurrent processing

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -63,6 +63,12 @@ export const analysisEntrySchema = z.object({
   agentSessionId: z.string().optional(),
   findingCount: z.number(),
   numTurns: z.number().optional(),
+  /**
+   * "process" (default) = investigation run; "revalidate" = revalidation
+   * pass. Optional for backward compat with entries written before the
+   * field existed.
+   */
+  phase: z.enum(["process", "revalidate"]).optional(),
   costUsd: z.number().optional(),
   usage: z
     .object({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -91,7 +91,33 @@ export interface AnalysisEntry {
   agentSessionId?: string;
   findingCount: number;
   numTurns?: number;
+  /**
+   * Which run-type produced this entry. `process` = an investigation run
+   * appended findings to the file; `revalidate` = a revalidation run
+   * applied verdicts to existing findings (no new findings expected).
+   *
+   * Optional for backward compat: entries written before this field
+   * existed are implicitly `process`. Aggregators that want to bucket
+   * the two should treat missing as `process`.
+   *
+   * The `--reinvestigate <N>` filter in `process()` and the sandbox
+   * partitioner explicitly ignore entries where `phase === "revalidate"`
+   * — a revalidate pass shouldn't count as "this file has already been
+   * processed by this agent for wave N".
+   */
+  phase?: "process" | "revalidate";
+  /**
+   * Per-file share of batch-level cost. The agent reports cost / tokens
+   * for the whole batch (one API call covers N files); we divide evenly
+   * so summing per-file entries gives the correct run total. Pre-fix
+   * entries hold the *batch* total stamped on every file, which inflates
+   * `metrics` cost roughly by batch size.
+   */
   costUsd?: number;
+  /**
+   * Per-file share of batch-level token usage. Same divide-by-N split
+   * as `costUsd`.
+   */
   usage?: {
     inputTokens: number;
     outputTokens: number;

--- a/packages/deepsec/src/__tests__/merge-records.test.ts
+++ b/packages/deepsec/src/__tests__/merge-records.test.ts
@@ -1,0 +1,287 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AnalysisEntry, FileRecord, Finding } from "@deepsec/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  mergeAfterExtract,
+  mergeFileRecord,
+  snapshotFileRecords,
+} from "../sandbox/merge-records.js";
+
+function entry(runId: string, agentType: string, investigatedAt: string): AnalysisEntry {
+  return {
+    runId,
+    investigatedAt,
+    durationMs: 1000,
+    agentType,
+    model: agentType === "codex" ? "gpt-5.5" : "claude-opus-4-7",
+    modelConfig: {},
+    findingCount: 0,
+  };
+}
+
+function finding(vulnSlug: string, title: string, extras: Partial<Finding> = {}): Finding {
+  return {
+    severity: "HIGH",
+    vulnSlug,
+    title,
+    description: "d",
+    lineNumbers: [1],
+    recommendation: "r",
+    confidence: "high",
+    ...extras,
+  };
+}
+
+function record(overrides: Partial<FileRecord> = {}): FileRecord {
+  return {
+    filePath: "src/foo.ts",
+    projectId: "p",
+    candidates: [],
+    lastScannedAt: "2026-05-06T15:00:00.000Z",
+    lastScannedRunId: "scan1",
+    fileHash: "h",
+    findings: [],
+    analysisHistory: [],
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("mergeFileRecord", () => {
+  it("unions analysisHistory by runId and sorts by investigatedAt", () => {
+    const host = record({
+      analysisHistory: [entry("claude-run", "claude-agent-sdk", "2026-05-06T15:54:37.000Z")],
+      status: "analyzed",
+    });
+    const incoming = record({
+      analysisHistory: [entry("codex-run", "codex", "2026-05-06T15:59:48.000Z")],
+      status: "analyzed",
+    });
+
+    const merged = mergeFileRecord(host, incoming);
+
+    expect(merged.analysisHistory.map((e) => e.runId)).toEqual(["claude-run", "codex-run"]);
+    expect(merged.status).toBe("analyzed");
+  });
+
+  it("dedupes analysisHistory when both sides serialize the same runId", () => {
+    const sameEntry = entry("run-x", "codex", "2026-05-06T15:59:48.000Z");
+    const host = record({ analysisHistory: [sameEntry] });
+    const incoming = record({
+      analysisHistory: [{ ...sameEntry, findingCount: 5 }],
+    });
+
+    const merged = mergeFileRecord(host, incoming);
+
+    expect(merged.analysisHistory).toHaveLength(1);
+    expect(merged.analysisHistory[0].findingCount).toBe(5); // incoming wins
+  });
+
+  it("unions findings by vulnSlug+title signature", () => {
+    const host = record({
+      findings: [finding("xss", "XSS via innerHTML")],
+    });
+    const incoming = record({
+      findings: [finding("ssrf", "SSRF in webhook handler")],
+    });
+
+    const merged = mergeFileRecord(host, incoming);
+
+    expect(merged.findings.map((f) => f.vulnSlug).sort()).toEqual(["ssrf", "xss"]);
+  });
+
+  it("preserves revalidation/triage from either side when finding signatures match", () => {
+    const hostFinding = finding("xss", "XSS", {
+      revalidation: {
+        verdict: "true-positive",
+        reasoning: "confirmed",
+        revalidatedAt: "2026-05-06T16:00:00.000Z",
+        runId: "reval-run",
+        model: "gpt-5.5",
+      },
+    });
+    const incomingFinding = finding("xss", "xss", {
+      triage: {
+        priority: "P0",
+        exploitability: "trivial",
+        impact: "critical",
+        reasoning: "trivial RCE",
+        triagedAt: "2026-05-06T16:05:00.000Z",
+        model: "claude-sonnet-4-6",
+      },
+    });
+
+    const merged = mergeFileRecord(
+      record({ findings: [hostFinding] }),
+      record({ findings: [incomingFinding] }),
+    );
+
+    expect(merged.findings).toHaveLength(1);
+    expect(merged.findings[0].revalidation?.verdict).toBe("true-positive");
+    expect(merged.findings[0].triage?.priority).toBe("P0");
+  });
+
+  it("preserves gitInfo when incoming lacks it", () => {
+    const host = record({
+      gitInfo: {
+        recentCommitters: [{ name: "alice", email: "a@x", date: "2026-05-06" }],
+        enrichedAt: "2026-05-06T15:00:00.000Z",
+      },
+    });
+    const incoming = record({ gitInfo: undefined });
+
+    const merged = mergeFileRecord(host, incoming);
+
+    expect(merged.gitInfo?.recentCommitters[0].name).toBe("alice");
+  });
+
+  it("status: 'analyzed' on either side wins", () => {
+    expect(
+      mergeFileRecord(record({ status: "analyzed" }), record({ status: "processing" })).status,
+    ).toBe("analyzed");
+    expect(
+      mergeFileRecord(record({ status: "pending" }), record({ status: "analyzed" })).status,
+    ).toBe("analyzed");
+    expect(
+      mergeFileRecord(record({ status: "processing" }), record({ status: "error" })).status,
+    ).toBe("error");
+  });
+
+  it("reproduces the parallel-orchestrator scenario end-to-end", () => {
+    // Repro: claude orchestrator finished a sandbox at 15:54:37 (host
+    // gets [claudeA]). Codex orchestrator started at 15:58:21, snapshotted
+    // the host (got [claudeA]), processed and is now uploading [claudeA, codexB].
+    //
+    // Meanwhile, ANOTHER claude sandbox started before 15:58:21 (so its
+    // local snapshot was empty) finished and is uploading [claudeC]. If
+    // its tarball lands AFTER codex's, the naive overwrite drops both
+    // claudeA and codexB. With the merge, all three survive.
+    let host = record({
+      analysisHistory: [entry("claudeA", "claude-agent-sdk", "2026-05-06T15:54:37.000Z")],
+      status: "analyzed",
+    });
+
+    // Codex sandbox uploads [claudeA, codexB] — extract overlays it on host
+    const codexUpload = record({
+      analysisHistory: [
+        entry("claudeA", "claude-agent-sdk", "2026-05-06T15:54:37.000Z"),
+        entry("codexB", "codex", "2026-05-06T15:59:48.000Z"),
+      ],
+      status: "analyzed",
+    });
+    host = mergeFileRecord(host, codexUpload);
+
+    // Late-arriving claude sandbox uploads [claudeC] only (its local snapshot
+    // had been empty when the run started)
+    const lateClaudeUpload = record({
+      analysisHistory: [entry("claudeC", "claude-agent-sdk", "2026-05-06T16:02:00.000Z")],
+      status: "analyzed",
+    });
+    host = mergeFileRecord(host, lateClaudeUpload);
+
+    expect(host.analysisHistory.map((e) => e.runId)).toEqual(["claudeA", "codexB", "claudeC"]);
+  });
+});
+
+describe("snapshotFileRecords + mergeAfterExtract", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-merge-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns an empty snapshot when files/ doesn't exist", () => {
+    expect(snapshotFileRecords(dir).size).toBe(0);
+  });
+
+  it("walks files/ recursively and indexes records by relative path", () => {
+    const inner = path.join(dir, "files", "src", "nested");
+    fs.mkdirSync(inner, { recursive: true });
+    fs.writeFileSync(
+      path.join(inner, "deep.ts.json"),
+      JSON.stringify(record({ filePath: "src/nested/deep.ts" })),
+    );
+    fs.writeFileSync(
+      path.join(dir, "files", "shallow.ts.json"),
+      JSON.stringify(record({ filePath: "shallow.ts" })),
+    );
+
+    const snap = snapshotFileRecords(dir);
+
+    expect(snap.size).toBe(2);
+    expect(snap.has(path.join("files", "src", "nested", "deep.ts.json"))).toBe(true);
+    expect(snap.has(path.join("files", "shallow.ts.json"))).toBe(true);
+  });
+
+  it("rewrites only files that existed in both the host snapshot and the post-extract state", () => {
+    // Pre-extraction: host has a record with claude history
+    const filesDir = path.join(dir, "files", "src");
+    fs.mkdirSync(filesDir, { recursive: true });
+    const recPath = path.join(filesDir, "foo.ts.json");
+    fs.writeFileSync(
+      recPath,
+      JSON.stringify(
+        record({
+          filePath: "src/foo.ts",
+          analysisHistory: [entry("claudeA", "claude-agent-sdk", "2026-05-06T15:54:37.000Z")],
+          status: "analyzed",
+        }),
+      ),
+    );
+    const snap = snapshotFileRecords(dir);
+
+    // Simulate a tar extract overwriting that file with [codexB] only —
+    // the pattern that drops history without merging.
+    fs.writeFileSync(
+      recPath,
+      JSON.stringify(
+        record({
+          filePath: "src/foo.ts",
+          analysisHistory: [entry("codexB", "codex", "2026-05-06T15:59:48.000Z")],
+          status: "analyzed",
+        }),
+      ),
+    );
+
+    // A second file the host had nothing for (sandbox-only contribution)
+    const newFilePath = path.join(filesDir, "bar.ts.json");
+    fs.writeFileSync(
+      newFilePath,
+      JSON.stringify(
+        record({
+          filePath: "src/bar.ts",
+          analysisHistory: [entry("codexB2", "codex", "2026-05-06T15:59:50.000Z")],
+        }),
+      ),
+    );
+
+    const merged = mergeAfterExtract(dir, snap);
+    expect(merged).toBe(1);
+
+    const fooAfter = JSON.parse(fs.readFileSync(recPath, "utf-8"));
+    expect(fooAfter.analysisHistory.map((e: AnalysisEntry) => e.runId)).toEqual([
+      "claudeA",
+      "codexB",
+    ]);
+
+    // bar.ts wasn't in the host snapshot, so it's left alone.
+    const barAfter = JSON.parse(fs.readFileSync(newFilePath, "utf-8"));
+    expect(barAfter.analysisHistory.map((e: AnalysisEntry) => e.runId)).toEqual(["codexB2"]);
+  });
+
+  it("skips malformed JSON in the snapshot rather than throwing", () => {
+    const filesDir = path.join(dir, "files");
+    fs.mkdirSync(filesDir, { recursive: true });
+    fs.writeFileSync(path.join(filesDir, "broken.ts.json"), "{not valid json");
+    fs.writeFileSync(path.join(filesDir, "ok.ts.json"), JSON.stringify(record()));
+
+    const snap = snapshotFileRecords(dir);
+    expect(snap.size).toBe(1);
+  });
+});

--- a/packages/deepsec/src/sandbox/download.ts
+++ b/packages/deepsec/src/sandbox/download.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { dataDir } from "@deepsec/core";
 import type { Sandbox } from "@vercel/sandbox";
 import * as tar from "tar";
+import { mergeAfterExtract, snapshotFileRecords } from "./merge-records.js";
 import { DATA_DIR } from "./setup.js";
 
 // Sandbox results are JSON file records, run metadata, and reports —
@@ -160,6 +161,14 @@ export async function extractTarballLocally(tarPath: string, destDir: string): P
       `Refusing sandbox results tarball: ${violations.length} disallowed entr${violations.length === 1 ? "y" : "ies"}:\n  ${preview}${more}\nAllowed: regular files with extensions ${[...ALLOWED_EXTENSIONS].sort().join(", ")}.`,
     );
   }
+
+  // Snapshot existing per-file records BEFORE extracting. The tarball
+  // extract is a blind overwrite, so without this any prior on-host
+  // analysisHistory / findings / revalidation / triage entries would
+  // disappear when a concurrently-running sandbox uploads its (older)
+  // view of the same file. We re-merge after extract.
+  const hostSnapshot = snapshotFileRecords(destDir);
   await tar.extract({ file: tarPath, cwd: destDir });
+  mergeAfterExtract(destDir, hostSnapshot);
   return fileCount;
 }

--- a/packages/deepsec/src/sandbox/merge-records.ts
+++ b/packages/deepsec/src/sandbox/merge-records.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { AnalysisEntry, FileRecord, Finding } from "@deepsec/core";
+
+/**
+ * Tarball extraction is `cwd=dataDir(projectId)`, so file records live
+ * under `<destDir>/files/**.json`. We only merge those — run metadata
+ * (`runs/*.json`) is unique per runId, so the tar overwrite is safe there.
+ */
+const FILES_SUBDIR = "files";
+
+/**
+ * Snapshot all existing file records under `<destDir>/files/` into a map
+ * keyed by their path relative to `destDir` (e.g. `"files/src/foo.ts.json"`).
+ *
+ * Called BEFORE tar extraction so we have the host's pre-extraction state
+ * to merge against once the tarball lands.
+ *
+ * Best-effort: malformed JSON is skipped silently rather than aborting the
+ * download — a corrupt host record shouldn't block a sandbox upload, and
+ * the incoming version will replace it via the normal extract path.
+ */
+export function snapshotFileRecords(destDir: string): Map<string, FileRecord> {
+  const out = new Map<string, FileRecord>();
+  const filesRoot = path.join(destDir, FILES_SUBDIR);
+  if (!fs.existsSync(filesRoot)) return out;
+
+  const stack: string[] = [filesRoot];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        stack.push(full);
+      } else if (e.isFile() && e.name.endsWith(".json")) {
+        try {
+          const raw = JSON.parse(fs.readFileSync(full, "utf-8"));
+          out.set(path.relative(destDir, full), raw as FileRecord);
+        } catch {
+          // skip malformed
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Merge two FileRecords representing the same file but written by
+ * concurrent sandbox uploads.
+ *
+ * The race we're fixing: sandbox A and sandbox B both snapshotted the
+ * host data dir at slightly different times. Each appended its own
+ * `analysisHistory` entry locally, then uploaded a full tarball. Without
+ * merging, whichever tarball is extracted last overwrites the other's
+ * history — and in practice we observed entire codex runs disappearing
+ * from per-file `analysisHistory` despite being recorded in `runs/*.json`.
+ *
+ * Merge strategy:
+ *   - `analysisHistory`: union by `runId` (each run is globally unique).
+ *     For the same runId on both sides, prefer `incoming` since the
+ *     tarball is the more recent serialization.
+ *   - `findings`: union by `(vulnSlug, normalized title)` signature, the
+ *     same key `process()` uses to dedupe re-runs. For matching findings,
+ *     merge field-by-field so a `revalidation` / `triage` set on either
+ *     side survives.
+ *   - `gitInfo`: prefer whichever side has it set — enrich runs only
+ *     populate, never clear, so losing it across an extract is real loss.
+ *   - `status`: "analyzed" wins over anything else (a finished run on
+ *     either side means the file is analyzed). Otherwise prefer incoming.
+ *   - `lockedByRunId` / `lockedAt`: prefer incoming; the per-batch loop
+ *     in `process()` is the authoritative writer.
+ *   - Scan-time fields (`candidates`, `lastScannedAt`, `lastScannedRunId`,
+ *     `fileHash`): prefer incoming. Concurrent process/revalidate runs
+ *     don't touch these — if they differ, the difference came from a
+ *     scan run that has its own non-racing lifecycle.
+ */
+export function mergeFileRecord(host: FileRecord, incoming: FileRecord): FileRecord {
+  const historyByRunId = new Map<string, AnalysisEntry>();
+  for (const entry of host.analysisHistory ?? []) {
+    historyByRunId.set(entry.runId, entry);
+  }
+  for (const entry of incoming.analysisHistory ?? []) {
+    historyByRunId.set(entry.runId, entry);
+  }
+  const mergedHistory = Array.from(historyByRunId.values()).sort(
+    (a, b) => new Date(a.investigatedAt).getTime() - new Date(b.investigatedAt).getTime(),
+  );
+
+  const findingsBySig = new Map<string, Finding>();
+  for (const f of host.findings ?? []) {
+    findingsBySig.set(findingSignature(f), f);
+  }
+  for (const f of incoming.findings ?? []) {
+    const sig = findingSignature(f);
+    const existing = findingsBySig.get(sig);
+    findingsBySig.set(sig, existing ? mergeFinding(existing, f) : f);
+  }
+  const mergedFindings = Array.from(findingsBySig.values());
+
+  const status =
+    host.status === "analyzed" || incoming.status === "analyzed" ? "analyzed" : incoming.status;
+
+  return {
+    ...incoming,
+    gitInfo: incoming.gitInfo ?? host.gitInfo,
+    findings: mergedFindings,
+    analysisHistory: mergedHistory,
+    status,
+  };
+}
+
+function findingSignature(f: Finding): string {
+  return `${f.vulnSlug ?? ""}::${(f.title ?? "").trim().toLowerCase()}`;
+}
+
+function mergeFinding(host: Finding, incoming: Finding): Finding {
+  return {
+    ...host,
+    ...incoming,
+    revalidation: incoming.revalidation ?? host.revalidation,
+    triage: incoming.triage ?? host.triage,
+    producedByRunId: host.producedByRunId ?? incoming.producedByRunId,
+  };
+}
+
+/**
+ * After tar extraction, walk `<destDir>/files/**.json` and re-write any
+ * record that also existed in `hostSnapshot` with a merged version.
+ *
+ * Files that didn't exist on the host before extraction are left
+ * untouched (they're the sandbox's contribution). Files that existed on
+ * the host but are missing from the tarball are also untouched (the
+ * sandbox didn't change them this poll).
+ *
+ * Returns the number of records that were merge-rewritten.
+ */
+export function mergeAfterExtract(destDir: string, hostSnapshot: Map<string, FileRecord>): number {
+  if (hostSnapshot.size === 0) return 0;
+  const filesRoot = path.join(destDir, FILES_SUBDIR);
+  if (!fs.existsSync(filesRoot)) return 0;
+
+  let merged = 0;
+  const stack: string[] = [filesRoot];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (!(e.isFile() && e.name.endsWith(".json"))) continue;
+      const rel = path.relative(destDir, full);
+      const host = hostSnapshot.get(rel);
+      if (!host) continue;
+
+      let incoming: FileRecord;
+      try {
+        incoming = JSON.parse(fs.readFileSync(full, "utf-8")) as FileRecord;
+      } catch {
+        continue;
+      }
+      const out = mergeFileRecord(host, incoming);
+      fs.writeFileSync(full, JSON.stringify(out, null, 2) + "\n");
+      merged++;
+    }
+  }
+  return merged;
+}

--- a/packages/deepsec/src/sandbox/partitioner.ts
+++ b/packages/deepsec/src/sandbox/partitioner.ts
@@ -47,6 +47,9 @@ export function partitionFiles(
           const alreadyDone = (r.analysisHistory ?? []).some((h) => {
             if ((h.usage?.outputTokens ?? 0) <= 0) return false;
             if (h.agentType !== agentType) return false;
+            // Mirror processor/index.ts: revalidate entries don't count
+            // as "already processed" for a reinvestigate wave.
+            if (h.phase === "revalidate") return false;
             return h.reinvestigateMarker === marker;
           });
           return !alreadyDone;

--- a/packages/processor/src/__tests__/process-revalidate.test.ts
+++ b/packages/processor/src/__tests__/process-revalidate.test.ts
@@ -397,6 +397,202 @@ describe("processor with stub agent", () => {
     expect(after.findings[0].revalidation?.reasoning).toBe("stub: confirmed");
   });
 
+  it("process() divides batch-level cost / tokens evenly across files in the batch", async () => {
+    // Repro for the metrics inflation bug: agent.investigate() reports
+    // one cost / token total for the whole batch (one API call covers N
+    // files), and we used to stamp that total onto every file's
+    // analysisHistory entry. Summing per-file entries then over-counted
+    // by ~batch size in `metrics`.
+    const fx = setupProject({ files: ["a.ts", "b.ts", "c.ts", "d.ts"] });
+    fx.writeRecord(pendingRecord(fx.projectId, "a.ts"));
+    fx.writeRecord(pendingRecord(fx.projectId, "b.ts"));
+    fx.writeRecord(pendingRecord(fx.projectId, "c.ts"));
+    fx.writeRecord(pendingRecord(fx.projectId, "d.ts"));
+
+    const stub = new StubAgent({
+      async *investigateImpl(params) {
+        return {
+          results: params.batch.map((r) => ({ filePath: r.filePath, findings: [] })),
+          meta: {
+            durationMs: 4000,
+            durationApiMs: 2000,
+            numTurns: 8,
+            costUsd: 4.0,
+            usage: {
+              inputTokens: 4000,
+              outputTokens: 400,
+              cacheReadInputTokens: 800,
+              cacheCreationInputTokens: 200,
+            },
+          },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    await processProject({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+      batchSize: 4,
+    });
+
+    const records = ["a.ts", "b.ts", "c.ts", "d.ts"].map((f) => fx.readRecord(f));
+    // Each file gets a quarter of the batch-level numbers.
+    for (const r of records) {
+      expect(r.analysisHistory).toHaveLength(1);
+      const h = r.analysisHistory[0];
+      expect(h.costUsd).toBe(1.0);
+      expect(h.usage?.inputTokens).toBe(1000);
+      expect(h.usage?.outputTokens).toBe(100);
+      expect(h.usage?.cacheReadInputTokens).toBe(200);
+      expect(h.usage?.cacheCreationInputTokens).toBe(50);
+      expect(h.durationMs).toBe(1000);
+      expect(h.durationApiMs).toBe(500);
+      expect(h.numTurns).toBe(2);
+      expect(h.phase).toBe("process");
+    }
+    // Sum across per-file entries reproduces the batch total.
+    const sumCost = records.reduce((s, r) => s + (r.analysisHistory[0].costUsd ?? 0), 0);
+    expect(sumCost).toBeCloseTo(4.0, 6);
+  });
+
+  it("revalidate() pushes a per-file analysisHistory entry tagged phase='revalidate' with divided cost", async () => {
+    const fx = setupProject({ files: ["x.ts", "y.ts"] });
+    for (const f of ["x.ts", "y.ts"]) {
+      const r = pendingRecord(fx.projectId, f);
+      r.status = "analyzed";
+      r.findings = [
+        {
+          severity: "HIGH",
+          vulnSlug: "auth-bypass",
+          title: `bug in ${f}`,
+          description: "x",
+          lineNumbers: [1],
+          recommendation: "x",
+          confidence: "high",
+        },
+      ];
+      r.analysisHistory = [
+        {
+          runId: "earlier",
+          investigatedAt: new Date().toISOString(),
+          durationMs: 1,
+          agentType: "stub",
+          model: "stub",
+          modelConfig: {},
+          findingCount: 1,
+          phase: "process",
+        },
+      ];
+      fx.writeRecord(r);
+    }
+
+    const stub = new StubAgent({
+      async *revalidateImpl(params) {
+        return {
+          verdicts: params.batch.flatMap((rec) =>
+            rec.findings.map((f) => ({
+              filePath: rec.filePath,
+              title: f.title,
+              verdict: "true-positive" as const,
+              reasoning: "stub",
+            })),
+          ),
+          meta: {
+            durationMs: 2000,
+            costUsd: 0.5,
+            usage: {
+              inputTokens: 2000,
+              outputTokens: 200,
+              cacheReadInputTokens: 0,
+              cacheCreationInputTokens: 0,
+            },
+          },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+      batchSize: 2,
+    });
+
+    const xs = fx.readRecord("x.ts");
+    const ys = fx.readRecord("y.ts");
+
+    // Each file now has the original process entry + a new revalidate entry.
+    for (const r of [xs, ys]) {
+      expect(r.analysisHistory).toHaveLength(2);
+      const reval = r.analysisHistory.find((h) => h.phase === "revalidate");
+      expect(reval).toBeDefined();
+      expect(reval?.costUsd).toBe(0.25);
+      expect(reval?.usage?.inputTokens).toBe(1000);
+      expect(reval?.findingCount).toBe(1);
+      expect(reval?.agentType).toBe("stub");
+    }
+  });
+
+  it("process(--reinvestigate N) ignores phase='revalidate' entries when deciding what's already done", async () => {
+    // A revalidate run shouldn't satisfy a process wave: a file that
+    // only has a revalidate entry for agent X still needs a fresh
+    // process pass for agent X on wave N.
+    const fx = setupProject({ files: ["a.ts"] });
+    const rec = pendingRecord(fx.projectId, "a.ts");
+    rec.status = "analyzed";
+    rec.analysisHistory = [
+      {
+        runId: "reval-only",
+        investigatedAt: new Date().toISOString(),
+        durationMs: 1,
+        agentType: "stub",
+        model: "stub",
+        modelConfig: {},
+        findingCount: 0,
+        phase: "revalidate",
+        usage: {
+          inputTokens: 1,
+          outputTokens: 1,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: 0,
+        },
+        reinvestigateMarker: 1, // simulate a future bug stamping it
+      },
+    ];
+    fx.writeRecord(rec);
+
+    const stub = new StubAgent();
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await processProject({
+      projectId: fx.projectId,
+      agentType: "stub",
+      reinvestigate: 1,
+      concurrency: 1,
+    });
+
+    expect(result.analysisCount).toBe(1);
+    expect(stub.calls.investigateCalls).toHaveLength(1);
+  });
+
   it("revalidate() skips findings that already have a verdict unless --force", async () => {
     const fx = setupProject({ files: ["app.ts"] });
     const rec = pendingRecord(fx.projectId, "app.ts");

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -341,6 +341,12 @@ export async function process(params: {
       const alreadyDone = (r.analysisHistory ?? []).some((h) => {
         if ((h.usage?.outputTokens ?? 0) <= 0) return false;
         if (h.agentType !== agentType) return false;
+        // A revalidate entry doesn't satisfy a process wave: revalidation
+        // doesn't re-investigate, it just attaches verdicts. Even if a
+        // revalidate entry somehow carried `reinvestigateMarker` (today
+        // it doesn't), counting it here would silently skip files that
+        // still need a fresh process pass.
+        if (h.phase === "revalidate") return false;
         return h.reinvestigateMarker === reinvestigate;
       });
       return !alreadyDone;
@@ -489,6 +495,32 @@ export async function process(params: {
       totalOutputTokens += batchMeta.usage?.outputTokens ?? 0;
       totalDurationMs += batchMeta.durationMs;
 
+      // Cost / tokens / duration / turns are batch-level — one agent call
+      // covers all files in the batch. Stamping the batch total onto every
+      // file's analysisHistory entry inflates `metrics` totals by ~batch
+      // size. Divide evenly so summing per-file entries gives the correct
+      // run total. We split by the count of records that will actually
+      // get an entry (results that match a record in the batch) — silent
+      // skips don't dilute the share.
+      const validResultCount = results.reduce(
+        (n, r) => n + (batch.some((b) => b.filePath === r.filePath) ? 1 : 0),
+        0,
+      );
+      const splitN = Math.max(1, validResultCount);
+      const perFileCost = batchMeta.costUsd != null ? batchMeta.costUsd / splitN : undefined;
+      const perFileUsage = batchMeta.usage
+        ? {
+            inputTokens: batchMeta.usage.inputTokens / splitN,
+            outputTokens: batchMeta.usage.outputTokens / splitN,
+            cacheReadInputTokens: batchMeta.usage.cacheReadInputTokens / splitN,
+            cacheCreationInputTokens: batchMeta.usage.cacheCreationInputTokens / splitN,
+          }
+        : undefined;
+      const perFileDurationMs = batchMeta.durationMs / splitN;
+      const perFileDurationApiMs =
+        batchMeta.durationApiMs != null ? batchMeta.durationApiMs / splitN : undefined;
+      const perFileNumTurns = batchMeta.numTurns != null ? batchMeta.numTurns / splitN : undefined;
+
       // Update file records with results + metadata.
       //
       // Re-investigation always *merges* — existing findings are preserved
@@ -517,16 +549,17 @@ export async function process(params: {
         record.analysisHistory.push({
           runId,
           investigatedAt: new Date().toISOString(),
-          durationMs: batchMeta.durationMs,
-          durationApiMs: batchMeta.durationApiMs,
+          durationMs: perFileDurationMs,
+          durationApiMs: perFileDurationApiMs,
           agentType,
           model,
           modelConfig: config,
           agentSessionId: batchMeta.agentSessionId,
           findingCount: findingsForHistoryCount,
-          numTurns: batchMeta.numTurns,
-          costUsd: batchMeta.costUsd,
-          usage: batchMeta.usage,
+          numTurns: perFileNumTurns,
+          phase: "process",
+          costUsd: perFileCost,
+          usage: perFileUsage,
           refusal: batchMeta.refusal,
           codexStderr: batchMeta.codexStderr,
           reinvestigateMarker: typeof reinvestigate === "number" ? reinvestigate : undefined,
@@ -839,7 +872,8 @@ export async function revalidate(params: {
       }
 
       const output = result.value as RevalidateOutput;
-      totalCostUsd += output.meta.costUsd ?? 0;
+      const batchMeta = output.meta;
+      totalCostUsd += batchMeta.costUsd ?? 0;
 
       // Match verdicts to findings across all files in the batch
       for (const verdict of output.verdicts) {
@@ -865,7 +899,49 @@ export async function revalidate(params: {
         else totalUncertain++;
       }
 
+      // Push a per-file `analysisHistory` entry for this revalidate batch.
+      // Without this, revalidate cost is only ever recorded in
+      // `runMeta.stats.totalCostUsd` and is invisible to the `metrics`
+      // command (which aggregates strictly off `record.analysisHistory`).
+      // We split batch-level cost / tokens / duration / turns evenly over
+      // the files in the batch so the per-file totals add up to the
+      // batch's actual spend.
+      const splitN = Math.max(1, batch.length);
+      const perFileCost = batchMeta.costUsd != null ? batchMeta.costUsd / splitN : undefined;
+      const perFileUsage = batchMeta.usage
+        ? {
+            inputTokens: batchMeta.usage.inputTokens / splitN,
+            outputTokens: batchMeta.usage.outputTokens / splitN,
+            cacheReadInputTokens: batchMeta.usage.cacheReadInputTokens / splitN,
+            cacheCreationInputTokens: batchMeta.usage.cacheCreationInputTokens / splitN,
+          }
+        : undefined;
+      const perFileDurationMs = batchMeta.durationMs / splitN;
+      const perFileDurationApiMs =
+        batchMeta.durationApiMs != null ? batchMeta.durationApiMs / splitN : undefined;
+      const perFileNumTurns = batchMeta.numTurns != null ? batchMeta.numTurns / splitN : undefined;
+      const investigatedAt = new Date().toISOString();
+
       for (const file of batch) {
+        const verdictsForFile = output.verdicts.filter((v) => v.filePath === file.filePath).length;
+        file.analysisHistory.push({
+          runId,
+          investigatedAt,
+          durationMs: perFileDurationMs,
+          durationApiMs: perFileDurationApiMs,
+          agentType,
+          model,
+          modelConfig: config,
+          agentSessionId: batchMeta.agentSessionId,
+          findingCount: verdictsForFile,
+          numTurns: perFileNumTurns,
+          phase: "revalidate",
+          costUsd: perFileCost,
+          usage: perFileUsage,
+          refusal: batchMeta.refusal,
+          codexStderr: batchMeta.codexStderr,
+        });
+
         try {
           enrichFileRecord(file, effectiveRootPath);
         } catch (e) {


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
