### PR TITLE
feat: Add agent skills folder for npx skills ecosystem

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -10,7 +10,7 @@ npx skills add vercel-labs/deepsec
 Or pin a single skill:
 
 ```bash
-npx skills add vercel-labs/deepsec --skill writing-deepsec-matchers
+npx skills add vercel-labs/deepsec --skill deepsec-writing-matchers
 ```
 
 ## What's in here

--- a/skills/README.md
+++ b/skills/README.md
@@ -19,8 +19,8 @@ npx skills add vercel-labs/deepsec --skill writing-deepsec-matchers
 |---|---|
 | [`deepsec`](deepsec/SKILL.md) | Umbrella — any deepsec question. Routes to the focused skills below. |
 | [`deepsec-getting-started`](deepsec-getting-started/SKILL.md) | First scan, install, INFO.md, calibration pass. |
-| [`writing-deepsec-matchers`](writing-deepsec-matchers/SKILL.md) | Add a regex matcher to catch entry-points or org-specific shapes the built-ins miss. |
-| [`writing-deepsec-plugins`](writing-deepsec-plugins/SKILL.md) | Author a plugin (matchers, notifiers, ownership, people, executor). |
+| [`deepsec-writing-matchers`](deepsec-writing-matchers/SKILL.md) | Add a regex matcher to catch entry-points or org-specific shapes the built-ins miss. |
+| [`deepsec-writing-plugins`](deepsec-writing-plugins/SKILL.md) | Author a plugin (matchers, notifiers, ownership, people, executor). |
 | [`deepsec-pr-review`](deepsec-pr-review/SKILL.md) | `process --diff` for CI gating + a hardened GitHub Actions workflow. |
 | [`deepsec-configuration`](deepsec-configuration/SKILL.md) | `deepsec.config.ts` and `data/<id>/config.json` reference. |
 | [`deepsec-models`](deepsec-models/SKILL.md) | Pick agent (Claude/Codex), model, handle refusals, drop in future models. |

--- a/skills/README.md
+++ b/skills/README.md
@@ -15,18 +15,18 @@ npx skills add vercel-labs/deepsec --skill deepsec-writing-matchers
 
 ## What's in here
 
-| Skill | When it activates |
-|---|---|
-| [`deepsec`](deepsec/SKILL.md) | Umbrella — any deepsec question. Routes to the focused skills below. |
-| [`deepsec-getting-started`](deepsec-getting-started/SKILL.md) | First scan, install, INFO.md, calibration pass. |
-| [`deepsec-writing-matchers`](deepsec-writing-matchers/SKILL.md) | Add a regex matcher to catch entry-points or org-specific shapes the built-ins miss. |
-| [`deepsec-writing-plugins`](deepsec-writing-plugins/SKILL.md) | Author a plugin (matchers, notifiers, ownership, people, executor). |
-| [`deepsec-pr-review`](deepsec-pr-review/SKILL.md) | `process --diff` for CI gating + a hardened GitHub Actions workflow. |
-| [`deepsec-configuration`](deepsec-configuration/SKILL.md) | `deepsec.config.ts` and `data/<id>/config.json` reference. |
-| [`deepsec-models`](deepsec-models/SKILL.md) | Pick agent (Claude/Codex), model, handle refusals, drop in future models. |
-| [`deepsec-sandbox-setup`](deepsec-sandbox-setup/SKILL.md) | AI Gateway + Vercel Sandbox auth, BYOK, quota recovery, troubleshooting. |
-| [`deepsec-data-layout`](deepsec-data-layout/SKILL.md) | `data/<id>/` schema — FileRecord, RunMeta, Finding, AnalysisEntry. jq recipes. |
-| [`deepsec-architecture`](deepsec-architecture/SKILL.md) | Pipeline internals, append-only model, sandbox credential brokering, design decisions. |
+| Skill                                                           | When it activates                                                                      |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`deepsec`](deepsec/SKILL.md)                                   | Umbrella — any deepsec question. Routes to the focused skills below.                   |
+| [`deepsec-getting-started`](deepsec-getting-started/SKILL.md)   | First scan, install, INFO.md, calibration pass.                                        |
+| [`deepsec-writing-matchers`](deepsec-writing-matchers/SKILL.md) | Add a regex matcher to catch entry-points or org-specific shapes the built-ins miss.   |
+| [`deepsec-writing-plugins`](deepsec-writing-plugins/SKILL.md)   | Author a plugin (matchers, notifiers, ownership, people, executor).                    |
+| [`deepsec-pr-review`](deepsec-pr-review/SKILL.md)               | `process --diff` for CI gating + a hardened GitHub Actions workflow.                   |
+| [`deepsec-configuration`](deepsec-configuration/SKILL.md)       | `deepsec.config.ts` and `data/<id>/config.json` reference.                             |
+| [`deepsec-models`](deepsec-models/SKILL.md)                     | Pick agent (Claude/Codex), model, handle refusals, drop in future models.              |
+| [`deepsec-sandbox-setup`](deepsec-sandbox-setup/SKILL.md)       | AI Gateway + Vercel Sandbox auth, BYOK, quota recovery, troubleshooting.               |
+| [`deepsec-data-layout`](deepsec-data-layout/SKILL.md)           | `data/<id>/` schema — FileRecord, RunMeta, Finding, AnalysisEntry. jq recipes.         |
+| [`deepsec-architecture`](deepsec-architecture/SKILL.md)         | Pipeline internals, append-only model, sandbox credential brokering, design decisions. |
 
 ## How these are scoped
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,67 @@
+# deepsec skills
+
+Agent skills for [deepsec](https://github.com/vercel-labs/deepsec), the
+AI-powered vulnerability scanner. Install with [`npx skills`](https://skills.sh):
+
+```bash
+npx skills add vercel-labs/deepsec
+```
+
+Or pin a single skill:
+
+```bash
+npx skills add vercel-labs/deepsec --skill writing-deepsec-matchers
+```
+
+## What's in here
+
+| Skill | When it activates |
+|---|---|
+| [`deepsec`](deepsec/SKILL.md) | Umbrella — any deepsec question. Routes to the focused skills below. |
+| [`deepsec-getting-started`](deepsec-getting-started/SKILL.md) | First scan, install, INFO.md, calibration pass. |
+| [`writing-deepsec-matchers`](writing-deepsec-matchers/SKILL.md) | Add a regex matcher to catch entry-points or org-specific shapes the built-ins miss. |
+| [`writing-deepsec-plugins`](writing-deepsec-plugins/SKILL.md) | Author a plugin (matchers, notifiers, ownership, people, executor). |
+| [`deepsec-pr-review`](deepsec-pr-review/SKILL.md) | `process --diff` for CI gating + a hardened GitHub Actions workflow. |
+| [`deepsec-configuration`](deepsec-configuration/SKILL.md) | `deepsec.config.ts` and `data/<id>/config.json` reference. |
+| [`deepsec-models`](deepsec-models/SKILL.md) | Pick agent (Claude/Codex), model, handle refusals, drop in future models. |
+| [`deepsec-sandbox-setup`](deepsec-sandbox-setup/SKILL.md) | AI Gateway + Vercel Sandbox auth, BYOK, quota recovery, troubleshooting. |
+| [`deepsec-data-layout`](deepsec-data-layout/SKILL.md) | `data/<id>/` schema — FileRecord, RunMeta, Finding, AnalysisEntry. jq recipes. |
+| [`deepsec-architecture`](deepsec-architecture/SKILL.md) | Pipeline internals, append-only model, sandbox credential brokering, design decisions. |
+
+## How these are scoped
+
+Each skill is **self-contained** — it copies the relevant doc text
+inline, so `npx skills add` works without the user having the deepsec
+repo or package on disk. The umbrella `deepsec` skill is the front
+door; it tells the agent which focused sibling to open for any given
+question.
+
+The skills follow the [Agent Skills Specification](https://skills.sh) —
+YAML frontmatter with `name` and `description`, then markdown
+instructions. Compatible with Claude Code, OpenCode, Cursor, Codex,
+and the other agents [`npx skills`](https://skills.sh) supports.
+
+## Authoring style
+
+- **Hard rules** at the bottom of each SKILL.md — the few mistakes
+  agents have to actively avoid (e.g. "always run `--limit 50` first";
+  "never give `pull-requests: write` to the job that runs PR code").
+- **Decision tables** wherever an agent is choosing between options.
+- **Real, copy-pasteable code** for matchers, configs, and the
+  GitHub Actions workflow — not pseudocode.
+- **No external doc links for the core content** — everything an
+  agent needs is in the SKILL.md itself. External links go to
+  upstream provider docs (Vercel AI Gateway, Anthropic Console, etc.)
+  where credentials are obtained.
+
+## Updating these skills
+
+When the upstream `docs/` or `packages/deepsec/SKILL.md` changes,
+update the corresponding skill here. The skills are intentionally
+copies, not pointers — they need to work standalone after `npx skills
+add`.
+
+## License
+
+Apache 2.0 (matches the parent deepsec repo). See [LICENSE](../LICENSE)
+and [NOTICE](../NOTICE).

--- a/skills/deepsec-architecture/SKILL.md
+++ b/skills/deepsec-architecture/SKILL.md
@@ -143,7 +143,7 @@ The CLI calls `loadConfig()` before parsing args, builds a
 module-level singleton (`getRegistry()`). All internal code consults
 the registry rather than hard-coding integrations.
 
-See the `writing-deepsec-plugins` skill for authoring details.
+See the `deepsec-writing-plugins` skill for authoring details.
 
 ## Distributed execution (Vercel Sandbox)
 

--- a/skills/deepsec-architecture/SKILL.md
+++ b/skills/deepsec-architecture/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: deepsec-architecture
+description: How deepsec is built — the scan/process/revalidate/enrich pipeline, append-only on-disk model, plugin extension points, sandbox credential brokering, and core design decisions. Activates when the user asks how deepsec works internally, what a stage actually does, or why a design choice was made.
+---
+
+# deepsec architecture
+
+## Pipeline
+
+```
+       scan          process        revalidate          enrich           export
+        │              │                │                │                  │
+        ▼              ▼                ▼                ▼                  ▼
+  candidates  →   findings    TP/FP/Fixed verdict  →  +committers  →  JSON / md-dir
+                                                       +ownership
+```
+
+Each stage is a separate CLI subcommand and reads/writes a consistent
+on-disk representation. **Stages are idempotent** — re-running merges
+new information rather than overwriting.
+
+## On-disk layout
+
+```
+data/<projectId>/
+├── project.json              # rootPath, githubUrl (auto-managed)
+├── INFO.md                   # repo context injected into AI prompts
+├── config.json               # priorityPaths, promptAppend, ignorePaths (optional)
+├── files/                    # one JSON per scanned file (FileRecord)
+│   └── path/to/file.ts.json
+├── runs/                     # one JSON per run (RunMeta)
+│   └── 20260429-abcd.json
+└── reports/                  # generated reports
+```
+
+Each `FileRecord` is the source of truth for everything deepsec knows
+about a single source file: candidate matches, AI findings, analysis
+history, git committer info, ownership.
+
+The **merge model is additive**: every stage adds to the FileRecord. A
+re-scan merges new candidates into the existing set; a re-process
+appends to `analysisHistory` and merges new findings; revalidation tags
+existing findings with verdicts. Nothing is overwritten or deleted.
+
+For full schemas, see the `deepsec-data-layout` skill.
+
+## Stage details
+
+### scan
+
+- **What it does:** Glob the project root, run regex matchers on every
+  matched file, write `candidates` to each FileRecord.
+- **Cost:** Free (no AI). ~15s for 2k files.
+- **Inputs:** Project root, matcher set (built-ins + plugin contributions).
+- **Outputs:** `data/<id>/files/**/*.json` with `candidates` populated and
+  `status: "pending"`.
+
+The matcher set is built per-run from the default registry plus any
+matchers contributed by active plugins. **Plugin matchers can override
+built-ins** by reusing the same slug.
+
+### process
+
+- **What it does:** Pick batches of pending files, send each batch to the
+  configured AI agent backend with the system prompt + INFO.md, parse
+  the agent's JSON response into `Finding`s, write back to each
+  FileRecord.
+- **Cost:** $$. The expensive stage.
+- **Inputs:** FileRecords with `status: "pending"`, `INFO.md`, the prompt
+  template (`packages/processor/src/index.ts:DEFAULT_PROMPT_TEMPLATE`).
+- **Outputs:** FileRecord `findings[]` populated, `status: "analyzed"`,
+  `analysisHistory[]` appended.
+
+Two agent backends, both routed through Vercel AI Gateway by default:
+
+| `--agent` | SDK | Default model |
+|---|---|---|
+| `codex` (default) | `@openai/codex-sdk` | `gpt-5.5` |
+| `claude` | `@anthropic-ai/claude-agent-sdk` | `claude-opus-4-7` |
+
+Same prompt, same JSON output schema. You can mix backends within a
+project — re-process a file with a different agent and the second
+run's findings get merged with the first.
+
+**Concurrency:** `--concurrency 5 --batch-size 5` means 5 batches in
+flight, 5 files per batch = 25 files in the air at peak. The processor
+claims files atomically via `lockedByRunId` so multiple workers can
+run in parallel without stepping on each other.
+
+### revalidate
+
+- **What it does:** Re-check existing findings for false positives. The
+  agent re-reads the code, consults git history (was this fixed?), and
+  emits a verdict: `true-positive`, `false-positive`, `fixed`, or
+  `uncertain`.
+- **Cost:** $$. Comparable to `process`. Worth running on HIGH+.
+- **Inputs:** Findings with no `revalidation` field, or with `--force`.
+- **Outputs:** `revalidation: { verdict, reasoning, … }` on each finding.
+
+Empirically reduces FP rate by 50%+ on most repos.
+
+### enrich
+
+- **What it does:** Attach git committer info and (with a plugin)
+  ownership data to FileRecords with findings.
+- **Cost:** Free if no ownership plugin; otherwise one HTTP round-trip
+  per file to the ownership provider.
+- **Inputs:** FileRecords with findings, the project's git history.
+- **Outputs:** `gitInfo: { recentCommitters, ownership }` on each record.
+
+### export / report / metrics
+
+Read-only stages. Don't modify FileRecords; just shape the data for
+human or downstream consumption.
+
+- **export** — flat list of findings as JSON or directory of markdown.
+- **report** — per-project markdown summary + JSON.
+- **metrics** — cross-project counts and TP rates.
+
+## Plugin architecture
+
+Five extension points, all defined in `packages/core/src/plugin.ts`:
+
+| Slot | Behavior |
+|---|---|
+| `matchers` | additive |
+| `notifiers` | additive |
+| `agents` | additive |
+| `ownership` | single-slot (last plugin wins) |
+| `people` | single-slot |
+| `executor` | single-slot |
+
+A plugin registers via `deepsec.config.ts`:
+
+```ts
+export default defineConfig({
+  plugins: [vercel(), myPlugin()],
+});
+```
+
+The CLI calls `loadConfig()` before parsing args, builds a
+`PluginRegistry` from the active plugins, and stashes it on a
+module-level singleton (`getRegistry()`). All internal code consults
+the registry rather than hard-coding integrations.
+
+See the `writing-deepsec-plugins` skill for authoring details.
+
+## Distributed execution (Vercel Sandbox)
+
+`pnpm deepsec sandbox process --sandboxes N` distributes work across N
+Vercel Sandbox microVMs:
+
+1. **Tarball bundling** — three tarballs (app, target source, data)
+   prepared in parallel, respecting `.gitignore` via `git ls-files`.
+   Streamed to disk with SHA256 checksums to bound memory.
+2. **File partitioning** — partitioner loads all project file records,
+   filters eligibility by command (process: pending/error files;
+   revalidate: findings ≥ `--min-severity`), sorts by priority paths
+   and severity, splits into N disjoint partitions balanced by record
+   count.
+3. **Bootstrap & spawn** — for each sandbox: extract tarballs, install
+   deps, mark setup complete, spawn the deepsec CLI with `--manifest
+   <path>` pointing at the partition's file list.
+4. **Result download** — tar files modified in `data/<projectId>/`
+   newer than the setup marker; extract with strict path allowlist;
+   merge sandbox writes onto local records.
+
+### Credential brokering
+
+Real API tokens never enter the sandbox. Instead:
+
+- Sandbox env sees a placeholder `BROKERED_TOKEN_PLACEHOLDER`.
+- The Vercel firewall network policy injects a `Deepsec-Credentials`
+  header with the real tokens.
+- An in-sandbox `request-proxy.mjs` strips the placeholder and injects
+  the real token on every upstream request.
+- The proxy also strips `eager_input_streaming` from Anthropic tool
+  schemas for Bedrock compatibility.
+
+This keeps secrets out of `/proc/<pid>/environ` on a compromised
+worker.
+
+## Design decisions
+
+1. **One file = one FileRecord.** The unit of work is a source file,
+   not a finding. Scanner, processor, and revalidator all operate on
+   files, so atomic per-file locking and idempotent merges fall out
+   naturally.
+
+2. **Append-only analysis history.** Re-running the processor doesn't
+   overwrite past findings. It appends a new entry to `analysisHistory`
+   and merges new findings (deduped by slug + normalized title) into
+   `findings`. You can re-run with a different agent, prompt, or model
+   and get a strict improvement instead of a destructive replacement.
+
+3. **Plugin-mediated integrations.** Matchers, notifiers, ownership
+   sources, and the remote executor all sit behind plugin contracts.
+   The open-source release ships with a generic core; org-specific
+   matchers, notifiers, ownership oracles, and people directories slot
+   in as external plugins.
+
+4. **Per-batch prompt assembly.** A polyglot repo (Next.js + Django)
+   splits into language-specific batches. A Python-only batch doesn't
+   get Next.js highlights — keeps the per-batch prompt small and
+   focused. Modular prompt: core (severity defs, FP guidance) +
+   per-framework highlights + per-slug notes + INFO.md +
+   `promptAppend`.
+
+5. **Atomic locking with stale-lock reclaim.** `lockedByRunId` claims
+   a file. If the owning run is done/error/missing or the lock is >1h
+   old, another run can reclaim it. Survives crashes without
+   clobbering concurrent runs.
+
+6. **Quota-aware graceful resume.** Provider-specific prose is matched
+   to classify quota exhaustion (Claude: "credit balance too low";
+   Codex: "you've hit your usage limit"; Gateway: "insufficient_funds";
+   etc.). Throws a typed exception that aborts new batches, cancels
+   in-flight ones, finalizes finished work, and surfaces a remediation
+   message. Re-running the same command resumes where it stopped.
+
+7. **Refusal tracking.** A post-investigation follow-up turn asks the
+   agent to self-report declined content. Baked into `analysisHistory`
+   for auditing. No silent skips.
+
+## Where the code lives
+
+| Package | Responsibility |
+|---|---|
+| `packages/core` | Types, schemas, plugin contracts, config loader (`defineConfig`) |
+| `packages/scanner` | Regex matchers + scanning engine + tech detection |
+| `packages/processor` | AI agent integration (Claude, Codex), batching, triage, revalidate, prompt assembly |
+| `packages/deepsec` | Publishable npm package: bundled CLI + `deepsec/config` sub-export + Vercel Sandbox executor |
+| `e2e/` | End-to-end tests against a fixture project |
+
+For deeper code-level context, the live source under `packages/` is
+the source of truth — these schemas and prompts change per release.

--- a/skills/deepsec-configuration/SKILL.md
+++ b/skills/deepsec-configuration/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: deepsec-configuration
+description: Reference for deepsec.config.ts and per-project config.json — projects, plugins, matcher filtering, INFO.md, environment variables. Activates when the user asks what fields a deepsec config takes or how to wire up multiple projects/plugins.
+---
+
+# deepsec configuration reference
+
+deepsec reads `deepsec.config.{ts,mjs,js,cjs}` from the current working
+directory, walking up. The CLI inherits whatever the file declares.
+
+```ts
+import { defineConfig } from "deepsec/config";
+import myPlugin from "@my-org/deepsec-plugin-foo";
+
+export default defineConfig({
+  projects: [
+    { id: "my-app",  root: "../my-app" },
+    { id: "service", root: "../service", githubUrl: "https://github.com/me/service/blob/main" },
+  ],
+  plugins: [myPlugin()],
+});
+```
+
+## Top-level fields
+
+| Field | Type | Purpose |
+|---|---|---|
+| `projects` | `ProjectDeclaration[]` | The codebases deepsec knows about. |
+| `plugins` | `DeepsecPlugin[]` | Loaded in order; later plugins override single-slot capabilities. |
+| `matchers` | `{ only?: string[]; exclude?: string[] }` | Filter the matcher set used by `scan`. |
+| `defaultAgent` | `string` | Default `--agent` value (`codex` or `claude`). |
+| `dataDir` | `string` | Override the `data/` directory. Defaults to `./data`. |
+
+## ProjectDeclaration
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `id` | `string` | yes | Used as `--project-id` and the data directory name (`data/<id>/`). |
+| `root` | `string` | yes | Absolute or relative path to the codebase. |
+| `githubUrl` | `string` | no | `https://github.com/owner/repo/blob/branch` — used in exports for clickable links. Auto-detected from `git remote` when omitted. |
+| `infoMarkdown` | `string` | no | Repo context injected into AI prompts. Overrides `data/<id>/INFO.md` if both are present. |
+| `promptAppend` | `string` | no | Free-form text appended to the system prompt for this project. |
+| `priorityPaths` | `string[]` | no | Path prefixes to process first. |
+
+## A worked example
+
+```ts
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { type DeepsecPlugin, defineConfig } from "deepsec/config";
+import { webappDebugFlag } from "./matchers/webapp-debug-flag.js";
+import { webappRouteNoRateLimit } from "./matchers/webapp-route-no-rate-limit.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const webappPlugin: DeepsecPlugin = {
+  name: "webapp-internal",
+  matchers: [webappDebugFlag, webappRouteNoRateLimit],
+};
+
+export default defineConfig({
+  projects: [
+    {
+      id: "webapp",
+      root: "./your-app",
+      githubUrl: "https://github.com/acme/webapp/blob/main",
+      infoMarkdown: fs.readFileSync(path.join(here, "INFO.md"), "utf-8"),
+      promptAppend: "Pay extra attention to /api/admin/* and /api/billing/* surfaces.",
+      priorityPaths: ["src/api/admin/", "src/api/billing/", "src/lib/auth/"],
+    },
+  ],
+  plugins: [webappPlugin],
+});
+```
+
+## INFO.md
+
+If `infoMarkdown` isn't set in config, deepsec looks for
+`data/<id>/INFO.md` and injects its contents into the prompt for
+`process`, `triage`, and `revalidate`.
+
+A few hundred words of repo context (what the codebase does, the auth
+shape, the threat model, known false-positive sources) is the right
+length. INFO.md is **load-bearing for AI precision** — a generic
+template-content INFO.md noticeably hurts findings quality.
+
+The `deepsec init` command prints an agent prompt that walks a coding
+agent through writing INFO.md from your codebase. See the
+`deepsec-getting-started` skill.
+
+## Matcher filtering
+
+```ts
+matchers: {
+  only: ["sql-injection", "auth-bypass"],   // run *only* these
+  exclude: ["framework-internal-header"],    // skip these
+}
+```
+
+If `only` is set, `exclude` is ignored. CLI flag `--matchers <slugs>`
+overrides the config when both are present.
+
+## Plugin order
+
+Plugins are evaluated in array order:
+
+```ts
+plugins: [genericPlugin(), orgPlugin()]
+```
+
+- **`matchers`, `notifiers`, `agents`** — additive. Both plugins'
+  contributions register.
+- **`ownership`, `people`, `executor`** — last-write-wins.
+  `orgPlugin()`'s provider replaces `genericPlugin()`'s.
+
+See the `writing-deepsec-plugins` skill for the full plugin contract.
+
+## Per-project config files
+
+Some legacy fields still live in `data/<id>/config.json`:
+
+```json
+{
+  "priorityPaths": ["app/api/", "lib/"],
+  "promptAppend": "Pay extra attention to the booking flow.",
+  "ignorePaths": ["**/legacy/**"]
+}
+```
+
+Read by `scan` and the AI agents. **Overrides the same fields on the
+project declaration if both are present.**
+
+## Conditional plugin loading
+
+The config file is real TypeScript — any module-load logic works:
+
+```ts
+const projectId = process.argv[process.argv.indexOf("--project-id") + 1];
+const isInternal = projectId?.startsWith("internal-") ?? false;
+
+export default defineConfig({
+  projects: [
+    { id: "internal-api",   root: "../api" },
+    { id: "open-source-app", root: "../app" },
+  ],
+  plugins: isInternal ? [orgPlugin()] : [],
+});
+```
+
+## Environment variables
+
+Loaded automatically from `.env.local` (in the workspace root) or from
+the process environment.
+
+### Required
+
+You need either the one-line shortcut **or** an explicit token for the
+backend you're using.
+
+| Var | Used by | Purpose |
+|---|---|---|
+| `AI_GATEWAY_API_KEY` | all AI commands | Shortcut. Expands at startup into `ANTHROPIC_AUTH_TOKEN` / `OPENAI_API_KEY` / `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL`. One key covers Claude and Codex. Falls back to `VERCEL_OIDC_TOKEN` (from `vercel env pull`) when unset. |
+| `ANTHROPIC_AUTH_TOKEN` | `process`, `revalidate`, `triage` (Claude) | API token for the Claude Agent SDK. AI Gateway-issued or Anthropic-issued. |
+| `ANTHROPIC_BASE_URL` | same | Default (gateway): `https://ai-gateway.vercel.sh`. Set to `https://api.anthropic.com` for direct. |
+
+### Optional
+
+| Var | Used by | Purpose |
+|---|---|---|
+| `OPENAI_API_KEY` | `--agent codex` | Codex SDK token. |
+| `OPENAI_BASE_URL` | `--agent codex` | Default (gateway): `https://ai-gateway.vercel.sh/v1`. |
+| `DEEPSEC_AGENT_DEBUG` | both backends | Set to `1` for verbose agent logging. |
+| `DEEPSEC_DATA_ROOT` | core | Override the data directory location. Equivalent to `dataDir` in config. |
+
+Explicit values always win over the `AI_GATEWAY_API_KEY` expansion —
+useful for mixing direct Anthropic with gateway-routed OpenAI.
+
+For credential setup, see the `deepsec-sandbox-setup` skill.
+
+## Hard rules
+
+- **Don't put org-specific code in `deepsec.config.ts`.** If it has
+  the literal name of an internal helper or service, factor it into a
+  plugin instead. See `writing-deepsec-plugins`.
+- **Don't override the data directory** with `dataDir` unless you're
+  doing something unusual — the relative-path default makes
+  multi-machine sync simpler.
+- **Per-project `config.json` overrides config-file fields.** When
+  both are set, the JSON wins. Don't fight it; pick one location.

--- a/skills/deepsec-configuration/SKILL.md
+++ b/skills/deepsec-configuration/SKILL.md
@@ -114,7 +114,7 @@ plugins: [genericPlugin(), orgPlugin()]
 - **`ownership`, `people`, `executor`** — last-write-wins.
   `orgPlugin()`'s provider replaces `genericPlugin()`'s.
 
-See the `writing-deepsec-plugins` skill for the full plugin contract.
+See the `deepsec-writing-plugins` skill for the full plugin contract.
 
 ## Per-project config files
 
@@ -182,7 +182,7 @@ For credential setup, see the `deepsec-sandbox-setup` skill.
 
 - **Don't put org-specific code in `deepsec.config.ts`.** If it has
   the literal name of an internal helper or service, factor it into a
-  plugin instead. See `writing-deepsec-plugins`.
+  plugin instead. See `deepsec-writing-plugins`.
 - **Don't override the data directory** with `dataDir` unless you're
   doing something unusual — the relative-path default makes
   multi-machine sync simpler.

--- a/skills/deepsec-data-layout/SKILL.md
+++ b/skills/deepsec-data-layout/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: deepsec-data-layout
+description: Reference for deepsec's on-disk data/ schema — FileRecord, RunMeta, ProjectConfig, Finding, AnalysisEntry, the per-file lifecycle and append-only merge model. Activates when the user wants to read data/<id>/ directly with jq, write a downstream tool, or understand what a stage adds to a record.
+---
+
+# deepsec data layout
+
+`data/` is deepsec's on-disk state. Each project owns a subdirectory;
+files inside are append-only across runs.
+
+```
+data/<projectId>/
+├── project.json              # rootPath, githubUrl (auto-managed)
+├── INFO.md                   # repo context injected into AI prompts
+├── config.json               # priorityPaths, promptAppend, ignorePaths (optional)
+├── files/                    # one JSON per scanned source file (FileRecord)
+│   └── path/to/source.ts.json
+├── runs/                     # one JSON per run (RunMeta)
+│   └── 20260429215021-19ac.json
+└── reports/                  # generated markdown + JSON reports
+```
+
+`data/` is **gitignored by default**. To version it (CI, sharing across
+machines), commit it explicitly.
+
+The schemas below are the source of truth for any tool that reads
+`data/` directly. They live in `packages/core/src/types.ts`.
+
+## project.json — `ProjectConfig`
+
+Auto-written on first scan; safe to edit by hand.
+
+| Field | Type | Purpose |
+|---|---|---|
+| `projectId` | `string` | Matches the directory name. |
+| `rootPath` | `string` | Absolute path to the codebase. Updated each scan with the most recent `--root`. |
+| `createdAt` | `string` (ISO) | Project init time. |
+| `githubUrl` | `string?` | Auto-detected from `git remote` when missing. |
+
+## config.json — per-project overrides
+
+Optional. Read by `scan` and the AI agents.
+
+| Field | Type | Purpose |
+|---|---|---|
+| `priorityPaths` | `string[]` | Path prefixes processed first. |
+| `promptAppend` | `string` | Free-form text appended to the system prompt for this project. |
+| `ignorePaths` | `string[]` | Glob patterns to skip during scan. |
+
+Overrides equivalent fields on the project declaration in
+`deepsec.config.ts` if both are present.
+
+## INFO.md
+
+Free-form markdown injected into the AI prompt for `process`,
+`triage`, and `revalidate`. Load-bearing for AI precision — see the
+`deepsec-getting-started` skill for the agent prompt that writes a
+good one.
+
+## files/<path>.json — `FileRecord`
+
+The core per-file accumulator. Every stage **adds to** this record;
+nothing is overwritten. Re-scanning merges new candidates.
+Re-processing appends to `analysisHistory`. Revalidation annotates
+findings rather than replacing them.
+
+The on-disk path mirrors the source path under `<rootPath>` plus a
+`.json` suffix: `src/api/auth.ts` → `files/src/api/auth.ts.json`.
+
+### Top-level fields
+
+| Field | Type | Purpose |
+|---|---|---|
+| `filePath` | `string` | Path relative to `rootPath`. |
+| `projectId` | `string` | The owning project. |
+| `candidates` | `CandidateMatch[]` | Regex matcher hits. |
+| `lastScannedAt` | `string` (ISO) | Most recent scan timestamp. |
+| `lastScannedRunId` | `string` | runId of the scan that last touched this file. |
+| `fileHash` | `string` (sha-256) | Source content hash at last scan. |
+| `findings` | `Finding[]` | Latest set of AI-produced findings. |
+| `analysisHistory` | `AnalysisEntry[]` | Append-only log of every AI investigation. |
+| `gitInfo` | `object?` | Git committer info + ownership data, written by `enrich`. |
+| `status` | `"pending" \| "processing" \| "analyzed" \| "error"` | Lifecycle state. |
+| `lockedByRunId` | `string?` | When non-empty, a run holds this file. Cleared on completion. |
+
+### `CandidateMatch`
+
+| Field | Type | Purpose |
+|---|---|---|
+| `vulnSlug` | `string` | Matcher slug that fired. |
+| `lineNumbers` | `number[]` | 1-indexed source lines. |
+| `snippet` | `string` | Short excerpt around the first match. |
+| `matchedPattern` | `string` | Human-readable label (the matcher's `label`). |
+
+### `Finding`
+
+| Field | Type | Purpose |
+|---|---|---|
+| `severity` | `"CRITICAL" \| "HIGH" \| "MEDIUM" \| "HIGH_BUG" \| "BUG" \| "LOW"` | See README. |
+| `vulnSlug` | `string` | Matcher slug or `other-<topic>` if no matcher fits. |
+| `title` | `string` | One-sentence summary. |
+| `description` | `string` | Full explanation. |
+| `lineNumbers` | `number[]` | 1-indexed lines. |
+| `recommendation` | `string` | Suggested fix. |
+| `confidence` | `"high" \| "medium" \| "low"` | Agent's self-rated confidence. |
+| `triage` | `Triage?` | Set by `triage`. |
+| `revalidation` | `Revalidation?` | Set by `revalidate`. |
+
+### `Triage` (set by `deepsec triage`)
+
+| Field | Type |
+|---|---|
+| `priority` | `"P0" \| "P1" \| "P2" \| "skip"` |
+| `exploitability` | `"trivial" \| "moderate" \| "difficult"` |
+| `impact` | `"critical" \| "high" \| "medium" \| "low"` |
+| `reasoning` | `string` |
+| `triagedAt` | `string` (ISO) |
+| `model` | `string` |
+
+### `Revalidation` (set by `deepsec revalidate`)
+
+| Field | Type |
+|---|---|
+| `verdict` | `"true-positive" \| "false-positive" \| "fixed" \| "uncertain"` |
+| `reasoning` | `string` (includes git-history evidence if `fixed`) |
+| `adjustedSeverity` | `Severity?` |
+| `revalidatedAt` | `string` (ISO) |
+| `runId` | `string` |
+| `model` | `string` |
+
+### `AnalysisEntry`
+
+One per AI investigation. Append-only — nothing is ever deleted.
+
+| Field | Type |
+|---|---|
+| `runId` | `string` |
+| `investigatedAt` | `string` (ISO) |
+| `durationMs` | `number` |
+| `durationApiMs` | `number?` |
+| `agentType` | `"claude-agent-sdk" \| "codex"` |
+| `model` | `string` |
+| `modelConfig` | `Record<string, unknown>` |
+| `agentSessionId` | `string?` |
+| `findingCount` | `number` |
+| `numTurns` | `number?` |
+| `costUsd` | `number?` |
+| `usage` | `{ inputTokens, outputTokens, cacheReadInputTokens, cacheCreationInputTokens }?` |
+| `refusal` | `RefusalReport?` |
+| `codexStderr` | `string?` (forensic, when an investigation produced 0 output tokens) |
+| `reinvestigateMarker` | `number?` (wave marker from `--reinvestigate <N>`) |
+
+### `RefusalReport`
+
+| Field | Type |
+|---|---|
+| `refused` | `boolean` |
+| `reason` | `string?` |
+| `skipped` | `Array<{ filePath?: string; reason: string }>?` |
+| `raw` | `string?` (trimmed raw model response, for debugging) |
+
+### `gitInfo` (set by `deepsec enrich`)
+
+| Field | Type |
+|---|---|
+| `recentCommitters` | `Array<{ name, email, date }>` |
+| `enrichedAt` | `string` (ISO) |
+| `ownership` | `OwnershipData?` (when an ownership plugin is active) |
+
+### `status` lifecycle
+
+```
+pending     -- scan finished, awaits AI
+   ↓
+processing  -- a run is currently investigating (lockedByRunId set)
+   ↓
+analyzed    -- AnalysisEntry appended; findings updated
+```
+
+`error` is set if the agent crashed mid-investigation. Re-running
+`process` retries `error` and `pending` files.
+
+## runs/<runId>.json — `RunMeta`
+
+One per `scan` / `process` / `revalidate` invocation. Used for status
+reporting (`deepsec status`) and for filtering exports by run.
+
+| Field | Type |
+|---|---|
+| `runId` | `<YYYYMMDDHHMMSS>-<rand4>` (sortable) |
+| `projectId` | `string` |
+| `rootPath` | `string` |
+| `createdAt` | `string` (ISO) |
+| `completedAt` | `string?` (ISO; absent while running) |
+| `type` | `"scan" \| "process" \| "revalidate"` |
+| `phase` | `"running" \| "done" \| "error"` |
+| `scannerConfig` | `{ matcherSlugs }?` (set on scan runs) |
+| `processorConfig` | `{ agentType, model, modelConfig }?` (set on process / revalidate runs) |
+| `stats` | counters: filesScanned, candidatesFound, findingsCount, totalCostUsd, truePositives, falsePositives, … |
+
+## reports/
+
+Generated by `deepsec report`. One markdown per project plus a JSON
+summary. **Re-running `report` overwrites; nothing here is incremental.**
+
+## Reading data/ directly with jq
+
+The append-only model makes a few patterns work well:
+
+**Every TP HIGH+ finding across a project**:
+```bash
+jq -r '. as $r | $r.findings[]
+  | select(.revalidation.verdict=="true-positive")
+  | select(.severity=="HIGH" or .severity=="CRITICAL")
+  | [$r.filePath, .severity, .title] | @tsv' \
+  data/<id>/files/**/*.json
+```
+
+**Total spend on a project**:
+```bash
+jq -s 'map(.analysisHistory[].costUsd // 0) | add' \
+  data/<id>/files/**/*.json
+```
+
+**Files still pending after a run**:
+```bash
+jq -r 'select(.status=="pending") | .filePath' \
+  data/<id>/files/**/*.json
+```
+
+For richer queries, prefer `deepsec export --format json` — it applies
+filters consistently with the rest of the CLI.
+
+## Hard rules
+
+- **Don't write to `data/<id>/files/*.json` from outside deepsec.**
+  Concurrent runs use `lockedByRunId` for coordination; mutating mid-
+  run can corrupt the lock state. Use `deepsec export` to read out;
+  use `enrich` / `triage` / `revalidate` to add structured fields.
+- **Don't delete `analysisHistory` entries.** They're forensically
+  important — model regressions and refusals are diagnosed from this
+  trail.
+- **Don't depend on the `findings[]` array order.** Findings are
+  merged by `(vulnSlug, normalized title)` across re-runs; ordering
+  is not stable.

--- a/skills/deepsec-getting-started/SKILL.md
+++ b/skills/deepsec-getting-started/SKILL.md
@@ -182,7 +182,7 @@ projects; auto-resolution only kicks in when there's exactly one.
 
 ## Where to go next
 
-- **Add custom matchers** for entry-point shapes the defaults miss → `writing-deepsec-matchers`.
+- **Add custom matchers** for entry-point shapes the defaults miss → `deepsec-writing-matchers`.
 - **Configure projects, plugins, matcher filtering** → `deepsec-configuration`.
 - **Pick agent / model / handle refusals** → `deepsec-models`.
 - **CI / PR review** → `deepsec-pr-review`.

--- a/skills/deepsec-getting-started/SKILL.md
+++ b/skills/deepsec-getting-started/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: deepsec-getting-started
+description: First-scan walkthrough for deepsec — install, register the project, write INFO.md, run scan + process + revalidate, export findings. Activates when the user is setting up deepsec for the first time or running their first scan.
+---
+
+# Getting started with deepsec
+
+deepsec is an AI-powered vulnerability scanner. It lives in a
+`.deepsec/` directory at the root of the repo you want to scan,
+checked into git so teammates inherit project context. Generated scan
+output (findings, runs, reports) stays gitignored.
+
+## Install
+
+Requires **Node.js 22+**. From the root of the codebase you want to scan:
+
+```bash
+npx deepsec init                                   # creates .deepsec/ + registers this repo
+cd .deepsec
+pnpm install                                       # installs deepsec
+```
+
+`init` lays down a minimal scaffold inside `.deepsec/`:
+- `package.json` and `pnpm-workspace.yaml` (isolates this dir from any parent monorepo)
+- `deepsec.config.ts` (one `projects[]` entry pointing at `..`, id derived from your repo dir's basename)
+- `data/<id>/INFO.md` (template with section placeholders)
+- `data/<id>/SETUP.md` (per-project agent prompt)
+- workspace-level `AGENTS.md`, `.env.local`, `.gitignore`
+
+No custom matchers in the scaffold — add those later, only when a real
+finding shapes one for you.
+
+## Pick a credential
+
+Open `.env.local` and pick one of:
+
+- **AI Gateway API key** — set `AI_GATEWAY_API_KEY=vck_…`. Get a key
+  from [Vercel AI Gateway](https://vercel.com/ai-gateway). One key
+  covers both Claude and Codex.
+- **Vercel OIDC token** — run `npx vercel link && npx vercel env pull`
+  in this workspace. That writes `VERCEL_OIDC_TOKEN` to `.env.local`,
+  which deepsec uses as the gateway credential automatically. Token
+  expires after 12 hours; re-pull when you hit auth errors.
+
+Prefer Anthropic directly? Set `ANTHROPIC_AUTH_TOKEN=sk-ant-…` and
+`ANTHROPIC_BASE_URL=https://api.anthropic.com` instead. If `claude` or
+`codex` is already logged in on this machine, non-sandbox runs
+(`process` / `revalidate` / `triage`) skip the token and reuse the
+subscription.
+
+For full credential setup, see the `deepsec-sandbox-setup` skill.
+
+## Add another codebase (optional)
+
+To scan a different codebase from the same `.deepsec/`:
+
+```bash
+pnpm deepsec init-project <path>     # relative paths resolve against .deepsec/'s parent
+```
+
+## Fill in INFO.md
+
+`INFO.md` is what makes deepsec project-aware. It's injected into the
+AI prompt for every batch — vague content here means vague findings.
+
+### Option A: let your coding agent do it (recommended)
+
+Open the **parent repo** (the codebase you scanned, not `.deepsec/`) in
+your coding agent (Claude Code, Codex, Cursor, …) and paste the prompt
+that `deepsec init` printed. It walks the agent through:
+
+1. Read `.deepsec/node_modules/deepsec/SKILL.md` to understand the tool.
+2. Open `.deepsec/data/<id>/SETUP.md` for project-specific instructions.
+3. Skim the codebase, then replace each section of
+   `.deepsec/data/<id>/INFO.md`.
+
+Keep INFO.md SHORT — target 50–100 lines total. Pick 3–5 examples per
+section, not exhaustive enumeration. Name primitives (auth helpers,
+middleware) but no line numbers. Skip generic CWE categories — built-in
+matchers cover those. Cover only what's project-specific.
+
+### Option B: by hand
+
+Edit `data/<id>/INFO.md` directly — no extra wiring needed in
+`deepsec.config.ts`. Even a paragraph noticeably improves AI output.
+
+## Run a scan
+
+```bash
+pnpm deepsec scan
+```
+
+`--project-id` is auto-resolved when the config has a single project
+(the common case). Pass `--project-id <id>` once you've registered
+more than one project. Pass `--root <path>` to override the resolved
+path — useful for one-off scans against a different checkout.
+
+`scan` runs ~110 regex matchers across the codebase. **No AI calls at
+this stage.** On a 2,000-file project it takes ~15s. Output goes to
+`data/<id>/files/` as one JSON file per scanned source file (called a
+`FileRecord`).
+
+```bash
+pnpm deepsec status
+```
+
+shows the current state: how many files were scanned, how many are
+pending AI investigation.
+
+## Run the AI investigation
+
+```bash
+pnpm deepsec process --limit 50      # CALIBRATE FIRST
+```
+
+**Always run `--limit 50` first** before a full pass. Costs swing 2–3x
+based on file complexity; calibrate before committing.
+
+```bash
+pnpm deepsec process --concurrency 5
+```
+
+Defaults: Codex (gpt-5.5) by default; Claude Opus available via
+`--agent claude`. 5 files per batch, 5 batches in parallel = 25 files in
+flight at once.
+
+| Files | Approx cost | Approx wall time |
+|---|---|---|
+| 100   | $25–60     | 5–15 min |
+| 500   | $130–300   | 25–60 min |
+| 2,000 | $500–1200  | 1.5–4 hr |
+
+Lower parallelism (`--concurrency 1`) or set `--limit 50` to budget-cap.
+
+### If a run errors out
+
+`process` is safe to re-run. If a batch fails (network blip, transient
+model error, quota exhausted, you hit Ctrl-C), just run the same command
+again — deepsec resumes, skipping files that already finished and
+re-investigating only the ones that didn't. Nothing to clean up. Same
+applies to `revalidate`.
+
+For a different backend or model:
+
+```bash
+pnpm deepsec process --agent claude --model claude-opus-4-7
+pnpm deepsec process --agent codex --model gpt-5.5
+```
+
+See the `deepsec-models` skill for the full backend / model matrix and
+refusal handling.
+
+## Triage and revalidate
+
+```bash
+pnpm deepsec triage --severity HIGH
+pnpm deepsec revalidate --min-severity HIGH
+```
+
+- **triage**: classifies findings P0/P1/P2 without re-reading the code.
+  ~1¢/finding.
+- **revalidate**: re-reads the code and the git history, then emits a
+  TP/FP/Fixed/Uncertain verdict. Comparable cost to `process`. Cuts FP
+  rate by 50%+ on most repos.
+
+Both optional, but worth running on the HIGH/CRITICAL set.
+
+## Get the findings out
+
+```bash
+pnpm deepsec export --format md-dir --out ./findings
+pnpm deepsec export --format json   --out findings.json
+pnpm deepsec metrics                  # quick aggregate
+```
+
+`md-dir` writes one markdown file per finding under
+`./findings/{CRITICAL,HIGH,MEDIUM,…}/`. `json` writes a single array
+suitable for piping to a downstream issue tracker.
+
+Each command accepts `--project-id <id>` if your config has multiple
+projects; auto-resolution only kicks in when there's exactly one.
+
+## Where to go next
+
+- **Add custom matchers** for entry-point shapes the defaults miss → `writing-deepsec-matchers`.
+- **Configure projects, plugins, matcher filtering** → `deepsec-configuration`.
+- **Pick agent / model / handle refusals** → `deepsec-models`.
+- **CI / PR review** → `deepsec-pr-review`.
+
+## Hard rules
+
+- Always run `--limit 50` before a full `process` pass on a fresh project.
+- Don't commit `data/*/files/` or `data/*/runs/` — gitignored on purpose.
+- A blank INFO.md hurts precision; fill it before the first real
+  `process` pass.

--- a/skills/deepsec-models/SKILL.md
+++ b/skills/deepsec-models/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: deepsec-models
+description: Pick a deepsec backend (Claude vs Codex) and model, understand defaults, refusal handling, and how to drop in a future model. Activates when the user asks which agent to use, how to set --model, or about a refusal in the run output.
+---
+
+# Choosing a deepsec backend and model
+
+deepsec talks to LLMs through two interchangeable backends:
+
+| Backend            | Default model         | Used by                  |
+|--------------------|-----------------------|--------------------------|
+| `codex` (default)  | `gpt-5.5`             | `process`, `revalidate`  |
+| `claude`           | `claude-opus-4-7`     | `process`, `revalidate`  |
+| `claude` (triage)  | `claude-sonnet-4-6`   | `triage` (Claude-only)   |
+
+Both backends route through [Vercel AI Gateway](https://vercel.com/ai-gateway)
+by default — a single token covers Claude **and** Codex. To use
+Anthropic or OpenAI directly, point `ANTHROPIC_BASE_URL` /
+`OPENAI_BASE_URL` at the provider.
+
+## CLI selection
+
+```bash
+# Codex (default), default model:
+pnpm deepsec process --project-id my-app
+
+# Claude with a specific model:
+pnpm deepsec process --project-id my-app --agent claude --model claude-sonnet-4-6
+
+# Codex backend, specific model:
+pnpm deepsec process --project-id my-app --agent codex --model gpt-5.4
+
+# Triage uses Claude; pass a cheaper model if desired:
+pnpm deepsec triage --project-id my-app --model claude-haiku-4-5
+```
+
+`--agent` and `--model` are accepted on `revalidate` too. Set the
+default backend project-wide via `defaultAgent` in `deepsec.config.ts`
+(see the `deepsec-configuration` skill).
+
+## Why these defaults
+
+### `claude-opus-4-7` for `process` / `revalidate` (when on Claude)
+
+Investigating a candidate site is a multi-step reasoning task: trace
+control flow, recognize an auth boundary, decide whether input is
+attacker-controlled, judge severity. Stronger reasoning models pay for
+themselves in lower FP rate, even at higher per-call cost. Opus is the
+strongest of the Claude family at this kind of code reasoning.
+
+If cost matters more than precision (a 10k-file repo, a quick triaged
+starter list), drop to `claude-sonnet-4-6` — same prompt, ~3× cheaper,
+~10–20% higher FP rate.
+
+### `gpt-5.5` for the Codex backend
+
+Codex is the OpenAI-flavored agent loop: grep-heavy, fast, runs in a
+strict read-only sandbox. `gpt-5.5` is the right balance of reasoning
+and cost for that loop. `gpt-5.5-pro` is the most careful Codex
+option at significantly higher cost; `gpt-5.4` and below are fine for
+follow-up reinvestigation passes.
+
+### `claude-sonnet-4-6` for `triage`
+
+Triage buckets findings into P0/P1/P2/skip without re-reading the code
+— it just looks at the finding text. Cheap task; Opus is overkill.
+Sonnet keeps `triage` at ~1¢/finding.
+
+## Claude vs Codex — strengths
+
+| Strength | Claude (Opus) | Codex (gpt-5.5) |
+|---|---|---|
+| Reasoning about authorization shapes and cross-file flows | Strong | Good |
+| Grep-heavy investigations | Good | Strong (strict sandbox helps) |
+| Cost | $$$ | $ |
+| Sandbox isolation by default | No (read-only via tool config) | Yes (strict) |
+
+A useful pattern: run Claude first, then re-process unconvincing
+findings with `--agent codex --reinvestigate` for a second opinion.
+Findings dedupe across agents.
+
+## Refusals
+
+Models occasionally refuse to investigate a candidate — usually when
+source contains an exploit pattern they read as harmful, or when a
+path trips a content filter. After every batch, deepsec issues a
+follow-up turn:
+
+> Looking back at the investigation: was there anything you declined
+> to fully analyze, refused to look at, or skipped because the content
+> or the task felt uncomfortable or out of scope?
+
+The agent answers in a structured JSON shape (see `parseRefusalReport`
+in `packages/processor/src/agents/shared.ts`). If `refused: true`:
+
+- The batch gets a `refusal` record in run metadata.
+- The per-batch log line shows a ⚠️ `refusal` marker.
+- The `refusal` field on the FileRecord sticks around for audit.
+
+**No silent skips.**
+
+Claude Opus and `gpt-5.5` refuse less than 1% of batches in practice.
+A refused batch produces no false negatives — affected files stay
+`pending` (revalidation keeps the original verdict), so re-running
+`--reinvestigate` against the other backend picks up the dropped
+sites. Findings dedupe across agents, so you don't pay twice.
+
+If a single file consistently triggers a refusal (>5% of batches),
+it's usually one path with a hard-to-disambiguate exploit pattern.
+Add it to `config.json:ignorePaths`, or run that file alone with
+`--batch-size 1` so the refusal doesn't take a batch of otherwise-fine
+files down with it.
+
+## Future models (Anthropic Mythos, gpt-6, …)
+
+The model is a flag, not a baked-in choice. Point `--model` at the new
+identifier:
+
+```bash
+pnpm deepsec process --project-id my-app --model anthropic-mythos-1
+pnpm deepsec process --project-id my-app --agent codex --model gpt-6
+```
+
+Two small integration points if the new model is on Codex:
+
+1. **The model identifier** — whatever string the provider's SDK
+   accepts. deepsec passes it through unchanged. **No code change
+   needed to use a new model on either backend.**
+2. **Pricing for the cost-per-batch readout.** The Claude Agent SDK
+   reports cost natively, so new Claude-family models drop in with
+   zero code changes. Codex doesn't, so add a line to
+   `MODEL_PRICING_USD_PER_M_TOKENS` in
+   `packages/processor/src/agents/codex-sdk.ts` for each new
+   OpenAI/Codex model. Without it, the batch still runs — the cost
+   readout is simply omitted.
+
+When a new model becomes the right default, change the relevant entry
+in `packages/deepsec/src/agent-defaults.ts` (one string per backend)
+and the `DEFAULT_MODEL` constant in the corresponding agent file.
+
+Existing data and findings are unaffected — deepsec records which
+agent + model produced each finding, so a model change shows up
+cleanly in `analysisHistory` of any re-investigated file.
+
+A useful pattern when a new model lands: re-run `process` with
+`--reinvestigate <N>` (a wave marker) against existing high-severity
+findings to see whether the new model overturns verdicts. The wave
+marker tags the new analysis without losing the old one.
+
+## Hard rules
+
+- **Don't lower from Opus → Sonnet on first scans of a new repo.** FP
+  rate on Sonnet is materially higher; the false leads cost more in
+  human triage time than the model savings.
+- **`triage` is Claude-only.** `--agent codex` is rejected for that
+  command.
+- **Don't combine `--reinvestigate` with the same agent + model** that
+  produced the original findings — you'll just re-run identical
+  investigations. Switch agents or models for a real second opinion.

--- a/skills/deepsec-pr-review/SKILL.md
+++ b/skills/deepsec-pr-review/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: deepsec-pr-review
+description: Use deepsec as a pull-request gate or local diff review with `process --diff`. Activates when the user asks how to scan only changed files, set up CI for PRs, write a deepsec GitHub Actions workflow, or get an exit-code gate for net-new findings.
+---
+
+# Reviewing changes (PR mode)
+
+`deepsec process` has a direct-invocation mode for reviewing a specific
+set of files — typically the files changed in a pull request. This is
+the right tool for a **fast, scoped read of changed code** in CI,
+rather than a whole-repo audit.
+
+```bash
+deepsec process --diff origin/main
+```
+
+## How it differs from a full scan
+
+The standard flow is `scan` → `process` over the entire repo:
+
+| Step      | What it looks at        | What it produces                  |
+|-----------|-------------------------|-----------------------------------|
+| `scan`    | The full source tree    | Regex candidates per file         |
+| `process` | All pending candidates  | AI findings on every flagged file |
+
+Direct mode collapses both into one invocation, scoped to a file list:
+
+| Step              | What it looks at                | What it produces                                       |
+|-------------------|---------------------------------|--------------------------------------------------------|
+| Resolve files     | `--diff` / `--files` / stdin    | A POSIX-relative file list under `rootPath`            |
+| Scoped scan       | Only the listed files           | Candidates as **signals** for the prompt (best-effort) |
+| Always-process    | The same listed files           | AI findings — even on files no matcher hit             |
+
+The scoped scan still runs because regex hits are useful prompt
+anchors. Files with no hits still get a record and still get
+investigated as a holistic review.
+
+## Flags
+
+The five sources are mutually exclusive:
+
+```text
+--diff <ref|range>     git diff --name-only <ref> (e.g. origin/main, HEAD~1..HEAD)
+--diff-staged          The index vs HEAD
+--diff-working         Uncommitted + untracked files
+--files <csv>          Comma-separated path list
+--files-from <path>    Newline-delimited paths from <path> (or "-" for stdin)
+```
+
+Other knobs:
+
+```text
+--no-ignore            Bypass the default ignore filter (test files, dist/, node_modules/, …)
+--comment-out <path>   Write a PR-comment-shaped markdown summary to <path> (only when findings exist)
+--project-id <id>      Override the project id (auto-derived from rootPath basename otherwise)
+--root <path>          Override the project root (defaults to cwd or deepsec.config.ts)
+```
+
+`--agent`, `--model`, `--concurrency`, `--batch-size`, `--max-turns`
+work the same as in standard mode.
+
+## Auto-created projects
+
+You don't need `deepsec init` first. With a direct-mode flag, `process`
+will:
+
+1. Use `--project-id` if passed. If declared in `deepsec.config.ts`,
+   use the declared root; otherwise `--root` (or cwd).
+2. Otherwise, derive the id from the basename of the resolved root.
+3. Write `data/<id>/project.json` if it doesn't exist.
+
+Auto-creation is one-line and non-destructive — it never modifies
+`deepsec.config.ts`. It just ensures `data/<id>/` exists so file
+records and the optional PR-comment markdown have somewhere to land.
+
+## Exit codes
+
+| Code | Meaning                                          |
+|------|--------------------------------------------------|
+| `0`  | No findings produced in this run                 |
+| `1`  | At least one finding was produced                |
+| `≠1` | Runtime error (bad input, missing credentials, …)|
+
+This makes direct mode a drop-in CI gate: the job fails when the agent
+finds something. **Net-new findings only** count toward the exit
+code — re-running on a file with existing findings doesn't fail the
+build unless something new is surfaced. Pre-existing findings (from a
+prior full scan, or earlier PR-review runs) on touched files are
+intentionally excluded so the gate matches the change-scoped review
+model.
+
+## PR comments
+
+`--comment-out <path>` writes a markdown body summarizing the **net-new
+findings** from this run — same scope as the exit-code gate. Findings
+already on touched files (from earlier full scans or prior PR reviews)
+aren't re-surfaced. Descriptions and recommendations are truncated
+(600 / 400 chars) to stay under GitHub's 65 KiB comment limit; full
+text lives in `data/<id>/files/`.
+
+The file is only written when there are findings, so a green run leaves
+nothing on disk and your "post comment" step can short-circuit on
+`if: hashFiles('comment.md') != ''`.
+
+## Reference workflow (GitHub Actions)
+
+This is the workflow used to review PRs in deepsec itself. Copy as-is:
+
+```yaml
+name: deepsec
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need history for `git diff origin/<base>`
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 24, cache: pnpm }
+
+      - run: pnpm install --frozen-lockfile
+      - run: npm install -g @anthropic-ai/claude-code
+
+      - id: deepsec
+        env:
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          CLAUDE_CODE_EXECUTABLE: claude
+        run: |
+          pnpm deepsec process \
+            --diff origin/${{ github.event.pull_request.base.ref }} \
+            --comment-out comment.md
+
+      - if: always() && hashFiles('comment.md') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: deepsec-comment
+          path: comment.md
+          retention-days: 1
+
+  comment:
+    needs: analyze
+    if: always() && needs.analyze.result == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - id: dl
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: deepsec-comment
+
+      - if: steps.dl.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: fs.readFileSync('comment.md', 'utf8'),
+            });
+```
+
+### Why it's split into two jobs
+
+- **`analyze`** runs PR-controlled code (the user's `pnpm install`,
+  their config, their source) with the AI gateway secret in scope but
+  **no write permissions** on the repo.
+- **`comment`** has `pull-requests: write` but never runs PR code — it
+  consumes only the sanitized `comment.md` artifact.
+
+A malicious PR can't combine "execute arbitrary code" with "write to
+the repository" in a single privileged step.
+
+### Other notes
+
+- **Same-repo gate** (`if: github.event.pull_request.head.repo.full_name == github.repository`):
+  skips fork PRs entirely. Forks don't receive repo secrets under
+  `pull_request` anyway — this gate is a UX cleanup so fork PRs show
+  "skipped" instead of red ❌ from a doomed run.
+- **`fetch-depth: 0`** — needed so `git diff origin/<base>` resolves
+  against the merge base; default shallow clone doesn't have it.
+- **`npm install -g @anthropic-ai/claude-code`** — installing the
+  Claude Code CLI globally + setting `CLAUDE_CODE_EXECUTABLE: claude`
+  skips the SDK's bundled-binary resolution, which can fail on Linux
+  under some package managers.
+- **`pnpm deepsec`** — swap for `npx -y deepsec`, `npm exec deepsec`,
+  or `yarn deepsec` to match your package manager.
+- **`comment.md` is uploaded only when findings exist** —
+  `--comment-out` writes nothing on a green run, so the `hashFiles`
+  check skips and the `comment` job downloads no artifact.
+
+## Threat model notes
+
+- **Don't grant `pull-requests: write` to a job that runs PR code.**
+  Keep PR code in the no-write `analyze` job. A PR can add arbitrary
+  code to its own `package.json` postinstall scripts or to a project
+  config file the CLI loads — both run before any of your own steps.
+- **Pin actions to full SHAs in production.** The example above uses
+  major-version tags (`@v4`) for readability. For a hardened
+  deployment, swap each tag for the action's full commit SHA.
+- **The AI gateway secret still flows through PR code.** Even with the
+  job split, `analyze` has the secret in env while running
+  PR-controlled `pnpm install`. The `author_association` (same-repo)
+  gate is what prevents that from being a vulnerability. For
+  defense-in-depth, run `analyze` only after a label is applied:
+  `if: contains(github.event.pull_request.labels.*.name, 'review-ok')`.
+
+## Cost notes
+
+Wide diffs are expensive — each file pays for an AI investigation. For
+PRs against `main`, scope to the merge base (`origin/main`), not the
+entire branch ancestry. If a touched file isn't worth investigating
+(generated code, fixtures), drop it via a custom `--files-from`:
+
+```bash
+git diff --name-only origin/main \
+  | grep -v '^generated/' \
+  | deepsec process --files-from -
+```
+
+## When NOT to use direct mode
+
+- **For the initial sweep of a large repo**: full `scan` + `process`
+  orders by noise tier, parallelizes better, and benefits from
+  whole-repo signal in matcher gating. Direct mode is for incremental
+  review.
+- **For revalidating existing findings**: use `revalidate` with its
+  own filters.
+
+## Hard rules
+
+- **Never give `pull-requests: write` to the job that runs PR code.**
+  Use the two-job split.
+- **Always set `fetch-depth: 0`** on checkout for `--diff` against the
+  base branch.
+- **Always pass the merge base ref**, not `HEAD~1` or branch ancestry,
+  unless you specifically want every commit on the branch reviewed.

--- a/skills/deepsec-sandbox-setup/SKILL.md
+++ b/skills/deepsec-sandbox-setup/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: deepsec-sandbox-setup
+description: Set up AI Gateway and Vercel Sandbox credentials for deepsec — picking between API key vs OIDC token, BYOK, subscription fallback, and troubleshooting auth failures and credit exhaustion. Activates when the user mentions AI_GATEWAY_API_KEY, VERCEL_OIDC_TOKEN, "401 unauthorized", "credits exhausted", or sandbox auth.
+---
+
+# Setting up AI Gateway and Vercel Sandbox
+
+deepsec uses two Vercel products. Most users only need the first.
+
+| Product | When you need it |
+|---|---|
+| **AI Gateway** | Always — for `process` and `revalidate`. One token covers Claude and Codex. Adds provider failover, observability, and zero data retention. |
+| **Vercel Sandbox** | Only for `deepsec sandbox process` (distributed scans across microVMs). Skip if running locally. |
+
+Both have a free tier suitable for evaluation. Real scans on
+production codebases will exceed the free tier — top up before
+kicking off long runs.
+
+## AI Gateway
+
+### Pick a credential
+
+Two ways to authenticate. **If you don't know which to pick, use the
+API key** — it's faster to set up and works everywhere, including CI.
+
+| Where you're running | Use this |
+|---|---|
+| Anywhere | API key (Option A) |
+| Local + already linked to a Vercel project (`.vercel/project.json` exists) | OIDC token (Option B) |
+| Inside `deepsec sandbox …` | OIDC token (automatic — same token authenticates both) |
+
+### Option A: API key
+
+1. Open the [AI Gateway API Keys page](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai-gateway%2Fapi-keys&title=AI+Gateway+API+Keys).
+2. Click **Create key** and follow the prompts.
+3. Copy the key (`vck_…`). Keys never expire unless revoked.
+
+In your scanning workspace's `.env.local`:
+
+```bash
+AI_GATEWAY_API_KEY=vck_…
+```
+
+### Option B: OIDC token
+
+If you're already running Vercel Sandbox, this is automatic — the same
+`vercel env pull` that authenticates the sandbox also authenticates
+the gateway. Otherwise:
+
+```bash
+# In your scanning workspace:
+npx vercel link              # link this directory to a Vercel project
+npx vercel env pull          # writes VERCEL_OIDC_TOKEN to .env.local
+```
+
+deepsec auto-refreshes the token when near expiry (via `@vercel/oidc`),
+but the underlying refresh requires `.vercel/project.json` in the
+workspace — re-run `vercel env pull` if refresh fails or the directory
+moved.
+
+The token expires after **12 hours**.
+
+### Verify
+
+```bash
+pnpm deepsec scan --limit 20         # cheap, no AI calls
+pnpm deepsec process --limit 5       # exercises the gateway
+```
+
+If the second command fails with `Missing AI credentials` or `401`,
+see [Troubleshooting](#troubleshooting) below.
+
+### How the credential expansion works
+
+deepsec expands whichever credential it finds (API key first, OIDC
+token as fallback) at startup into the four vars the agent SDKs read:
+
+- `ANTHROPIC_AUTH_TOKEN`
+- `ANTHROPIC_BASE_URL`
+- `OPENAI_API_KEY`
+- `OPENAI_BASE_URL`
+
+So a single credential covers both Codex (`--agent codex`, the
+default) and Claude (`--agent claude`).
+
+**Any of those four vars set explicitly takes precedence** over the
+expansion — useful for mixing direct Anthropic with gateway-routed
+OpenAI, etc.
+
+## Costs and credits
+
+The AI Gateway uses pay-as-you-go pricing with **zero markup** on
+provider rates. Every Vercel team gets **$5/month free credit** for
+evaluation. Full scans on real codebases will exhaust that — top up
+before kicking off a long run.
+
+- [Top up credits](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%3Fmodal%3Dtop-up) — opens the AI dashboard with the top-up modal.
+- [Auto top-up](https://vercel.com/docs/ai-gateway/pricing#configure-auto-top-up) — set a threshold; charges automatically when balance dips.
+- [Pricing reference](https://vercel.com/docs/ai-gateway/pricing) — model-by-model rates.
+
+Rough budget for a `process` pass with Claude Opus (default settings):
+
+| Files | Approx cost |
+|---|---|
+| 100   | $25–60   |
+| 500   | $130–300 |
+| 2,000 | $500–1200 |
+
+Run `--limit 50` first to calibrate before a full pass.
+
+### When credits run out
+
+If `process` or `revalidate` halts because the gateway balance is
+exhausted (or a direct provider key ran out), deepsec stops gracefully
+— no further batches launch, in-flight batches are cancelled, the
+file lock state is preserved. The CLI prints a remediation message
+with the right top-up URL.
+
+After topping up, **re-run the same command**. It picks up exactly
+where it stopped — files already analyzed are skipped, only the
+unfinished ones get re-investigated.
+
+## Subscriptions (Claude Pro / ChatGPT Plus)
+
+If `claude` or `codex` is logged in on this machine, non-sandbox runs
+(`process`, `revalidate`, `triage`) can fall back to that subscription
+session — no API key needed:
+
+```bash
+claude login    # for --agent claude
+codex login     # for --agent codex
+```
+
+Subscriptions are useful for **evaluating** deepsec but generally do
+**not** have enough headroom for full repo scans. The Claude weekly /
+5-hour and ChatGPT Plus quotas trip well before a real codebase is
+finished. Switch to the gateway (or a direct provider key) once past
+evaluation.
+
+## BYOK and direct providers
+
+If you have your own Anthropic / OpenAI agreement, two options:
+
+**Through the gateway (recommended)** — configure
+[BYOK](https://vercel.com/docs/ai-gateway/authentication-and-byok#bring-your-own-key-byok)
+at the team level. No gateway markup, with failover and observability
+on top.
+
+**Bypass the gateway entirely** — set the explicit base URL + token
+pairs in `.env.local`:
+
+```bash
+# Anthropic direct
+ANTHROPIC_AUTH_TOKEN=sk-ant-…
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+
+# OpenAI direct
+OPENAI_API_KEY=sk-…
+# (OPENAI_BASE_URL defaults to api.openai.com — only set for proxies)
+```
+
+Mix freely — gateway for Claude, direct for OpenAI, etc. The explicit
+values always win over the `AI_GATEWAY_API_KEY` expansion.
+
+## Vercel Sandbox
+
+Only needed for `deepsec sandbox process` and `deepsec sandbox-all`.
+Skip this section for local-only.
+
+deepsec supports both auth methods the Sandbox SDK accepts:
+
+| Where you're running | Use this |
+|---|---|
+| Local development | OIDC token |
+| Long-running CI, external infra, server-side cron | Access token |
+| Deployed on Vercel | OIDC (automatic, nothing to set) |
+
+### Option A: OIDC token (recommended for local)
+
+```bash
+# In your scanning workspace:
+npx vercel link              # link this directory to a Vercel project
+npx vercel env pull          # writes VERCEL_OIDC_TOKEN to .env.local
+```
+
+The token expires after **12 hours**; re-run `vercel env pull` when you
+hit auth errors. The Vercel project you link to is just the auth
+scope — any project on your team works.
+
+If you go this route, you don't need a separate AI Gateway API key:
+the same OIDC token authenticates the gateway automatically.
+
+### Option B: access token (API key)
+
+Use when OIDC isn't viable: external CI/CD, non-Vercel hosting, jobs
+that run unattended longer than 12 hours, or any setup where running
+`vercel env pull` interactively isn't practical. Three env vars in
+`.env.local`:
+
+```bash
+VERCEL_TOKEN=…               # https://vercel.com/account/tokens
+VERCEL_TEAM_ID=team_…        # Team Settings → Team ID
+VERCEL_PROJECT_ID=prj_…      # any project's Settings → General → Project ID
+```
+
+The Sandbox SDK reads these directly from `process.env` at
+`Sandbox.create()` time.
+
+You can keep both sets of env vars in `.env.local`. The SDK prefers
+`VERCEL_OIDC_TOKEN` when present and falls back to access-token mode
+otherwise — handy for OIDC locally and access-token in scheduled CI.
+
+### Try a sandbox run
+
+```bash
+pnpm deepsec sandbox process --project-id my-app --sandboxes 4
+```
+
+If the sandbox can't authenticate, the spawn fails with the SDK's
+error. Re-run `vercel env pull` (OIDC) or double-check the three
+access-token vars.
+
+## Troubleshooting
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| `Missing AI credentials for --agent claude` / `codex` | No credential present. | Set `AI_GATEWAY_API_KEY=vck_…` in `.env.local`, or run `claude login` / `codex login`. |
+| `401 Unauthorized` from `process` / `revalidate` | Credential present but rejected. | OIDC: re-run `vercel env pull` (12h expiry). API key: regenerate. Confirm `.env.local` is in cwd. |
+| `✘ Stopped: Vercel AI Gateway credits exhausted` | Gateway balance is $0. | [Top up](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%3Fmodal%3Dtop-up), then re-run the same command. |
+| `✘ Stopped: Anthropic API credits exhausted` | Direct Anthropic out of credits. | Top up at [Anthropic Console](https://console.anthropic.com/), or switch to the gateway. |
+| `✘ Stopped: OpenAI API quota exhausted` | Direct OpenAI out of quota. | Top up in OpenAI dashboard, or switch to the gateway. |
+| `✘ Stopped: Claude Pro/Max subscription exhausted` | Hit weekly / 5-hour subscription cap. | Switch to AI Gateway. |
+| `✘ Stopped: ChatGPT subscription exhausted` | Hit ChatGPT Plus / Pro quota. | Switch to AI Gateway. |
+| Sandbox spawn fails with auth error | OIDC expired (12h) or access-token vars wrong. | Re-run `vercel env pull` (OIDC) or check `VERCEL_TOKEN` / `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID`. |
+| Findings missing cost in the log | Pricing entry missing for a non-default Codex model. | Add to `MODEL_PRICING_USD_PER_M_TOKENS` in `codex-sdk.ts`, or ignore (run still works). |
+
+### After any quota / credit fix
+
+`process` and `revalidate` resume on re-run — there's no recovery
+flag, no state to reset. Files already analyzed stay analyzed; only
+the unfinished ones get picked up. (To redo finished work, use
+`--reinvestigate` for `process` or `--force` for `revalidate`.)
+
+## Hard rules
+
+- **Don't commit `.env.local` to git.** It contains live credentials.
+  The `init` scaffold's `.gitignore` already excludes it; don't
+  override.
+- **Never use a Claude Pro / ChatGPT Plus subscription for a full repo
+  scan.** Subscriptions trip well before completion. Use them only
+  for evaluation.
+- **OIDC tokens expire every 12 hours.** If a long-running CI job
+  outlives that, switch to access-token mode (`VERCEL_TOKEN`).

--- a/skills/deepsec-writing-matchers/SKILL.md
+++ b/skills/deepsec-writing-matchers/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: writing-deepsec-matchers
+name: deepsec-writing-matchers
 description: Add custom regex matchers to deepsec to catch entry-point shapes and org-specific patterns the built-in set misses. Activates when the user wants to extend deepsec's coverage for their codebase.
 ---
 

--- a/skills/deepsec-writing-matchers/SKILL.md
+++ b/skills/deepsec-writing-matchers/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: writing-deepsec-matchers
+description: Add custom regex matchers to deepsec to catch entry-point shapes and org-specific patterns the built-in set misses. Activates when the user wants to extend deepsec's coverage for their codebase.
+---
+
+# Writing matchers with your coding agent
+
+This skill is for users running deepsec inside a `.deepsec/` workspace
+— i.e. they ran `npx deepsec init`, deepsec is installed in
+`node_modules/`, and `data/<id>/` has at least one scan in it.
+
+The intended loop:
+
+```
+scan (fast, wide) → process (AI, slow + expensive) → revalidate → write better matchers
+```
+
+The default matcher set covers common CWE shapes (SQL injection, SSRF,
+path traversal, etc.) and a handful of popular framework shapes
+(Next.js, Prisma, Express). It will miss patterns specific to a
+codebase: an internal RPC framework, a less common language, a custom
+auth helper, a non-default route layout. Custom matchers fill those
+gaps.
+
+## When to write one
+
+- A revalidated true-positive needs a matcher to catch siblings on future scans.
+- A cluster of `other-*` slugs in `deepsec metrics` points at a real category deepsec has no name for.
+- The target repo has **entry points the default matchers don't see**. Common gaps: Hono, Elysia, Cloudflare Workers, Bun, Deno, FastAPI, Rails controllers, Go `chi`/`gin`, internal RPC.
+- You have an **organization-specific** pattern (internal auth helper, internal SDK call, custom middleware).
+
+## Where matchers live
+
+Custom matchers go inside `.deepsec/` and are wired through an inline
+plugin in `deepsec.config.ts`:
+
+```
+.deepsec/
+├── deepsec.config.ts                # inline plugin lists the matchers
+└── matchers/
+    ├── my-route-no-auth.ts
+    └── my-internal-rpc.ts
+```
+
+```ts
+// deepsec.config.ts
+import { defineConfig, type DeepsecPlugin } from "deepsec/config";
+import { myRouteNoAuth } from "./matchers/my-route-no-auth.js";
+import { myInternalRpc } from "./matchers/my-internal-rpc.js";
+
+const myPlugin: DeepsecPlugin = {
+  name: "my-app",
+  matchers: [myRouteNoAuth, myInternalRpc],
+};
+
+export default defineConfig({
+  projects: [{ id: "my-app", root: ".." }],
+  plugins: [myPlugin],
+});
+```
+
+**Slugs are unique. If your slug collides with a built-in, your
+matcher wins** — useful for swapping in a tighter org-specific
+version.
+
+If a matcher is genuinely reusable across orgs (CWE shape, public
+framework), upstream it to <https://github.com/vercel-labs/deepsec>
+instead — see that repo's `CONTRIBUTING.md`.
+
+## The MatcherPlugin contract
+
+Open `.deepsec/node_modules/deepsec/dist/config.d.ts` for the live
+types. Shape:
+
+```ts
+interface MatcherPlugin {
+  slug: string;                    // kebab-case, unique
+  description: string;
+  noiseTier: "precise" | "normal" | "noisy";
+  filePatterns: string[];          // globs, keep TIGHT
+  requires?: MatcherGate;          // optional tech/sentinel-file gate
+  examples?: string[];             // dev-time test cases
+  match(content: string, filePath: string): CandidateMatch[];
+}
+
+interface CandidateMatch {
+  vulnSlug: string;
+  lineNumbers: number[];           // 1-indexed
+  snippet: string;
+  matchedPattern: string;          // the matcher's `label`
+}
+```
+
+`regexMatcher(slug, patterns, content)` is a helper that handles the
+line-by-line iteration, snippet extraction, and dedup for you. Import
+it from `"deepsec/config"`.
+
+## Worked example
+
+A debug-flag matcher (real one from `samples/webapp/`):
+
+```ts
+import type { CandidateMatch, MatcherPlugin } from "deepsec/config";
+import { regexMatcher } from "deepsec/config";
+
+export const webappDebugFlag: MatcherPlugin = {
+  slug: "webapp-debug-flag",
+  description: "Routes/handlers gated only by env-var debug flags",
+  noiseTier: "normal",
+  filePatterns: ["src/api/**/*.ts", "src/server/**/*.ts"],
+  match(content, filePath): CandidateMatch[] {
+    if (/\.(test|spec)\.(ts|tsx)$/.test(filePath)) return [];
+    return regexMatcher(
+      "webapp-debug-flag",
+      [
+        { regex: /process\.env\.NODE_ENV\s*!==\s*['"]production['"]/, label: "NODE_ENV guard" },
+        { regex: /process\.env\.DEBUG_API\b/, label: "DEBUG_API flag" },
+      ],
+      content,
+    );
+  },
+};
+```
+
+Three things to copy from this:
+1. Skip test files via a `filePath` regex at the top of `match()`.
+2. Pass an array of `{ regex, label }` to `regexMatcher` — the label
+   is what shows up in the AI prompt as `matchedPattern`.
+3. `filePatterns` is **directory-anchored** (`src/api/**/*.ts`), not a
+   blanket `**/*.ts`. Tight globs keep noisy matchers fast.
+
+## Workflow: hand the workspace to your coding agent
+
+The most efficient way to write a useful matcher set is to let your
+coding agent do the analysis. Open the **parent repo** (the codebase
+being scanned) in Claude Code / Codex / Cursor / etc. so it can read
+both the source and `.deepsec/data/`. Then paste this prompt:
+
+> I want to add custom matchers to deepsec for this repo. deepsec is
+> already installed at `.deepsec/node_modules/deepsec/` and
+> `.deepsec/data/<projectId>/` has at least one scan + process pass in
+> it.
+>
+> **Read these first to understand the contract:**
+> - `.deepsec/node_modules/deepsec/dist/config.d.ts` — the
+>   `MatcherPlugin` interface and the `regexMatcher` helper signature.
+> - `.deepsec/node_modules/deepsec/dist/samples/webapp/matchers/webapp-debug-flag.ts`
+>   — small `normal`-tier matcher.
+> - `.deepsec/node_modules/deepsec/dist/samples/webapp/matchers/webapp-route-no-rate-limit.ts`
+>   — slightly larger matcher that combines a regex sweep with a
+>   negative pre-check.
+> - `.deepsec/node_modules/deepsec/dist/samples/webapp/deepsec.config.ts`
+>   — how the inline plugin wires matchers into the config.
+>
+> **Then do the analysis:**
+> 1. Walk `.deepsec/data/<projectId>/files/` and look at what the
+>    default matchers already cover. Note which `vulnSlug`s show up
+>    in `candidates[]`.
+> 2. Compare against the **target repository** (root above `.deepsec/`).
+>    Identify the major entry points: HTTP handlers, RPC entry points,
+>    queue consumers, cron jobs, CLI commands — anything taking
+>    untrusted input. Walk routes/handlers/api directories and
+>    framework config files (`next.config.*`, `wrangler.toml`,
+>    `serverless.yml`, `main.go`, `app.py`, etc.).
+> 3. Decide which entry points the default matchers don't reach.
+>    Common gaps: frameworks deepsec doesn't ship a glob for; less
+>    common languages; org-specific wrappers (auth middleware,
+>    rate-limit wrappers, request-validation helpers) where generic
+>    regexes don't know the convention.
+> 4. **Then write matchers that cover those gaps.** One matcher per
+>    concern. For each:
+>    - **Slug** (kebab-case, e.g. `hono-route-no-auth`,
+>      `worker-fetch-handler`).
+>    - **Noise tier**: `precise` (unambiguous shape, minimal FPs) /
+>      `normal` (broader, AI disambiguates) / `noisy` (every file in a
+>      glob becomes a candidate — use deliberately for entry-point
+>      coverage).
+>    - **`filePatterns`** as tight as possible. A `noisy` matcher with
+>      `**/*.{ts,tsx}` will wedge the scanner.
+>    - **Regex(es)** that match the shape. Skip test files
+>      (`.test.`, `.spec.`, `__tests__`, `_test.go`, etc.).
+>    - Save to `.deepsec/matchers/<slug>.ts`. Import types from
+>      `"deepsec/config"`.
+> 5. Wire the new matchers into the inline plugin in
+>    `.deepsec/deepsec.config.ts` (create the plugin if it doesn't
+>    exist yet).
+> 6. Run `pnpm deepsec scan --matchers <slug1>,<slug2>,…` from
+>    `.deepsec/` and report how many candidates each matcher fired.
+>    Open 3 candidates per matcher to spot-check the regex isn't
+>    producing obvious false positives.
+>
+> Bias toward `precise` when you can describe the bug exactly. Use
+> `noisy` deliberately when the goal is **entry-point coverage** —
+> you'd rather the AI look at every `**/api/**/route.ts` than rely on
+> a regex to predict which ones are vulnerable.
+>
+> Generalize the *shape* of the pattern, not specific identifiers. If
+> the repo's auth helper is `requireSession()`, the matcher should
+> catch any handler that doesn't call any session/auth helper, not the
+> literal string `requireSession`.
+
+## Noise tiers
+
+| Tier | When | Example |
+|---|---|---|
+| `precise` | Pattern is unambiguous. | `prisma-raw-sql`: `\$queryRawUnsafe\s*\(` matches only the unsafe API. |
+| `normal` | Pattern is broader; AI disambiguates. | `auth-bypass`: flags admin checks and skip-auth strings; AI judges. |
+| `noisy` | Every file matching a glob should be reviewed by the AI. | `service-entry-point`: every `**/api/**/route.ts` becomes a candidate. |
+
+Tier also influences ordering. `precise` candidates are processed
+first because they have the highest signal per token.
+
+## File globs
+
+Set `filePatterns` tightly. A noisy matcher with `**/*.{ts,tsx}`
+wedges the scanner on a 100k-file repo. Prefer:
+
+- Language-specific: `**/*.go`, `**/*.lua`, `**/*.tf`
+- Directory-anchored: `**/api/**/*.ts`, `**/services/**/handlers/*.ts`
+- Combined: `**/services/**/*.{ts,go}`
+
+## Tuning loop
+
+```bash
+pnpm deepsec scan --matchers <new-slug>
+```
+
+Watch the candidate count:
+- **0** → too strict, loosen.
+- **>100 in a small repo** → too loose, tighten.
+- Sweet spots: 1–20 hits per 1k files for `precise`; 5–100 for
+  `normal`. `noisy` matchers should match approximately the
+  entry-point count of the framework you targeted (10s, not 1000s).
+
+When happy, commit `.deepsec/deepsec.config.ts` and
+`.deepsec/matchers/`. The next full scan picks them up.
+
+## Where matchers should live: decision tree
+
+| Catches… | Where |
+|---|---|
+| Org-specific helper, package, or route layout | Your inline plugin (`.deepsec/matchers/`) |
+| Reference to a concrete internal service name | Your inline plugin |
+| A CWE shape the public set misses | Consider upstreaming |
+| A shape for a popular OSS framework (Hono, FastAPI, Drizzle) | Upstreaming benefits everyone |
+
+## Hard rules
+
+- **Never set `filePatterns: ["**/*.{ts,tsx}"]` on a `noisy` matcher.**
+  It will wedge the scanner on any non-trivial repo.
+- **Always skip test files in `match()`** with a `filePath` regex
+  (`.test.`, `.spec.`, `_test.go`, `__tests__`).
+- **Never hardcode a specific identifier when generalizing the shape**
+  is possible. Match "any handler that doesn't call any session/auth
+  helper", not `requireSession`.
+- **Spot-check 3 candidates per new matcher** before committing — a
+  loose regex that fires 500 times on a 2k-file repo will burn $100+
+  on the next `process` pass.

--- a/skills/deepsec-writing-plugins/SKILL.md
+++ b/skills/deepsec-writing-plugins/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: writing-deepsec-plugins
+description: Author a deepsec plugin — the contract for matchers, notifiers, ownership providers, people directories, and remote executors. Activates when the user wants to package matchers for sharing or wire deepsec into Slack, GitHub Issues, CODEOWNERS, an internal directory, or remote infrastructure.
+---
+
+# Writing a deepsec plugin
+
+A deepsec plugin can fill any of five slots:
+
+| Slot | Purpose |
+|---|---|
+| `matchers` | Additional regex matchers, registered alongside the built-ins |
+| `notifiers` | Where findings get reported (Slack, GitHub Issues, webhooks…) |
+| `ownership` | Map files to owning teams/people (e.g. an internal directory) |
+| `people` | Look up a person by email/name (managers, on-call, contact info) |
+| `executor` | Run a deepsec command on remote infrastructure |
+
+A single plugin can fill any subset.
+
+## The contract
+
+Source of truth: `packages/core/src/plugin.ts` (or
+`.deepsec/node_modules/deepsec/dist/config.d.ts` for the published
+types).
+
+```ts
+export interface DeepsecPlugin {
+  name: string;
+  matchers?: MatcherPlugin[];
+  notifiers?: NotifierPlugin[];
+  ownership?: OwnershipProvider;
+  people?: PeopleProvider;
+  executor?: ExecutorProvider;
+  agents?: AgentPluginRef[];
+  commands?: (program: unknown) => void;  // commander program
+}
+```
+
+Plugins are loaded from `deepsec.config.ts`:
+
+```ts
+import { defineConfig } from "deepsec/config";
+import myPlugin from "@my-org/deepsec-plugin";
+
+export default defineConfig({
+  projects: [{ id: "my-app", root: "../my-app" }],
+  plugins: [myPlugin({ /* options */ })],
+});
+```
+
+## Where to put your plugin
+
+- **Org-internal**: a workspace package inside `.deepsec/`, or a sibling
+  repo. pnpm/npm workspaces handle resolution.
+- **Shared**: publish to npm under your scope.
+- **Naming convention**: `@<scope>/plugin-<thing>` (Vite style), e.g.
+  `@my-org/plugin-internal-services`.
+
+## Slot 1: matchers (most common)
+
+Same shape as a built-in matcher. See `writing-deepsec-matchers` for
+how to author one.
+
+```ts
+// my-plugin/src/matchers/internal-rpc.ts
+import type { MatcherPlugin, CandidateMatch } from "deepsec/config";
+import { regexMatcher } from "deepsec/config";
+
+export const internalRpcMatcher: MatcherPlugin = {
+  slug: "internal-rpc-no-auth",
+  description: "Internal RPC handler without auth interceptor",
+  noiseTier: "precise",
+  filePatterns: ["**/*.go"],
+  match(content, filePath) {
+    return regexMatcher("internal-rpc-no-auth", [
+      { regex: /NewMyServiceHandler\s*\([^)]*\)/, label: "service handler" },
+    ], content);
+  },
+};
+```
+
+```ts
+// my-plugin/src/index.ts
+import type { DeepsecPlugin } from "deepsec/config";
+import { internalRpcMatcher } from "./matchers/internal-rpc.js";
+
+export default function myPlugin(): DeepsecPlugin {
+  return {
+    name: "@my-org/plugin-internal-services",
+    matchers: [internalRpcMatcher],
+  };
+}
+```
+
+```ts
+// deepsec.config.ts
+import myPlugin from "@my-org/plugin-internal-services";
+export default defineConfig({
+  projects: [/* … */],
+  plugins: [myPlugin()],
+});
+```
+
+Plugin matchers register alongside built-ins. **Slug collisions: the
+plugin wins** (last-registered overrides) — useful for swapping a
+built-in for a tighter org-specific version.
+
+## Slot 2: ownership
+
+Maps a file to the team or person that owns it. `deepsec enrich`
+attaches this to findings — useful for routing notifications and
+prioritizing review.
+
+```ts
+interface OwnershipProvider {
+  name: string;
+  fetchOwnership(args: {
+    filePath: string;
+    repo: string;
+  }): Promise<OwnershipData | null>;
+}
+```
+
+`OwnershipData` covers contributors, escalation teams, manager email,
+on-call info. Source of truth: `packages/core/src/types.ts:OwnershipData`.
+
+Return `null` when ownership data is unavailable; callers treat that
+as a soft-fail.
+
+A minimal ownership provider that reads from a `CODEOWNERS` file:
+
+```ts
+import type { OwnershipProvider } from "deepsec/config";
+import fs from "node:fs";
+
+export function codeownersProvider(rootPath: string): OwnershipProvider {
+  return {
+    name: "codeowners",
+    async fetchOwnership({ filePath }) {
+      // Parse CODEOWNERS, match filePath against globs, return
+      // the first matching team/email. Return null on no match.
+    },
+  };
+}
+```
+
+External plugins can wrap an internal directory or ownership oracle
+the same way.
+
+## Slot 3: people
+
+Looks up a person by email or name and returns their metadata
+(manager, slack handle, github username). Used by ownership and by
+notifiers for @-mentions and escalation.
+
+```ts
+interface PeopleProvider {
+  name: string;
+  lookup(query: string): Promise<Person | null>;
+  lookupManager?(person: Person): Promise<Person | null>;
+}
+```
+
+`Person` has a generic core (`name`, `email`, `title`, `managerKey`)
+plus an `extra` map for provider-specific fields (e.g. `slackId`,
+`slackHandle`).
+
+## Slot 4: notifiers
+
+Where findings get reported. Slack, GitHub Issues, webhooks, an
+internal incident system — whatever fits.
+
+```ts
+interface NotifierPlugin {
+  name: string;
+  notify(params: NotifyParams): Promise<FindingNotification>;
+}
+```
+
+`NotifyParams` carries the finding, the FileRecord, and the
+projectId. `FindingNotification` carries an `externalId` and
+`externalUrl` for correlation back to the source.
+
+deepsec doesn't ship a notifier in core. The original Slack notifier
+was removed during open-sourcing because Slack belongs in a plugin. A
+GitHub Issues notifier is a great first plugin to write.
+
+## Slot 5: executor
+
+Runs deepsec commands on remote infrastructure. The in-tree
+`@vercel/sandbox` executor is the canonical example. Docker,
+Kubernetes, and AWS-Batch executors all fit here.
+
+```ts
+interface ExecutorProvider {
+  name: string;
+  launch(req: ExecutorLaunchRequest, onLog: (m: string) => void): Promise<string>;  // runId
+  collect(runId: string): Promise<void>;
+  status?(runId: string): Promise<ExecutorStatus>;
+}
+```
+
+The Vercel-Sandbox path lives in `packages/deepsec/src/sandbox/`; it's
+not yet routed through `ExecutorProvider`. That refactor is on the
+roadmap — for now, this is the most experimental slot of the five.
+
+## Resolution order
+
+Plugins are evaluated in the order of the `plugins: [...]` array.
+
+- **`matchers`, `notifiers`, `agents`** — additive. All plugin
+  contributions stack.
+- **`ownership`, `people`, `executor`** — single-slot, last-wins. So a
+  generic `codeowners` ownership plugin can load first and an
+  org-specific oracle later in the array overrides it.
+
+## Testing your plugin
+
+Drop-in pattern:
+
+```ts
+// my-plugin/src/__tests__/plugin.test.ts
+import { describe, expect, it } from "vitest";
+import { createDefaultRegistry } from "deepsec/config";
+import myPlugin from "../index.js";
+
+describe("@my-org/plugin-internal-services", () => {
+  it("contributes the expected matchers", () => {
+    const plugin = myPlugin();
+    const slugs = plugin.matchers!.map(m => m.slug);
+    expect(slugs).toContain("internal-rpc-no-auth");
+  });
+
+  it("does not collide with built-ins", () => {
+    const built = new Set(createDefaultRegistry().slugs());
+    const plugin = myPlugin();
+    for (const m of plugin.matchers ?? []) {
+      // Either the slug is unique, or you're intentionally
+      // overriding. Document overrides loudly.
+    }
+  });
+});
+```
+
+## Hard rules
+
+- **Document slug collisions loudly.** A plugin matcher silently
+  overriding a built-in is a maintenance trap. If you intend to
+  override, comment why; if not, rename the slug.
+- **Return `null` on missing data, not a fake record.** Ownership /
+  people consumers treat `null` as a soft-fail; a partial fake breaks
+  notification routing.
+- **Don't put org-specific code in core.** If a matcher names an
+  internal helper or service, it belongs in a plugin, not upstreamed.

--- a/skills/deepsec-writing-plugins/SKILL.md
+++ b/skills/deepsec-writing-plugins/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: writing-deepsec-plugins
+name: deepsec-writing-plugins
 description: Author a deepsec plugin — the contract for matchers, notifiers, ownership providers, people directories, and remote executors. Activates when the user wants to package matchers for sharing or wire deepsec into Slack, GitHub Issues, CODEOWNERS, an internal directory, or remote infrastructure.
 ---
 

--- a/skills/deepsec-writing-plugins/SKILL.md
+++ b/skills/deepsec-writing-plugins/SKILL.md
@@ -58,7 +58,7 @@ export default defineConfig({
 
 ## Slot 1: matchers (most common)
 
-Same shape as a built-in matcher. See `writing-deepsec-matchers` for
+Same shape as a built-in matcher. See `deepsec-writing-matchers` for
 how to author one.
 
 ```ts

--- a/skills/deepsec/SKILL.md
+++ b/skills/deepsec/SKILL.md
@@ -22,8 +22,8 @@ For specific subtasks, prefer the focused sibling skills:
 | User intent | Skill |
 |---|---|
 | First scan, install, getting started | `deepsec-getting-started` |
-| Add a regex matcher for a missed pattern | `writing-deepsec-matchers` |
-| Author a plugin (matchers/notifiers/ownership/people/executor) | `writing-deepsec-plugins` |
+| Add a regex matcher for a missed pattern | `deepsec-writing-matchers` |
+| Author a plugin (matchers/notifiers/ownership/people/executor) | `deepsec-writing-plugins` |
 | PR review / CI gating with `process --diff` | `deepsec-pr-review` |
 | `deepsec.config.ts` reference | `deepsec-configuration` |
 | Pick an agent / model, handle refusals | `deepsec-models` |
@@ -77,14 +77,14 @@ pnpm deepsec export --format md-dir --out ./findings
 ## How to answer common questions
 
 - **"How do I run a scan?"** → `deepsec-getting-started`.
-- **"How do I add a matcher?"** → `writing-deepsec-matchers`.
+- **"How do I add a matcher?"** → `deepsec-writing-matchers`.
 - **"How do I review PRs in CI?"** → `deepsec-pr-review`.
 - **"What goes in `deepsec.config.ts`?"** → `deepsec-configuration`.
 - **"Claude or Codex? Which model?"** → `deepsec-models`.
 - **"How do I get an AI Gateway / Sandbox token?"** → `deepsec-sandbox-setup`.
 - **"What's in `data/<id>/files/foo.json`?"** → `deepsec-data-layout`.
 - **"What does deepsec actually do under the hood?"** → `deepsec-architecture`.
-- **"How do I write a plugin?"** → `writing-deepsec-plugins`.
+- **"How do I write a plugin?"** → `deepsec-writing-plugins`.
 
 ## Hard rules
 

--- a/skills/deepsec/SKILL.md
+++ b/skills/deepsec/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: deepsec
+description: Use deepsec, the AI-powered vulnerability scanner — running scans, configuring projects, reading findings, writing matchers, and authoring plugins. Activates when the user asks how to scan, configure, or extend deepsec.
+---
+
+# deepsec
+
+`deepsec` is an AI-powered vulnerability scanner that runs in your own
+infrastructure and is optimized for on-demand review of large existing
+repos. It uses the strongest available reasoning models at maximum
+thinking levels — full scans on real codebases routinely cost hundreds
+to thousands of dollars. Treat cost as the main constraint.
+
+## When this skill applies
+
+Activate this skill whenever the user mentions deepsec, asks how to
+scan a repo for vulnerabilities with AI, or works inside a `.deepsec/`
+directory.
+
+For specific subtasks, prefer the focused sibling skills:
+
+| User intent | Skill |
+|---|---|
+| First scan, install, getting started | `deepsec-getting-started` |
+| Add a regex matcher for a missed pattern | `writing-deepsec-matchers` |
+| Author a plugin (matchers/notifiers/ownership/people/executor) | `writing-deepsec-plugins` |
+| PR review / CI gating with `process --diff` | `deepsec-pr-review` |
+| `deepsec.config.ts` reference | `deepsec-configuration` |
+| Pick an agent / model, handle refusals | `deepsec-models` |
+| AI Gateway or Vercel Sandbox auth | `deepsec-sandbox-setup` |
+| Read `data/<id>/files/*.json` directly | `deepsec-data-layout` |
+| Pipeline internals, on-disk shape, design choices | `deepsec-architecture` |
+
+## Pipeline at a glance
+
+```
+scan → process → revalidate → enrich → export
+```
+
+| Command | What it does | Cost |
+|---|---|---|
+| `scan` | Run regex matchers, write `candidates` to FileRecords. | Free, ~15s for 2k files. |
+| `process` | AI investigates each candidate; emits `findings`. | $$ — the expensive stage. |
+| `process --diff <ref>` | Same, but only over files changed in a diff. CI-friendly. | $ |
+| `triage` | Classifies findings P0/P1/P2/skip. | ~1¢/finding. |
+| `revalidate` | Re-checks findings; emits TP/FP/Fixed/Uncertain. Cuts FP by 50%+. | $$ |
+| `enrich` | Attach git committers + (with plugin) ownership. | Free / 1 RTT/file. |
+| `export` | Findings as JSON or `md-dir`. | Free. |
+| `metrics` | Cross-project counts and TP rates. | Free. |
+| `status` | Project mirror snapshot. | Free. |
+| `sandbox <cmd>` | Run any of the above on Vercel Sandbox microVMs. | Same as above + sandbox time. |
+
+The pipeline is **idempotent and resumable**. If `process` halts (Ctrl-C,
+network blip, quota exhaustion), re-run the same command — files already
+analyzed are skipped, only the unfinished ones get picked up. No flag,
+no state cleanup.
+
+## Quick recipe
+
+```bash
+# From the root of the codebase you want to scan:
+npx deepsec init       # creates .deepsec/, registers this repo
+cd .deepsec
+pnpm install
+
+# Set AI_GATEWAY_API_KEY=vck_… in .env.local (or VERCEL_OIDC_TOKEN, or
+# ANTHROPIC_AUTH_TOKEN). Hand-write data/<id>/INFO.md or have your
+# coding agent fill it (the init command prints a prompt).
+
+pnpm deepsec scan
+pnpm deepsec process --limit 50      # cheap calibration first
+pnpm deepsec process                  # full pass
+pnpm deepsec revalidate --min-severity HIGH
+pnpm deepsec export --format md-dir --out ./findings
+```
+
+## How to answer common questions
+
+- **"How do I run a scan?"** → `deepsec-getting-started`.
+- **"How do I add a matcher?"** → `writing-deepsec-matchers`.
+- **"How do I review PRs in CI?"** → `deepsec-pr-review`.
+- **"What goes in `deepsec.config.ts`?"** → `deepsec-configuration`.
+- **"Claude or Codex? Which model?"** → `deepsec-models`.
+- **"How do I get an AI Gateway / Sandbox token?"** → `deepsec-sandbox-setup`.
+- **"What's in `data/<id>/files/foo.json`?"** → `deepsec-data-layout`.
+- **"What does deepsec actually do under the hood?"** → `deepsec-architecture`.
+- **"How do I write a plugin?"** → `writing-deepsec-plugins`.
+
+## Hard rules
+
+- **Never paraphrase the CLI flag set or plugin contract from memory.**
+  Open the relevant focused skill first. Flags, defaults, and field
+  names change.
+- **Never run `process` against a large repo without a `--limit 50`
+  calibration pass first.** Full passes routinely cost hundreds of
+  dollars; the user must see the cost shape before committing.
+- **Never commit `data/*/files/` or `data/*/runs/`** — gitignored by
+  default; that's intentional.
+- **Treat `INFO.md` as load-bearing.** A blank or generic INFO.md
+  noticeably hurts AI precision. If the user is about to run `process`
+  on a fresh project and INFO.md is the template, recommend filling it
+  first (or pasting the agent prompt that `deepsec init` prints).


### PR DESCRIPTION
## What changed

Added `skills/` with 10 self-contained `SKILL.md` files covering every major deepsec topic, installable via `npx skills add vercel-labs/deepsec`.

## Why

Coding agents have no structured way to learn deepsec's CLI flags, plugin contracts, or config shape. The `npx skills` ecosystem fixes this — one install gives any agent accurate deepsec context. Skills are self-contained copies so they work without the deepsec repo on disk.

## Verification checklist

- [x] `pnpm test` passes
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [x] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

No changes to `packages/`, skills only. The two-job GitHub Actions pattern in `deepsec-pr-review` (analyze + comment split) is intentional: the job running PR code never gets `pull-requests: write`.
