### PR TITLE
Default to Codex gpt-5.5

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ by default:
 | `--agent` | SDK | Default model |
 |---|---|---|
 | `codex` (default) | `@openai/codex-sdk` | `gpt-5.5` |
-| `claude-agent-sdk` | `@anthropic-ai/claude-agent-sdk` | `claude-opus-4-7` |
+| `claude` | `@anthropic-ai/claude-agent-sdk` | `claude-opus-4-7` |
 
 Same prompt, same JSON output schema. You can mix backends within a
 project — re-process a file with a different agent and the second run's

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,8 +70,8 @@ by default:
 
 | `--agent` | SDK | Default model |
 |---|---|---|
-| `claude-agent-sdk` (default) | `@anthropic-ai/claude-agent-sdk` | `claude-opus-4-7` |
-| `codex` | `@openai/codex-sdk` | `gpt-5.5` |
+| `codex` (default) | `@openai/codex-sdk` | `gpt-5.5` |
+| `claude-agent-sdk` | `@anthropic-ai/claude-agent-sdk` | `claude-opus-4-7` |
 
 Same prompt, same JSON output schema. You can mix backends within a
 project — re-process a file with a different agent and the second run's

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@ see [`samples/webapp/deepsec.config.ts`](../samples/webapp/deepsec.config.ts).
 | `projects` | `ProjectDeclaration[]` | The codebases deepsec knows about. |
 | `plugins` | `DeepsecPlugin[]` | Loaded in order; later plugins override single-slot capabilities. |
 | `matchers` | `{ only?: string[]; exclude?: string[] }` | Filter the matcher set used by `scan`. |
-| `defaultAgent` | `string` | Default `--agent` value (`claude-agent-sdk` or `codex`). See [models.md](models.md). |
+| `defaultAgent` | `string` | Default `--agent` value (`codex`, `claude`, or `claude-agent-sdk`). See [models.md](models.md). |
 | `dataDir` | `string` | Override the `data/` directory. Defaults to `./data`. |
 
 ## ProjectDeclaration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@ see [`samples/webapp/deepsec.config.ts`](../samples/webapp/deepsec.config.ts).
 | `projects` | `ProjectDeclaration[]` | The codebases deepsec knows about. |
 | `plugins` | `DeepsecPlugin[]` | Loaded in order; later plugins override single-slot capabilities. |
 | `matchers` | `{ only?: string[]; exclude?: string[] }` | Filter the matcher set used by `scan`. |
-| `defaultAgent` | `string` | Default `--agent` value (`codex`, `claude`, or `claude-agent-sdk`). See [models.md](models.md). |
+| `defaultAgent` | `string` | Default `--agent` value (`codex` or `claude`). See [models.md](models.md). |
 | `dataDir` | `string` | Override the `data/` directory. Defaults to `./data`. |
 
 ## ProjectDeclaration

--- a/docs/models.md
+++ b/docs/models.md
@@ -4,8 +4,8 @@ deepsec talks to LLMs through two interchangeable backends:
 
 | Backend                     | Default model         | Used by                      |
 |-----------------------------|-----------------------|------------------------------|
-| `claude-agent-sdk` (default) | `claude-opus-4-7`     | `process`, `revalidate`      |
-| `codex`                     | `gpt-5.5`             | `process`, `revalidate`      |
+| `codex` (default)           | `gpt-5.5`             | `process`, `revalidate`      |
+| `claude-agent-sdk`          | `claude-opus-4-7`     | `process`, `revalidate`      |
 | `claude-agent-sdk` (triage)  | `claude-sonnet-4-6`   | `triage` (Claude-only)       |
 
 Both backends route through [Vercel AI Gateway](https://vercel.com/ai-gateway)
@@ -16,11 +16,11 @@ Anthropic or OpenAI directly, point `ANTHROPIC_BASE_URL` /
 ## CLI selection
 
 ```bash
-# Claude (default backend), default model:
+# Codex (default backend), default model:
 pnpm deepsec process --project-id my-app
 
 # Claude with a specific model:
-pnpm deepsec process --project-id my-app --model claude-sonnet-4-6
+pnpm deepsec process --project-id my-app --agent claude --model claude-sonnet-4-6
 
 # Codex backend, default model:
 pnpm deepsec process --project-id my-app --agent codex

--- a/docs/models.md
+++ b/docs/models.md
@@ -5,8 +5,8 @@ deepsec talks to LLMs through two interchangeable backends:
 | Backend                     | Default model         | Used by                      |
 |-----------------------------|-----------------------|------------------------------|
 | `codex` (default)           | `gpt-5.5`             | `process`, `revalidate`      |
-| `claude-agent-sdk`          | `claude-opus-4-7`     | `process`, `revalidate`      |
-| `claude-agent-sdk` (triage)  | `claude-sonnet-4-6`   | `triage` (Claude-only)       |
+| `claude`                    | `claude-opus-4-7`     | `process`, `revalidate`      |
+| `claude` (triage)           | `claude-sonnet-4-6`   | `triage` (Claude-only)       |
 
 Both backends route through [Vercel AI Gateway](https://vercel.com/ai-gateway)
 by default, so a single token covers Claude **and** Codex. To use

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -59,8 +59,8 @@ AI_GATEWAY_API_KEY=vck_…
 deepsec expands whichever credential it finds (the API key first, the
 OIDC token as fallback) at startup into the four vars the agent SDKs
 read (`ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`, `ANTHROPIC_BASE_URL`,
-`OPENAI_BASE_URL`), so a single credential covers both Claude
-(`--agent claude-agent-sdk`, the default) and Codex (`--agent codex`).
+`OPENAI_BASE_URL`), so a single credential covers both Codex
+(`--agent codex`, the default) and Claude (`--agent claude`).
 Any of those four vars you set explicitly takes precedence over the
 expansion — useful for mixing direct Anthropic with gateway-routed
 OpenAI, etc.

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -155,6 +155,6 @@ vars (access token).
 |---|---|
 | `401` from `process` / `revalidate` | No gateway credential loaded — set `AI_GATEWAY_API_KEY` (or `ANTHROPIC_AUTH_TOKEN`), or run `vercel env pull` to get a `VERCEL_OIDC_TOKEN`. Confirm `.env.local` is in the cwd deepsec runs from. If you're using OIDC, the token may have expired (12 h) — re-pull. |
 | Sandbox spawn fails with auth error | OIDC token expired (12 h) — re-run `vercel env pull`. Or fall back to access-token mode. |
-| `Missing AI credentials for --agent claude-agent-sdk` | Set `AI_GATEWAY_API_KEY` / `ANTHROPIC_AUTH_TOKEN` in `.env.local`, or `claude login` for non-sandbox subscription auth. |
+| `Missing AI credentials for --agent claude` | Set `AI_GATEWAY_API_KEY` / `ANTHROPIC_AUTH_TOKEN` in `.env.local`, or `claude login` for non-sandbox subscription auth. |
 | `Missing AI credentials for --agent codex` | Set `AI_GATEWAY_API_KEY` / `OPENAI_API_KEY` in `.env.local`, or `codex login` for non-sandbox subscription auth. |
 | Findings missing cost in the log | Pricing entry missing for a non-default Codex model. See [models.md](models.md#future-models-eg-anthropic-mythos). |

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -66,6 +66,7 @@ describe("assertAgentCredential", () => {
   });
 
   it("throws actionable message for claude-agent-sdk when no token and no claude CLI", () => {
+    expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(/--agent claude/);
     expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(/ANTHROPIC_AUTH_TOKEN/);
     expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(/AI_GATEWAY_API_KEY/);
     expect(() => assertAgentCredential("claude-agent-sdk")).toThrow(

--- a/packages/deepsec/src/__tests__/resolve-agent-type.test.ts
+++ b/packages/deepsec/src/__tests__/resolve-agent-type.test.ts
@@ -12,13 +12,22 @@ describe("resolveAgentType", () => {
     expect(resolveAgentType("claude-agent-sdk")).toBe("claude-agent-sdk");
   });
 
+  it("aliases claude to claude-agent-sdk", () => {
+    expect(resolveAgentType("claude")).toBe("claude-agent-sdk");
+  });
+
+  it("aliases claude from defaultAgent config", () => {
+    setLoadedConfig(defineConfig({ projects: [], defaultAgent: "claude" }));
+    expect(resolveAgentType(undefined)).toBe("claude-agent-sdk");
+  });
+
   it("falls back to defaultAgent from config when not provided", () => {
     setLoadedConfig(defineConfig({ projects: [], defaultAgent: "codex" }));
     expect(resolveAgentType(undefined)).toBe("codex");
   });
 
-  it("falls back to claude-agent-sdk when neither is set", () => {
+  it("falls back to codex when neither is set", () => {
     setLoadedConfig(defineConfig({ projects: [] }));
-    expect(resolveAgentType(undefined)).toBe("claude-agent-sdk");
+    expect(resolveAgentType(undefined)).toBe("codex");
   });
 });

--- a/packages/deepsec/src/__tests__/resolve-agent-type.test.ts
+++ b/packages/deepsec/src/__tests__/resolve-agent-type.test.ts
@@ -7,7 +7,7 @@ describe("resolveAgentType", () => {
     setLoadedConfig(defineConfig({ projects: [] }));
   });
 
-  it("returns the user-provided value when given", () => {
+  it("accepts the legacy claude-agent-sdk value", () => {
     setLoadedConfig(defineConfig({ projects: [], defaultAgent: "codex" }));
     expect(resolveAgentType("claude-agent-sdk")).toBe("claude-agent-sdk");
   });

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -132,7 +132,7 @@ program
   .option("--run-id <id>", "Resume a specific processing run")
   .option(
     "--agent <type>",
-    "Agent plugin type: claude-agent-sdk or codex (default: defaultAgent in deepsec.config.ts, else claude-agent-sdk)",
+    "Agent plugin type: codex, claude, or claude-agent-sdk (default: defaultAgent in deepsec.config.ts, else codex)",
   )
   .option(
     "--model <model>",
@@ -192,7 +192,7 @@ program
   .option("--run-id <id>", "Resume a specific revalidation run")
   .option(
     "--agent <type>",
-    "Agent plugin type: claude-agent-sdk or codex (default: defaultAgent in deepsec.config.ts, else claude-agent-sdk)",
+    "Agent plugin type: codex, claude, or claude-agent-sdk (default: defaultAgent in deepsec.config.ts, else codex)",
   )
   .option(
     "--model <model>",

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -132,11 +132,11 @@ program
   .option("--run-id <id>", "Resume a specific processing run")
   .option(
     "--agent <type>",
-    "Agent plugin type: codex, claude, or claude-agent-sdk (default: defaultAgent in deepsec.config.ts, else codex)",
+    "Agent plugin type: codex or claude (default: defaultAgent in deepsec.config.ts, else codex)",
   )
   .option(
     "--model <model>",
-    "Model to use (default: claude-opus-4-7 for claude-agent-sdk, gpt-5.5 for codex)",
+    "Model to use (default: claude-opus-4-7 for claude, gpt-5.5 for codex)",
   )
   .option("--max-turns <n>", "Max conversation turns per batch (default: 150)", parseInt)
   .option(
@@ -192,11 +192,11 @@ program
   .option("--run-id <id>", "Resume a specific revalidation run")
   .option(
     "--agent <type>",
-    "Agent plugin type: codex, claude, or claude-agent-sdk (default: defaultAgent in deepsec.config.ts, else codex)",
+    "Agent plugin type: codex or claude (default: defaultAgent in deepsec.config.ts, else codex)",
   )
   .option(
     "--model <model>",
-    "Model to use (default: claude-opus-4-7 for claude-agent-sdk, gpt-5.5 for codex)",
+    "Model to use (default: claude-opus-4-7 for claude, gpt-5.5 for codex)",
   )
   .option("--max-turns <n>", "Max conversation turns per batch (default: 150)", parseInt)
   .option(
@@ -278,7 +278,7 @@ program
   .option("--require-owner", "Drop findings that have no ownership data (no assignee, no teams)")
   .option(
     "--only-agent <type>",
-    "Only export findings produced by this agent backend (e.g. codex, claude-agent-sdk)",
+    "Only export findings produced by this agent backend (e.g. codex, claude)",
   )
   .option(
     "--only-marker <n>",

--- a/packages/deepsec/src/commands/export.ts
+++ b/packages/deepsec/src/commands/export.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { FileRecord, Finding, Severity } from "@deepsec/core";
 import { dataDir, getDataRoot, loadAllFileRecords } from "@deepsec/core";
 import { BOLD, DIM, GREEN, RESET, YELLOW } from "../formatters.js";
+import { resolveAgentType } from "../resolve-agent-type.js";
 
 const SEVERITY_ORDER: Record<Severity, number> = {
   CRITICAL: 0,
@@ -347,6 +348,7 @@ export async function exportCommand(opts: {
   if (onlyMarker !== undefined && !Number.isFinite(onlyMarker)) {
     throw new Error(`--only-marker must be a number, got "${opts.onlyMarker}"`);
   }
+  const onlyAgent = opts.onlyAgent ? resolveAgentType(opts.onlyAgent) : undefined;
   if (opts.onlyAgent) console.log(`  Only agent: ${opts.onlyAgent}`);
   if (onlyMarker !== undefined) console.log(`  Only marker: ${onlyMarker}`);
 
@@ -396,7 +398,7 @@ export async function exportCommand(opts: {
           continue;
 
         const source = findingSource[findingIndex];
-        if (opts.onlyAgent && source?.agentType !== opts.onlyAgent) continue;
+        if (onlyAgent && source?.agentType !== onlyAgent) continue;
         if (onlyMarker !== undefined && source?.reinvestigateMarker !== onlyMarker) continue;
 
         const githubUrl = makeGithubLink(repoUrl, record.filePath, finding.lineNumbers);

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -179,8 +179,10 @@ export function assertAgentCredential(
 
   if (anthropic) return;
   if (!options.inSandbox && hasLocalClaudeAgent()) return;
+  const displayAgent =
+    agentType === "claude-agent-sdk" || agentType === undefined ? "claude" : agentType;
   throw new Error(
-    `Missing AI credentials for --agent ${agentType ?? "claude-agent-sdk"}.\n` +
+    `Missing AI credentials for --agent ${displayAgent}.\n` +
       `\n` +
       `  Add to .env.local:    AI_GATEWAY_API_KEY=vck_…   (or ANTHROPIC_AUTH_TOKEN=…)\n` +
       `  Setup: ${SETUP_DOC_URL}`,

--- a/packages/deepsec/src/resolve-agent-type.ts
+++ b/packages/deepsec/src/resolve-agent-type.ts
@@ -6,8 +6,9 @@ import { getConfig } from "@deepsec/core";
  * Precedence:
  *   1. The `--agent` value the user passed (always wins).
  *   2. `defaultAgent` from deepsec.config.ts.
- *   3. `claude-agent-sdk`.
+ *   3. `codex`.
  */
 export function resolveAgentType(provided: string | undefined): string {
-  return provided ?? getConfig()?.defaultAgent ?? "claude-agent-sdk";
+  const resolved = provided ?? getConfig()?.defaultAgent ?? "codex";
+  return resolved === "claude" ? "claude-agent-sdk" : resolved;
 }


### PR DESCRIPTION
## What changed

Default 5.5 for Deepsec 
Alias `--agent claude` to `--agent claude-agent-sdk` 

## Why

codex 5.5 is a better model from personal experience to discovering existing codebases.
also adding claude

## Verification

- [x] `pnpm test` passes
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
