### PR TITLE
fix(scanner): error on unknown --matchers slugs

### DIFF
--- a/packages/scanner/src/__tests__/scan-files.test.ts
+++ b/packages/scanner/src/__tests__/scan-files.test.ts
@@ -103,4 +103,16 @@ describe("scanFiles()", () => {
     const after = readFileRecord(projectId, "src/x.ts")!;
     expect(after.candidates.length).toBe(candCountBefore);
   });
+
+  it("throws on unknown matcher slugs", async () => {
+    const { root, projectId } = makeProject({ "a.ts": "x\n" });
+    await expect(
+      scanFiles({
+        projectId,
+        root,
+        filePaths: ["a.ts"],
+        matcherSlugs: ["xss", "does-not-exist", "also-fake"],
+      }),
+    ).rejects.toThrow(/Unknown matcher slugs: does-not-exist, also-fake/);
+  });
 });

--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -434,6 +434,17 @@ export async function scan(params: {
   languageStats: LanguageStats[];
 }> {
   const registry = buildMergedRegistry();
+
+  if (params.matcherSlugs) {
+    const unknown = registry.unknownSlugs(params.matcherSlugs);
+    if (unknown.length > 0) {
+      throw new Error(
+        `Unknown matcher slug${unknown.length > 1 ? "s" : ""}: ${unknown.join(", ")}.\n` +
+          `  Available matchers: ${registry.slugs().sort().join(", ")}`,
+      );
+    }
+  }
+
   const allSelected = params.matcherSlugs
     ? registry.getBySlugs(params.matcherSlugs)
     : registry.getAll();
@@ -619,6 +630,17 @@ export async function scanFiles(params: {
   skippedMatchers: string[];
 }> {
   const registry = buildMergedRegistry();
+
+  if (params.matcherSlugs) {
+    const unknown = registry.unknownSlugs(params.matcherSlugs);
+    if (unknown.length > 0) {
+      throw new Error(
+        `Unknown matcher slug${unknown.length > 1 ? "s" : ""}: ${unknown.join(", ")}.\n` +
+          `  Available matchers: ${registry.slugs().sort().join(", ")}`,
+      );
+    }
+  }
+
   const allSelected = params.matcherSlugs
     ? registry.getBySlugs(params.matcherSlugs)
     : registry.getAll();

--- a/packages/scanner/src/matcher-registry.ts
+++ b/packages/scanner/src/matcher-registry.ts
@@ -21,6 +21,11 @@ export class MatcherRegistry {
       .filter((m): m is MatcherPlugin => m !== undefined);
   }
 
+  /** Returns slug strings from `requested` that don't exist in the registry. */
+  unknownSlugs(requested: string[]): string[] {
+    return requested.filter((s) => !this.matchers.has(s));
+  }
+
   slugs(): string[] {
     return Array.from(this.matchers.keys());
   }


### PR DESCRIPTION
## Summary
- Adds `unknownSlugs()` method to `MatcherRegistry`
- Both `scan()` and `scanFiles()` now validate requested slugs before running
- Throws a clear error naming the unknown slugs and listing all available matchers

## Reproduction (from #34)
```bash
deepsec scan --matchers xss,does-not-exist
```

**Before:** silently runs only `xss`, exits 0
**After:** throws `Unknown matcher slug: does-not-exist` with the full available matcher list

## Test plan
- [x] Added regression test in `scan-files.test.ts`
- [ ] `pnpm test:unit`
- [ ] `pnpm lint`

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)