### PR TITLE
Don't write a .env.local sample during init

### DIFF
--- a/.github/workflows/deepsec.yml
+++ b/.github/workflows/deepsec.yml
@@ -16,6 +16,7 @@ jobs:
     # filter — without it, fork PRs would run, fail on the missing
     # credential, and post a red ❌ on every external contribution.
     if: github.event.pull_request.head.repo.full_name == github.repository
+    environment: deepsec-run
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/e2e/bundle.test.ts
+++ b/e2e/bundle.test.ts
@@ -176,7 +176,6 @@ export default defineConfig({
         "deepsec.config.ts",
         "README.md",
         "AGENTS.md",
-        ".env.local",
         ".gitignore",
         "data/my-app/INFO.md",
         "data/my-app/SETUP.md",
@@ -184,6 +183,7 @@ export default defineConfig({
       ]) {
         expect(fs.existsSync(path.join(workspace, f)), `missing ${f}`).toBe(true);
       }
+      expect(fs.existsSync(path.join(workspace, ".env.local"))).toBe(false);
       // No top-level INFO.md / SETUP.md — both live under data/<id>/.
       expect(fs.existsSync(path.join(workspace, "INFO.md"))).toBe(false);
       expect(fs.existsSync(path.join(workspace, "SETUP.md"))).toBe(false);

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/src/commands/init.ts
+++ b/packages/deepsec/src/commands/init.ts
@@ -56,7 +56,6 @@ export function initCommand(opts: InitOpts) {
   writeFile(workspaceDir, "pnpm-workspace.yaml", pnpmWorkspaceYaml());
   writeFile(workspaceDir, "deepsec.config.ts", emptyConfigTs());
   writeFile(workspaceDir, "AGENTS.md", workspaceAgentsMd());
-  writeFile(workspaceDir, ".env.local", envLocal());
   writeFile(workspaceDir, ".gitignore", gitignore());
 
   // Register the first project via the shared code path. Same writes
@@ -318,16 +317,6 @@ asked to set a project up.
 The deepsec skill is at \`node_modules/deepsec/SKILL.md\` (after
 \`pnpm install\`). The full docs ship at
 \`node_modules/deepsec/dist/docs/\`.
-`;
-}
-
-function envLocal(): string {
-  // One-line gateway setup. deepsec expands AI_GATEWAY_API_KEY at startup
-  // into ANTHROPIC_AUTH_TOKEN / OPENAI_API_KEY / *_BASE_URL, so a user
-  // who only has a gateway key is fully wired with this single line.
-  // Users with claude/codex CLI logged in locally can leave this empty
-  // for non-sandbox runs — deepsec auto-detects.
-  return `AI_GATEWAY_API_KEY=
 `;
 }
 


### PR DESCRIPTION
This breaks using subscriptions by default and break vc env pull