### PR TITLE
Turn on provenance now that the repo is public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,17 @@ jobs:
       # npm exchanges the GitHub OIDC token for a publish credential at
       # publish time. No NPM_TOKEN / NODE_AUTH_TOKEN secret is consulted.
       #
-      # Note: --provenance is intentionally OFF. npm rejects provenance
-      # uploads from repos whose GitHub visibility is "internal" or "private"
-      # (E422 "Unsupported GitHub Actions source repository visibility").
-      # Add --provenance once the repo is flipped to "public".
+      # `--provenance` attaches a signed attestation linking the published
+      # tarball to this exact workflow run + commit SHA. Requires:
+      #   - the GitHub repo to be PUBLIC (npm 422s on private/internal repos),
+      #   - `id-token: write` on this job (set above),
+      #   - npm CLI ≥ 9.5 (the `npm install -g npm@latest` step above ensures
+      #     a recent enough release).
+      # The attestation is published to npm's transparency log and shows up
+      # on the package's npmjs.com page as a "Provenance" badge. We chose
+      # the CLI flag over `publishConfig.provenance` so an accidental
+      # laptop-side `npm publish` doesn't try to emit provenance without
+      # an OIDC token.
       - if: steps.ver.outputs.publish == 'true'
         working-directory: packages/deepsec
-        run: npm publish --access public
+        run: npm publish --access public --provenance

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
