### PR TITLE
Add Ollama support to the codex backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,13 @@ ANTHROPIC_BASE_URL=https://ai-gateway.vercel.sh
 # unset and Codex will fall back to ANTHROPIC_AUTH_TOKEN.
 OPENAI_API_KEY=
 OPENAI_BASE_URL=https://ai-gateway.vercel.sh/v1
+
+# Ollama (optional). Pass --ollama on `process` / `revalidate` to route
+# the codex backend at Ollama instead of AI Gateway. With OLLAMA_API_KEY
+# set the request goes to Ollama Cloud (https://ollama.com/v1); without
+# it, the local daemon at http://localhost:11434/v1 (overridable via
+# OLLAMA_HOST).
+OLLAMA_API_KEY=
+# OLLAMA_HOST=http://localhost:11434
+
+

--- a/docs/models.md
+++ b/docs/models.md
@@ -36,6 +36,27 @@ pnpm deepsec triage --project-id my-app --model claude-haiku-4-5
 default backend project-wide via `defaultAgent` in
 [`deepsec.config.ts`](configuration.md).
 
+## Ollama (`--ollama`)
+
+`process` and `revalidate` take `--ollama` to flip the codex backend
+onto codex's built-in `ollama` provider, which is the same path codex
+uses for `codex --oss`. The model name controls where the request
+goes: a `:cloud` suffix hits Ollama Cloud (needs `OLLAMA_API_KEY`),
+anything else hits your local daemon at `http://localhost:11434`
+(override with `OLLAMA_HOST`).
+
+```bash
+# Ollama Cloud (turbo)
+OLLAMA_API_KEY=... pnpm deepsec process --agent codex \
+  --model gpt-oss:120b-cloud --ollama
+
+# Local Ollama daemon (run `ollama serve` first)
+pnpm deepsec process --agent codex --model gpt-oss:120b --ollama
+```
+
+Same flag works on `revalidate`. `DEEPSEC_OLLAMA=1` is the env-var
+equivalent if you'd rather not retype the flag.
+
 ## Why these defaults
 
 ### `claude-opus-4-7` for `process` and `revalidate`

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -115,6 +115,17 @@ describe("assertAgentCredential", () => {
     expect(() => assertAgentCredential("codex")).toThrow(/AI_GATEWAY_API_KEY/);
   });
 
+  it("passes for codex with no creds when DEEPSEC_OLLAMA is set", () => {
+    const prev = process.env.DEEPSEC_OLLAMA;
+    process.env.DEEPSEC_OLLAMA = "1";
+    try {
+      expect(() => assertAgentCredential("codex")).not.toThrow();
+    } finally {
+      if (prev === undefined) delete process.env.DEEPSEC_OLLAMA;
+      else process.env.DEEPSEC_OLLAMA = prev;
+    }
+  });
+
   it("skips the credential check for custom plugin agents", () => {
     // Tests use this so a stub agent registered via plugins[] doesn't
     // require fake ANTHROPIC_AUTH_TOKEN env vars.

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -138,6 +138,10 @@ program
     "--model <model>",
     "Model to use (default: claude-opus-4-7 for claude, gpt-5.5 for codex)",
   )
+  .option(
+    "--ollama",
+    "Route the codex backend at Ollama instead of AI Gateway. Uses Ollama Cloud (https://ollama.com/v1) when OLLAMA_API_KEY is set, the local daemon (http://localhost:11434/v1) otherwise. Codex backend only.",
+  )
   .option("--max-turns <n>", "Max conversation turns per batch (default: 150)", parseInt)
   .option(
     "--reinvestigate [n]",
@@ -197,6 +201,10 @@ program
   .option(
     "--model <model>",
     "Model to use (default: claude-opus-4-7 for claude, gpt-5.5 for codex)",
+  )
+  .option(
+    "--ollama",
+    "Route the codex backend at Ollama instead of AI Gateway. Uses Ollama Cloud (https://ollama.com/v1) when OLLAMA_API_KEY is set, the local daemon (http://localhost:11434/v1) otherwise. Codex backend only.",
   )
   .option("--max-turns <n>", "Max conversation turns per batch (default: 150)", parseInt)
   .option(

--- a/packages/deepsec/src/commands/process.ts
+++ b/packages/deepsec/src/commands/process.ts
@@ -79,6 +79,7 @@ export async function processCommand(opts: {
   runId?: string;
   agent?: string;
   model?: string;
+  ollama?: boolean;
   maxTurns?: number;
   /** Commander yields `true` when bare; string (unparsed) when an arg is provided */
   reinvestigate?: boolean | string;
@@ -100,6 +101,7 @@ export async function processCommand(opts: {
   ignore?: boolean;
   commentOut?: string;
 }) {
+  if (opts.ollama) process.env.DEEPSEC_OLLAMA = "1";
   const isDirectMode =
     opts.diff !== undefined ||
     !!opts.diffStaged ||

--- a/packages/deepsec/src/commands/revalidate.ts
+++ b/packages/deepsec/src/commands/revalidate.ts
@@ -58,6 +58,7 @@ export async function revalidateCommand(opts: {
   runId?: string;
   agent?: string;
   model?: string;
+  ollama?: boolean;
   maxTurns?: number;
   minSeverity?: string;
   force?: boolean;
@@ -70,6 +71,7 @@ export async function revalidateCommand(opts: {
   onlySlugs?: string;
   skipSlugs?: string;
 }) {
+  if (opts.ollama) process.env.DEEPSEC_OLLAMA = "1";
   const projectId = resolveProjectId(opts.projectId);
   const _project = readProjectConfig(projectId);
   const agentType = resolveAgentType(opts.agent);

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -165,6 +165,9 @@ export function assertAgentCredential(
   const openai = process.env.OPENAI_API_KEY;
 
   if (isCodex(agentType)) {
+    // --ollama bypasses OpenAI/AI Gateway; codex's built-in ollama provider handles its own auth.
+    const ollama = process.env.DEEPSEC_OLLAMA?.trim().toLowerCase();
+    if (ollama === "1" || ollama === "true") return;
     // Codex prefers OPENAI_API_KEY; AI Gateway issues a single token that
     // authenticates both backends, so an ANTHROPIC token is also accepted.
     if (openai || anthropic) return;
@@ -173,6 +176,7 @@ export function assertAgentCredential(
       `Missing AI credentials for --agent codex.\n` +
         `\n` +
         `  Add to .env.local:    AI_GATEWAY_API_KEY=vck_…   (or OPENAI_API_KEY=…)\n` +
+        `  Or use --ollama for local Ollama or Ollama Cloud (OLLAMA_API_KEY).\n` +
         `  Setup: ${SETUP_DOC_URL}`,
     );
   }

--- a/packages/processor/src/agents/codex-sdk.ts
+++ b/packages/processor/src/agents/codex-sdk.ts
@@ -68,6 +68,13 @@ function pickSandboxMode(): "danger-full-access" | "workspace-write" {
  */
 const CUSTOM_PROVIDER_ID = "ai_gateway";
 
+// Set by the `--ollama` CLI flag (DEEPSEC_OLLAMA=1). Explicit opt-in
+// only; we don't autodetect Ollama from the model name.
+function ollamaRequested(): boolean {
+  const v = process.env.DEEPSEC_OLLAMA?.trim().toLowerCase();
+  return v === "1" || v === "true";
+}
+
 /**
  * The codex CLI persists thread state to `$CODEX_HOME/sessions/` (defaulting
  * to `~/.codex`). Multiple concurrent codex CLI processes within one host
@@ -160,6 +167,10 @@ let cachedPaths: { wrapper: string; realBin: string } | null = null;
 
 function resolveCodexPaths(): { wrapper: string; realBin: string } | null {
   if (cachedPaths) return cachedPaths;
+  // codex SDK calls plain spawn() with no shell:true. On Windows that
+  // rejects .sh (EFTYPE) and Node's BatBadBut fix rejects .cmd
+  // (EINVAL). Fall through to codex.exe; stderr capture goes inert.
+  if (process.platform === "win32") return null;
   try {
     const here = path.dirname(fileURLToPath(import.meta.url));
     // Wrapper sits next to the source. After tsc, the .js lives in dist/
@@ -225,6 +236,8 @@ const CODEX_ENV_ALLOWLIST = new Set<string>([
   "RUST_BACKTRACE",
   // Codex itself
   "CODEX_HOME",
+  // OLLAMA_API_KEY is forwarded explicitly via `extras` only in Ollama mode.
+  "OLLAMA_HOST",
   // Our wrapper
   "CODEX_REAL_BIN",
   "CODEX_STDERR_LOG",
@@ -276,9 +289,11 @@ function buildCodexInvocation(): CodexInvocation {
   // (no token but the user has run `codex login` on this machine — let
   // codex use its default openai provider against their session). Sandbox
   // workers always go gateway; the preflight ensures a token is present
-  // before we ever get here in that path.
+  // before we ever get here in that path. `--ollama` is a third mode
+  // that bypasses both and selects codex's built-in `ollama` provider.
+  const ollamaMode = ollamaRequested();
   const haveApiToken = !!(process.env.OPENAI_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN);
-  const subscriptionHome = haveApiToken ? null : findCodexSubscriptionAuth();
+  const subscriptionHome = ollamaMode || haveApiToken ? null : findCodexSubscriptionAuth();
 
   const codexHome = makeCodexHome();
   if (subscriptionHome) {
@@ -310,6 +325,19 @@ function buildCodexInvocation(): CodexInvocation {
     // delete is needed.
     const env = buildCodexEnv(extras);
     const options: CodexOptions = { env };
+    if (codexPathOverride) options.codexPathOverride = codexPathOverride;
+    return { options, stderrLog, codexHome };
+  }
+
+  if (ollamaMode) {
+    // codex 0.125 ships a built-in `ollama` provider; selecting it is
+    // the SDK equivalent of `codex --oss`. The provider routes
+    // local-daemon vs Ollama Cloud via the model name's `:cloud` suffix.
+    if (process.env.OLLAMA_API_KEY) extras.OLLAMA_API_KEY = process.env.OLLAMA_API_KEY;
+    const options: CodexOptions = {
+      config: { model_provider: "ollama" },
+      env: buildCodexEnv(extras),
+    };
     if (codexPathOverride) options.codexPathOverride = codexPathOverride;
     return { options, stderrLog, codexHome };
   }


### PR DESCRIPTION

Added a `--ollama` flag to `process` and `revalidate` (`DEEPSEC_OLLAMA=1` is the env equivalent). When set, the codex backend selects codex 0.125's built-in `ollama` provider instead of routing through Vercel AI Gateway.

## Why

Lets you run deepsec against local Ollama or Ollama Cloud without an AI Gateway token. The codex CLI already supports this via `--oss`; this flag exposes the same path through the SDK so you don't have to edit `~/.codex/config.toml` or wrap codex yourself.

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [x] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

Typecheck and knip pass. `pnpm lint` (325 errors) and `pnpm test:unit` (11 failures in prompt-samples) reproduce on `main` too, so they're CRLF drift from my Windows checkout, not from this PR.

Tested on Ollama Cloud with `--model gpt-oss:120b-cloud --ollama` and `OLLAMA_API_KEY` set. Codex picked the Ollama provider and the investigation ran through. I didn't actually test the local daemon path on this branch, but it goes through the same `model_provider = "ollama"` selection so it should work the same way.

## Notes for reviewer

- Codex 0.125 reserves `ollama` as a built-in provider name and rejects any attempt to redefine it under `model_providers`. We just set `model_provider = "ollama"` and let the built-in handle local-vs-cloud routing via the `:cloud` model suffix. No custom provider, no `wire_api`, no base URL hardcoded on our side.
- Subscription mode (the `codex login` ChatGPT auth path) is skipped when `--ollama` is on so the ChatGPT session can't compete with the Ollama provider for the request.
- `OLLAMA_API_KEY` and `OLLAMA_HOST` get forwarded to the codex child env. Everything else still goes through the existing allowlist, so there's no new credential surface area.
- Side note: `resolveCodexPaths()` now returns null on Windows. The codex SDK calls plain `spawn()` with no `shell: true`, which Node refuses for `.sh` (EFTYPE) and for `.cmd` (Node's BatBadBut CVE fix gives EINVAL). The wrapper never worked on Windows; this just makes the skip explicit so `codex.exe` runs directly. Stderr capture still works on Linux/macOS.