### PR TITLE
Make sure that crashes during processing get picked up on next run

### DIFF
--- a/packages/core/src/__tests__/run.test.ts
+++ b/packages/core/src/__tests__/run.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { createRunMeta, ensureProject, generateRunId } from "../run.js";
+import { createRunMeta, ensureProject, generateRunId, isPidAlive } from "../run.js";
 
 describe("generateRunId", () => {
   it("returns a string with timestamp and suffix", () => {
@@ -47,6 +47,29 @@ describe("createRunMeta", () => {
 
     expect(meta.type).toBe("process");
     expect(meta.processorConfig?.agentType).toBe("claude-agent-sdk");
+  });
+
+  it("captures pid and hostname for crash recovery", () => {
+    const meta = createRunMeta({
+      projectId: "test",
+      rootPath: "/tmp",
+      type: "process",
+    });
+    expect(meta.pid).toBe(process.pid);
+    expect(meta.hostname).toBe(os.hostname());
+  });
+});
+
+describe("isPidAlive", () => {
+  it("returns true for the current process", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  it("returns false for a PID that does not exist", () => {
+    // PID 0x7fffffff is well outside the kernel's pid_max on every
+    // platform we run on, so the kernel can't possibly be tracking a
+    // live process at that number — process.kill(pid, 0) gives ESRCH.
+    expect(isPidAlive(0x7fffffff)).toBe(false);
   });
 });
 

--- a/packages/core/src/__tests__/shutdown.test.ts
+++ b/packages/core/src/__tests__/shutdown.test.ts
@@ -1,0 +1,170 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../../");
+const TSX = path.join(REPO_ROOT, "node_modules/.bin/tsx");
+const REGISTER_HOOK = path.resolve(__dirname, "../run.ts");
+
+/**
+ * Spawn a child node that:
+ *   1. Writes a "running" RunMeta to a temp data dir.
+ *   2. Calls `registerActiveRun(...)` so the shutdown handler is installed.
+ *   3. Prints "READY" and idles via setInterval.
+ *
+ * The test then sends the requested signal and waits for exit, with a
+ * hard timeout so a regression (handler suppresses default termination
+ * without providing an exit path → hang) shows up as a clear failure
+ * instead of a hung suite.
+ */
+function spawnShutdownChild(opts: {
+  dataRoot: string;
+  projectId: string;
+  runId: string;
+}): Promise<{ child: ReturnType<typeof spawn>; ready: Promise<void> }> {
+  const script = `
+    import { registerActiveRun } from ${JSON.stringify(REGISTER_HOOK)};
+    registerActiveRun(${JSON.stringify(opts.projectId)}, ${JSON.stringify(opts.runId)});
+    process.stdout.write("READY\\n");
+    // Keep the event loop alive so SIGINT actually has work to do.
+    setInterval(() => {}, 1000);
+  `;
+  const child = spawn(TSX, ["-e", script], {
+    env: { ...process.env, DEEPSEC_DATA_ROOT: opts.dataRoot },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const ready = new Promise<void>((resolve, reject) => {
+    let buf = "";
+    child.stdout.on("data", (chunk) => {
+      buf += chunk.toString();
+      if (buf.includes("READY")) resolve();
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (!buf.includes("READY")) {
+        reject(new Error(`child exited before READY (code=${code} signal=${signal})`));
+      }
+    });
+  });
+  return Promise.resolve({ child, ready });
+}
+
+function waitForExit(
+  child: ReturnType<typeof spawn>,
+  timeoutMs: number,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`child did not exit within ${timeoutMs}ms (hang)`));
+    }, timeoutMs);
+    child.on("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+function writeRunningMeta(opts: { dataRoot: string; projectId: string; runId: string }): void {
+  const runsDir = path.join(opts.dataRoot, opts.projectId, "runs");
+  fs.mkdirSync(runsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(runsDir, `${opts.runId}.json`),
+    JSON.stringify({
+      runId: opts.runId,
+      projectId: opts.projectId,
+      rootPath: "/tmp",
+      createdAt: new Date().toISOString(),
+      type: "process",
+      phase: "running",
+      stats: {},
+    }),
+  );
+}
+
+describe("shutdown handler exit path", () => {
+  it("exits the process on SIGINT when no other handler is installed", async () => {
+    // The regression this guards: attaching a SIGINT listener
+    // suppresses Node's default termination. If the listener doesn't
+    // call process.exit, the process hangs after Ctrl+C.
+    const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-shutdown-"));
+    const projectId = "test-proj";
+    const runId = "20260101000000-aaaaaaaaaaaaaaaa";
+    writeRunningMeta({ dataRoot, projectId, runId });
+
+    const { child, ready } = await spawnShutdownChild({ dataRoot, projectId, runId });
+    await ready;
+    child.kill("SIGINT");
+    const { code } = await waitForExit(child, 5000);
+    expect(code).toBe(130);
+
+    // And the run should have been flipped to error by the handler.
+    const meta = JSON.parse(
+      fs.readFileSync(path.join(dataRoot, projectId, "runs", `${runId}.json`), "utf-8"),
+    );
+    expect(meta.phase).toBe("error");
+  });
+
+  it("exits the process on SIGTERM when no other handler is installed", async () => {
+    const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-shutdown-"));
+    const projectId = "test-proj";
+    const runId = "20260101000000-bbbbbbbbbbbbbbbb";
+    writeRunningMeta({ dataRoot, projectId, runId });
+
+    const { child, ready } = await spawnShutdownChild({ dataRoot, projectId, runId });
+    await ready;
+    child.kill("SIGTERM");
+    const { code } = await waitForExit(child, 5000);
+    expect(code).toBe(143);
+  });
+
+  it("defers exit when another SIGINT listener is installed", async () => {
+    // When another handler is registered (the sandbox shutdown handler
+    // in the real CLI), our handler must NOT exit — that handler needs
+    // async cleanup time and will exit itself. We simulate the
+    // co-listener with a dummy that exits with a sentinel code so the
+    // test can tell whose exit path fired.
+    const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-shutdown-"));
+    const projectId = "test-proj";
+    const runId = "20260101000000-cccccccccccccccc";
+    writeRunningMeta({ dataRoot, projectId, runId });
+
+    const script = `
+      import { registerActiveRun } from ${JSON.stringify(REGISTER_HOOK)};
+      registerActiveRun(${JSON.stringify(projectId)}, ${JSON.stringify(runId)});
+      // Install a co-listener that takes ownership of exit, like the
+      // sandbox shutdown handler does in production.
+      process.on("SIGINT", () => {
+        // Give the core handler a chance to run first, then exit
+        // with a sentinel code that proves WE owned the exit path.
+        setTimeout(() => process.exit(42), 50);
+      });
+      process.stdout.write("READY\\n");
+      setInterval(() => {}, 1000);
+    `;
+    const child = spawn(TSX, ["-e", script], {
+      env: { ...process.env, DEEPSEC_DATA_ROOT: dataRoot },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await new Promise<void>((resolve, reject) => {
+      let buf = "";
+      child.stdout.on("data", (c) => {
+        buf += c.toString();
+        if (buf.includes("READY")) resolve();
+      });
+      child.on("error", reject);
+    });
+    child.kill("SIGINT");
+    const { code } = await waitForExit(child, 5000);
+    // Sentinel proves the OTHER listener exited the process, not ours.
+    expect(code).toBe(42);
+
+    // And the run was still flipped to error by the core handler.
+    const meta = JSON.parse(
+      fs.readFileSync(path.join(dataRoot, projectId, "runs", `${runId}.json`), "utf-8"),
+    );
+    expect(meta.phase).toBe("error");
+  });
+});

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -109,11 +109,34 @@ export function createRunMeta(params: {
     createdAt: new Date().toISOString(),
     type: params.type,
     phase: "running",
+    pid: process.pid,
+    hostname: os.hostname(),
     scannerConfig: params.scannerConfig,
     processorConfig: params.processorConfig,
     stats: {},
   };
   return meta;
+}
+
+/**
+ * Best-effort PID liveness check. `process.kill(pid, 0)` doesn't actually
+ * signal the process — it just probes whether the kernel would deliver a
+ * signal. ESRCH means "no such process" (genuinely dead). EPERM means the
+ * PID exists but is owned by a different user, which on a single-user
+ * developer machine effectively never happens; we treat it as "alive" to
+ * stay on the safe side. Returns `true` on any other failure for the same
+ * reason — false-positive reclaims clobber findings, false negatives just
+ * cost a retry on the next run.
+ */
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return false;
+    return true;
+  }
 }
 
 export function writeRunMeta(meta: RunMeta): void {
@@ -139,6 +162,84 @@ export function completeRun(
   meta.completedAt = new Date().toISOString();
   if (stats) Object.assign(meta.stats, stats);
   writeRunMeta(meta);
+}
+
+// --- Run-level shutdown handling ---
+//
+// Why this exists: when the CLI gets Ctrl+C'd (SIGINT) or killed
+// (SIGTERM), the long-running `process()` / `revalidate()` body exits
+// without reaching its `completeRun(..., "done")` call. The run's
+// RunMeta stays at `phase: "running"` forever, and every file the run
+// claimed stays at `status: "processing"` with that run's lockedByRunId.
+// The lock-reclaim logic only treats such locks as reclaimable after
+// `STALE_LOCK_MS` (1h), so files are effectively stuck for an hour.
+//
+// We fix the graceful-shutdown case (~99% of interruptions) by flipping
+// the run to `phase: "error"` from a SIGINT/SIGTERM handler. That single
+// synchronous write makes every claimed file immediately reclaimable on
+// the next invocation. Hard kills (SIGKILL / OOM / power) bypass this
+// handler, but those are covered by the PID-liveness check in
+// `isReclaimableLock`.
+const activeRuns = new Map<string, { projectId: string; runId: string }>();
+let shutdownHandlersInstalled = false;
+
+function flushActiveRuns(): void {
+  // Snapshot to a fresh array — completeRun's read+write can throw if
+  // the meta file was already cleaned up, and we don't want one bad
+  // entry to skip the rest.
+  for (const { projectId, runId } of [...activeRuns.values()]) {
+    try {
+      // Only flip if the run is still "running". Sequential
+      // process()/revalidate() calls in the same node process may
+      // leave already-completed entries in the Map if the caller
+      // forgets to unregister; flipping those would corrupt their
+      // phase ("done" → "error").
+      const meta = readRunMeta(projectId, runId);
+      if (meta.phase !== "running") continue;
+      completeRun(projectId, runId, "error");
+    } catch {
+      // best-effort
+    }
+  }
+  activeRuns.clear();
+}
+
+function installShutdownHandlers(): void {
+  if (shutdownHandlersInstalled) return;
+  shutdownHandlersInstalled = true;
+  const handler = () => {
+    flushActiveRuns();
+    // Do NOT call process.exit here — other listeners (e.g. the
+    // sandbox shutdown handler in `deepsec/sandbox/shutdown.ts`) need
+    // to run their own cleanup before the process actually terminates.
+    // Node will exit naturally once all signal listeners return and no
+    // active work remains, or the sandbox handler's exit() will fire.
+  };
+  process.on("SIGINT", handler);
+  process.on("SIGTERM", handler);
+  // beforeExit covers the case where a thrown error bubbles out of
+  // `process()` / `revalidate()` without `unregisterActiveRun` being
+  // called — without this, the run would be stranded at `phase:
+  // "running"` even though the node process is on its way out.
+  process.on("beforeExit", flushActiveRuns);
+}
+
+/**
+ * Register a run so that SIGINT/SIGTERM marks it as `phase: "error"`
+ * before the process exits. Call `unregisterActiveRun` (returned) when
+ * the run completes normally — leaving stale entries would cause us to
+ * try to error-flip already-completed runs at process exit.
+ */
+export function registerActiveRun(projectId: string, runId: string): () => void {
+  installShutdownHandlers();
+  const key = `${projectId}::${runId}`;
+  activeRuns.set(key, { projectId, runId });
+  let unregistered = false;
+  return () => {
+    if (unregistered) return;
+    unregistered = true;
+    activeRuns.delete(key);
+  };
 }
 
 export function listRuns(projectId: string): RunMeta[] {

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -207,13 +207,23 @@ function flushActiveRuns(): void {
 function installShutdownHandlers(): void {
   if (shutdownHandlersInstalled) return;
   shutdownHandlersInstalled = true;
-  const handler = () => {
+  const handler = (signal: NodeJS.Signals) => {
     flushActiveRuns();
-    // Do NOT call process.exit here — other listeners (e.g. the
-    // sandbox shutdown handler in `deepsec/sandbox/shutdown.ts`) need
-    // to run their own cleanup before the process actually terminates.
-    // Node will exit naturally once all signal listeners return and no
-    // active work remains, or the sandbox handler's exit() will fire.
+    // Attaching a listener for SIGINT/SIGTERM suppresses Node's
+    // default termination, so we have to provide an exit path
+    // ourselves or the process hangs after Ctrl+C. When another
+    // listener is also registered (e.g. the sandbox shutdown handler
+    // in `deepsec/sandbox/shutdown.ts`), defer to it — that handler
+    // needs async cleanup time and calls process.exit() itself once
+    // its sandboxes have stopped (or its 10s timeout fires).
+    //
+    // listenerCount counts the currently-executing handler too, so
+    // "1" means we're the only listener.
+    if (process.listenerCount(signal) <= 1) {
+      // Conventional signal exit codes: 128 + signal number
+      // (SIGINT=2 → 130, SIGTERM=15 → 143).
+      process.exit(signal === "SIGINT" ? 130 : 143);
+    }
   };
   process.on("SIGINT", handler);
   process.on("SIGTERM", handler);

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -174,6 +174,8 @@ export const runMetaSchema = z.object({
   completedAt: z.string().optional(),
   type: z.enum(["scan", "process", "revalidate"]),
   phase: z.enum(["running", "done", "error"]),
+  pid: z.number().optional(),
+  hostname: z.string().optional(),
   scannerConfig: z
     .object({
       matcherSlugs: z.array(z.string()),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,6 +8,21 @@ export interface RunMeta {
   completedAt?: string;
   type: "scan" | "process" | "revalidate";
   phase: "running" | "done" | "error";
+  /**
+   * OS process id of the run owner, captured at `createRunMeta`. Combined
+   * with `hostname` it lets `isReclaimableLock` detect crashed runs
+   * (SIGKILL / OOM / power loss) on the same host immediately, instead of
+   * waiting out the 1h `STALE_LOCK_MS` for `phase === "running"` runs that
+   * will never call `completeRun`. Optional for backward compat with run
+   * metas written before this field existed.
+   */
+  pid?: number;
+  /**
+   * Hostname of the machine the run was started on. PID liveness is only
+   * meaningful on the same host; cross-host stale runs still fall back to
+   * the timestamp-based staleness check.
+   */
+  hostname?: string;
   scannerConfig?: {
     matcherSlugs: string[];
     /**

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/processor/src/__tests__/process-revalidate.test.ts
+++ b/packages/processor/src/__tests__/process-revalidate.test.ts
@@ -309,6 +309,155 @@ describe("processor with stub agent", () => {
     expect(stub.calls.investigateCalls).toHaveLength(1);
   });
 
+  it("process() reclaims a lock whose owning run's PID is no longer alive on this host", async () => {
+    // Crash recovery: the owning run hard-crashed (SIGKILL / OOM /
+    // power loss) before it could flip phase to error. RunMeta is
+    // stuck at phase=running with a recorded PID. Without the PID
+    // liveness check, the lock would stay held until STALE_LOCK_MS
+    // (1h) elapsed. The check should treat the dead PID as a signal
+    // that the owner is gone, and reclaim immediately.
+    const fx = setupProject({ files: ["app.ts"] });
+
+    const deadRunId = "20260101000000-deadpidaaaaaaaa1";
+    const lockedRec = pendingRecord(fx.projectId, "app.ts");
+    lockedRec.status = "processing";
+    lockedRec.lockedByRunId = deadRunId;
+    lockedRec.lockedAt = new Date().toISOString();
+    fx.writeRecord(lockedRec);
+    fs.mkdirSync(path.join(fx.dataRoot, fx.projectId, "runs"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fx.dataRoot, fx.projectId, "runs", `${deadRunId}.json`),
+      JSON.stringify({
+        runId: deadRunId,
+        projectId: fx.projectId,
+        rootPath: fx.targetRoot,
+        createdAt: new Date().toISOString(),
+        type: "process",
+        phase: "running",
+        pid: 0x7fffffff, // not a live PID on any sane system
+        hostname: os.hostname(),
+        stats: {},
+      }),
+    );
+
+    const stub = new StubAgent();
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await processProject({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+    });
+
+    expect(result.analysisCount).toBe(1);
+    expect(stub.calls.investigateCalls).toHaveLength(1);
+  });
+
+  it("process() does NOT reclaim a lock when the owning PID is on a different host", async () => {
+    // Cross-host: we can't probe a remote PID, so a phase=running run
+    // from a different machine should fall back to the timestamp
+    // staleness check (STALE_LOCK_MS). A fresh lock from another host
+    // is still respected.
+    const fx = setupProject({ files: ["app.ts"] });
+
+    const otherRunId = "20260101000000-crossaaaaaaaaaaa";
+    const lockedRec = pendingRecord(fx.projectId, "app.ts");
+    lockedRec.status = "processing";
+    lockedRec.lockedByRunId = otherRunId;
+    lockedRec.lockedAt = new Date().toISOString();
+    fx.writeRecord(lockedRec);
+    fs.mkdirSync(path.join(fx.dataRoot, fx.projectId, "runs"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fx.dataRoot, fx.projectId, "runs", `${otherRunId}.json`),
+      JSON.stringify({
+        runId: otherRunId,
+        projectId: fx.projectId,
+        rootPath: fx.targetRoot,
+        createdAt: new Date().toISOString(),
+        type: "process",
+        phase: "running",
+        pid: 0x7fffffff,
+        hostname: `not-${os.hostname()}-different-host`,
+        stats: {},
+      }),
+    );
+
+    const stub = new StubAgent();
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await processProject({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+    });
+
+    expect(stub.calls.investigateCalls).toHaveLength(0);
+    expect(result.analysisCount).toBe(0);
+    const after = fx.readRecord("app.ts");
+    expect(after.status).toBe("processing");
+    expect(after.lockedByRunId).toBe(otherRunId);
+  });
+
+  it("process() does NOT reclaim a lock when the owning PID is still alive on this host", async () => {
+    // The owning run is healthy and still investigating — same host,
+    // live PID. Even with a fresh lockedAt and phase=running, the
+    // reclaimer must respect it and skip the file.
+    const fx = setupProject({ files: ["app.ts"] });
+
+    const liveRunId = "20260101000000-livepidaaaaaaaaa";
+    const lockedRec = pendingRecord(fx.projectId, "app.ts");
+    lockedRec.status = "processing";
+    lockedRec.lockedByRunId = liveRunId;
+    lockedRec.lockedAt = new Date().toISOString();
+    fx.writeRecord(lockedRec);
+    fs.mkdirSync(path.join(fx.dataRoot, fx.projectId, "runs"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fx.dataRoot, fx.projectId, "runs", `${liveRunId}.json`),
+      JSON.stringify({
+        runId: liveRunId,
+        projectId: fx.projectId,
+        rootPath: fx.targetRoot,
+        createdAt: new Date().toISOString(),
+        type: "process",
+        phase: "running",
+        // Our own pid — guaranteed alive while this test runs.
+        pid: process.pid,
+        hostname: os.hostname(),
+        stats: {},
+      }),
+    );
+
+    const stub = new StubAgent();
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await processProject({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+    });
+
+    expect(stub.calls.investigateCalls).toHaveLength(0);
+    expect(result.analysisCount).toBe(0);
+    const after = fx.readRecord("app.ts");
+    expect(after.status).toBe("processing");
+    expect(after.lockedByRunId).toBe(liveRunId);
+  });
+
   it("process() captures refusals from the agent into AnalysisEntry", async () => {
     const fx = setupProject({ files: ["app.ts"] });
     fx.writeRecord(pendingRecord(fx.projectId, "app.ts"));

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -287,504 +287,507 @@ export async function process(params: {
   const unregisterRun = registerActiveRun(projectId, runId);
 
   try {
-  const registry = createDefaultAgentRegistry();
-  const maybeAgent = registry.get(agentType);
-  if (!maybeAgent) {
-    throw new Error(`Unknown agent type: ${agentType}. Available: ${registry.types().join(", ")}`);
-  }
-  const agent = maybeAgent;
-
-  // Reclaim policy for `processing` records held by other runs. The
-  // race we're protecting against: two `process()` invocations against
-  // the same project at the same time. Without this check, the second
-  // run grabs files the first run is mid-investigation on, both write
-  // back, and findings/history get clobbered.
-  //
-  // A lock is reclaimable when ANY of:
-  //   1. The owning run's RunMeta says it's done/error/missing — the
-  //      lock won't be released by the original owner, ever. Covers the
-  //      graceful-shutdown path (SIGINT/SIGTERM) where we proactively
-  //      flip the run to `error` before exiting.
-  //   2. The owning run was started on this host and its PID is no
-  //      longer alive — the run crashed (SIGKILL / OOM / power loss)
-  //      without flipping phase. PID liveness gives us instant recovery
-  //      instead of waiting out STALE_LOCK_MS.
-  //   3. The lock is older than STALE_LOCK_MS — backstop for cross-host
-  //      stale runs and any case where neither phase nor PID tell us.
-  //
-  // STALE_LOCK_MS is generous (1h) because individual investigations
-  // can legitimately take 20–40 minutes on big repos with max
-  // thinking. False reclaims are catastrophic; false rejections only
-  // cost a retry on the next run.
-  const STALE_LOCK_MS = 60 * 60 * 1000;
-  const localHostname = os.hostname();
-  const isReclaimableLock = (r: FileRecord): boolean => {
-    if (!r.lockedByRunId) return true;
-    // Cross-check the owning run's status. A done/error/missing run's
-    // lock is always safe to reclaim — nobody is going to flip the
-    // record back to "analyzed".
-    let ownerMeta: Awaited<ReturnType<typeof readRunMeta>> | undefined;
-    try {
-      ownerMeta = readRunMeta(projectId, r.lockedByRunId);
-    } catch {
-      // Missing/corrupt run-meta — owning run is gone, reclaim safely.
-      return true;
-    }
-    if (ownerMeta.phase === "done" || ownerMeta.phase === "error") return true;
-    // Owner reports running — but it may have crashed without updating
-    // phase. If the run was started on this host and we recorded its
-    // PID, check whether the process is still alive. A dead PID means
-    // the run is genuinely gone and the lock can be reclaimed now,
-    // without waiting out STALE_LOCK_MS. Cross-host (different
-    // hostname) we can't probe, so we fall through to the timestamp
-    // check.
-    if (
-      ownerMeta.pid !== undefined &&
-      ownerMeta.hostname !== undefined &&
-      ownerMeta.hostname === localHostname &&
-      !isPidAlive(ownerMeta.pid)
-    ) {
-      return true;
-    }
-    // Records written before lockedAt existed have no timestamp; treat
-    // those as old enough to reclaim so we can recover legacy locked
-    // state.
-    if (!r.lockedAt) return true;
-    const ageMs = Date.now() - new Date(r.lockedAt).getTime();
-    return ageMs >= STALE_LOCK_MS;
-  };
-
-  // Load file records and pick which to process
-  const allRecords = loadAllFileRecords(projectId);
-  let toProcess: FileRecord[];
-
-  // Direct mode: caller passed an exact file list. Bypass the
-  // scanner-state filter, the noise sort, and reinvestigate logic — the
-  // user's list IS the work. Records are loaded by path; we expect
-  // `scanFiles()` to have run first so every path has a record on disk.
-  if (params.filePaths !== undefined) {
-    const wanted = new Set(params.filePaths.map((p) => p.replaceAll("\\", "/")));
-    const byPath = new Map(allRecords.map((r) => [r.filePath, r]));
-    const missing: string[] = [];
-    toProcess = [];
-    for (const p of wanted) {
-      const r = byPath.get(p);
-      if (r) toProcess.push(r);
-      else missing.push(p);
-    }
-    if (missing.length > 0) {
-      console.warn(
-        `[deepsec] process: ${missing.length} file(s) had no FileRecord and were skipped: ${missing.slice(0, 5).join(", ")}${missing.length > 5 ? "…" : ""}`,
+    const registry = createDefaultAgentRegistry();
+    const maybeAgent = registry.get(agentType);
+    if (!maybeAgent) {
+      throw new Error(
+        `Unknown agent type: ${agentType}. Available: ${registry.types().join(", ")}`,
       );
     }
-  } else if (typeof reinvestigate === "number") {
-    // Idempotent reinvestigate: `--reinvestigate <N>` is a *wave marker*.
-    // The first run with a given N tags every productive analysis it
-    // produces with `reinvestigateMarker = N`; re-running with the same N
-    // (e.g. after some sandboxes failed) skips files that already carry
-    // this marker for the same agent. Silent-failure entries don't count
-    // since they had 0 output tokens — the agent never actually ran.
+    const agent = maybeAgent;
+
+    // Reclaim policy for `processing` records held by other runs. The
+    // race we're protecting against: two `process()` invocations against
+    // the same project at the same time. Without this check, the second
+    // run grabs files the first run is mid-investigation on, both write
+    // back, and findings/history get clobbered.
     //
-    // To request a NEW pass, bump N (21 is "wave 21"). Different agents
-    // get separate markers because we filter by agentType.
-    toProcess = allRecords.filter((r) => {
-      const alreadyDone = (r.analysisHistory ?? []).some((h) => {
-        if ((h.usage?.outputTokens ?? 0) <= 0) return false;
-        if (h.agentType !== agentType) return false;
-        // A revalidate entry doesn't satisfy a process wave: revalidation
-        // doesn't re-investigate, it just attaches verdicts. Even if a
-        // revalidate entry somehow carried `reinvestigateMarker` (today
-        // it doesn't), counting it here would silently skip files that
-        // still need a fresh process pass.
-        if (h.phase === "revalidate") return false;
-        return h.reinvestigateMarker === reinvestigate;
-      });
-      return !alreadyDone;
-    });
-  } else if (reinvestigate) {
-    toProcess = allRecords;
-  } else {
-    toProcess = allRecords.filter(
-      (r) =>
-        r.status === "pending" ||
-        r.status === "error" ||
-        // Reclaim a `processing` record from another run only when the
-        // owning lock is genuinely abandoned. The previous version
-        // reclaimed unconditionally, which let two concurrent runs
-        // both pick up the same file and clobber each other on
-        // write. See `isReclaimableLock` for the exact criteria.
-        (r.status === "processing" && r.lockedByRunId !== runId && isReclaimableLock(r)),
-    );
-  }
-
-  // Apply manifest filter (exact file list from sandbox orchestrator)
-  if (manifestFilePaths) {
-    toProcess = toProcess.filter((r) => manifestFilePaths!.has(r.filePath));
-  }
-
-  // Slug filters: --only-slugs and --skip-slugs
-  const onlySet =
-    params.onlySlugs && params.onlySlugs.length > 0 ? new Set(params.onlySlugs) : undefined;
-  const skipSet =
-    params.skipSlugs && params.skipSlugs.length > 0 ? new Set(params.skipSlugs) : undefined;
-  if (onlySet || skipSet) {
-    toProcess = toProcess.filter((r) => {
-      const slugs = r.candidates.map((c) => c.vulnSlug);
-      if (onlySet && !slugs.some((s) => onlySet.has(s))) return false;
-      // Keep the record if any slug is NOT in the skip set — if all are skipped, drop it
-      if (skipSet && slugs.length > 0 && slugs.every((s) => skipSet.has(s))) return false;
-      return true;
-    });
-  }
-
-  // Sort: noise tier first (precise > normal > noisy), then priority paths
-  toProcess.sort((a, b) => {
-    // Primary: noise tier (precise matchers first)
-    const aSlugs = a.candidates.map((c) => c.vulnSlug);
-    const bSlugs = b.candidates.map((c) => c.vulnSlug);
-    const noiseDiff = noiseScore(aSlugs) - noiseScore(bSlugs);
-    if (noiseDiff !== 0) return noiseDiff;
-
-    // Secondary: priority paths from config
-    if (projectConfig.priorityPaths && projectConfig.priorityPaths.length > 0) {
-      const priorities = projectConfig.priorityPaths;
-      const aPri = priorities.findIndex((p) => a.filePath.startsWith(p));
-      const bPri = priorities.findIndex((p) => b.filePath.startsWith(p));
-      const aScore = aPri === -1 ? priorities.length : aPri;
-      const bScore = bPri === -1 ? priorities.length : bPri;
-      if (aScore !== bScore) return aScore - bScore;
-    }
-
-    // Tertiary: more candidate matches = higher priority
-    return b.candidates.length - a.candidates.length;
-  });
-
-  if (toProcess.length === 0) {
-    emitProgress({
-      type: "all_complete",
-      message: "No files to process",
-    });
-    completeRun(projectId, runId, "done", { filesProcessed: 0 });
-    return { runId, analysisCount: 0, findingCount: 0, errorBatchCount: 0 };
-  }
-
-  // Apply path filter
-  if (params.filter) {
-    toProcess = toProcess.filter((r) => r.filePath.startsWith(params.filter!));
-  }
-
-  // Apply limit
-  if (params.limit && toProcess.length > params.limit) {
-    toProcess = toProcess.slice(0, params.limit);
-  }
-
-  // Atomic claim under a per-project mutex. Without serializing this
-  // section, two `process()` invocations against the same project both
-  // see the same pending records, both write status="processing" with
-  // their own runId, and the loser's lock + later writes get clobbered.
-  // The lock is held only for the few seconds of disk I/O it takes to
-  // re-read each record and write a fresh lock — the real work runs
-  // outside it, so concurrent runs against disjoint file sets don't
-  // block each other. See acquireProcessLock for the mkdir-based atomic
-  // primitive and the 1h stale-lock cutoff.
-  const lockedAt = new Date().toISOString();
-  const claimed: FileRecord[] = [];
-  const inForceMode = !!reinvestigate || params.filePaths !== undefined;
-  const releaseProcessLock = await acquireProcessLock(projectId, runId);
-  try {
-    for (const record of toProcess) {
-      let current: FileRecord;
+    // A lock is reclaimable when ANY of:
+    //   1. The owning run's RunMeta says it's done/error/missing — the
+    //      lock won't be released by the original owner, ever. Covers the
+    //      graceful-shutdown path (SIGINT/SIGTERM) where we proactively
+    //      flip the run to `error` before exiting.
+    //   2. The owning run was started on this host and its PID is no
+    //      longer alive — the run crashed (SIGKILL / OOM / power loss)
+    //      without flipping phase. PID liveness gives us instant recovery
+    //      instead of waiting out STALE_LOCK_MS.
+    //   3. The lock is older than STALE_LOCK_MS — backstop for cross-host
+    //      stale runs and any case where neither phase nor PID tell us.
+    //
+    // STALE_LOCK_MS is generous (1h) because individual investigations
+    // can legitimately take 20–40 minutes on big repos with max
+    // thinking. False reclaims are catastrophic; false rejections only
+    // cost a retry on the next run.
+    const STALE_LOCK_MS = 60 * 60 * 1000;
+    const localHostname = os.hostname();
+    const isReclaimableLock = (r: FileRecord): boolean => {
+      if (!r.lockedByRunId) return true;
+      // Cross-check the owning run's status. A done/error/missing run's
+      // lock is always safe to reclaim — nobody is going to flip the
+      // record back to "analyzed".
+      let ownerMeta: Awaited<ReturnType<typeof readRunMeta>> | undefined;
       try {
-        const fresh = readFileRecord(projectId, record.filePath);
-        if (!fresh) continue;
-        current = fresh;
+        ownerMeta = readRunMeta(projectId, r.lockedByRunId);
       } catch {
-        continue;
+        // Missing/corrupt run-meta — owning run is gone, reclaim safely.
+        return true;
       }
-
-      const isOurs = current.lockedByRunId === runId;
-      const isFreelyClaimable =
-        current.status === "pending" ||
-        current.status === "error" ||
-        (current.status === "processing" &&
-          current.lockedByRunId !== runId &&
-          isReclaimableLock(current));
-      if (!isOurs && !isFreelyClaimable && !inForceMode) {
-        continue;
+      if (ownerMeta.phase === "done" || ownerMeta.phase === "error") return true;
+      // Owner reports running — but it may have crashed without updating
+      // phase. If the run was started on this host and we recorded its
+      // PID, check whether the process is still alive. A dead PID means
+      // the run is genuinely gone and the lock can be reclaimed now,
+      // without waiting out STALE_LOCK_MS. Cross-host (different
+      // hostname) we can't probe, so we fall through to the timestamp
+      // check.
+      if (
+        ownerMeta.pid !== undefined &&
+        ownerMeta.hostname !== undefined &&
+        ownerMeta.hostname === localHostname &&
+        !isPidAlive(ownerMeta.pid)
+      ) {
+        return true;
       }
+      // Records written before lockedAt existed have no timestamp; treat
+      // those as old enough to reclaim so we can recover legacy locked
+      // state.
+      if (!r.lockedAt) return true;
+      const ageMs = Date.now() - new Date(r.lockedAt).getTime();
+      return ageMs >= STALE_LOCK_MS;
+    };
 
-      current.status = "processing";
-      current.lockedByRunId = runId;
-      current.lockedAt = lockedAt;
-      writeFileRecord(current);
+    // Load file records and pick which to process
+    const allRecords = loadAllFileRecords(projectId);
+    let toProcess: FileRecord[];
 
-      // Mutate the in-memory snapshot we'll process from so downstream code
-      // sees the same lock state.
-      record.status = current.status;
-      record.lockedByRunId = current.lockedByRunId;
-      record.lockedAt = current.lockedAt;
-      claimed.push(record);
+    // Direct mode: caller passed an exact file list. Bypass the
+    // scanner-state filter, the noise sort, and reinvestigate logic — the
+    // user's list IS the work. Records are loaded by path; we expect
+    // `scanFiles()` to have run first so every path has a record on disk.
+    if (params.filePaths !== undefined) {
+      const wanted = new Set(params.filePaths.map((p) => p.replaceAll("\\", "/")));
+      const byPath = new Map(allRecords.map((r) => [r.filePath, r]));
+      const missing: string[] = [];
+      toProcess = [];
+      for (const p of wanted) {
+        const r = byPath.get(p);
+        if (r) toProcess.push(r);
+        else missing.push(p);
+      }
+      if (missing.length > 0) {
+        console.warn(
+          `[deepsec] process: ${missing.length} file(s) had no FileRecord and were skipped: ${missing.slice(0, 5).join(", ")}${missing.length > 5 ? "…" : ""}`,
+        );
+      }
+    } else if (typeof reinvestigate === "number") {
+      // Idempotent reinvestigate: `--reinvestigate <N>` is a *wave marker*.
+      // The first run with a given N tags every productive analysis it
+      // produces with `reinvestigateMarker = N`; re-running with the same N
+      // (e.g. after some sandboxes failed) skips files that already carry
+      // this marker for the same agent. Silent-failure entries don't count
+      // since they had 0 output tokens — the agent never actually ran.
+      //
+      // To request a NEW pass, bump N (21 is "wave 21"). Different agents
+      // get separate markers because we filter by agentType.
+      toProcess = allRecords.filter((r) => {
+        const alreadyDone = (r.analysisHistory ?? []).some((h) => {
+          if ((h.usage?.outputTokens ?? 0) <= 0) return false;
+          if (h.agentType !== agentType) return false;
+          // A revalidate entry doesn't satisfy a process wave: revalidation
+          // doesn't re-investigate, it just attaches verdicts. Even if a
+          // revalidate entry somehow carried `reinvestigateMarker` (today
+          // it doesn't), counting it here would silently skip files that
+          // still need a fresh process pass.
+          if (h.phase === "revalidate") return false;
+          return h.reinvestigateMarker === reinvestigate;
+        });
+        return !alreadyDone;
+      });
+    } else if (reinvestigate) {
+      toProcess = allRecords;
+    } else {
+      toProcess = allRecords.filter(
+        (r) =>
+          r.status === "pending" ||
+          r.status === "error" ||
+          // Reclaim a `processing` record from another run only when the
+          // owning lock is genuinely abandoned. The previous version
+          // reclaimed unconditionally, which let two concurrent runs
+          // both pick up the same file and clobber each other on
+          // write. See `isReclaimableLock` for the exact criteria.
+          (r.status === "processing" && r.lockedByRunId !== runId && isReclaimableLock(r)),
+      );
     }
-  } finally {
-    releaseProcessLock();
-  }
-  toProcess = claimed;
-  if (toProcess.length === 0) {
-    emitProgress({
-      type: "all_complete",
-      message: "Nothing to claim — another run owned every candidate file.",
+
+    // Apply manifest filter (exact file list from sandbox orchestrator)
+    if (manifestFilePaths) {
+      toProcess = toProcess.filter((r) => manifestFilePaths!.has(r.filePath));
+    }
+
+    // Slug filters: --only-slugs and --skip-slugs
+    const onlySet =
+      params.onlySlugs && params.onlySlugs.length > 0 ? new Set(params.onlySlugs) : undefined;
+    const skipSet =
+      params.skipSlugs && params.skipSlugs.length > 0 ? new Set(params.skipSlugs) : undefined;
+    if (onlySet || skipSet) {
+      toProcess = toProcess.filter((r) => {
+        const slugs = r.candidates.map((c) => c.vulnSlug);
+        if (onlySet && !slugs.some((s) => onlySet.has(s))) return false;
+        // Keep the record if any slug is NOT in the skip set — if all are skipped, drop it
+        if (skipSet && slugs.length > 0 && slugs.every((s) => skipSet.has(s))) return false;
+        return true;
+      });
+    }
+
+    // Sort: noise tier first (precise > normal > noisy), then priority paths
+    toProcess.sort((a, b) => {
+      // Primary: noise tier (precise matchers first)
+      const aSlugs = a.candidates.map((c) => c.vulnSlug);
+      const bSlugs = b.candidates.map((c) => c.vulnSlug);
+      const noiseDiff = noiseScore(aSlugs) - noiseScore(bSlugs);
+      if (noiseDiff !== 0) return noiseDiff;
+
+      // Secondary: priority paths from config
+      if (projectConfig.priorityPaths && projectConfig.priorityPaths.length > 0) {
+        const priorities = projectConfig.priorityPaths;
+        const aPri = priorities.findIndex((p) => a.filePath.startsWith(p));
+        const bPri = priorities.findIndex((p) => b.filePath.startsWith(p));
+        const aScore = aPri === -1 ? priorities.length : aPri;
+        const bScore = bPri === -1 ? priorities.length : bPri;
+        if (aScore !== bScore) return aScore - bScore;
+      }
+
+      // Tertiary: more candidate matches = higher priority
+      return b.candidates.length - a.candidates.length;
     });
-    completeRun(projectId, runId, "done", { filesProcessed: 0 });
-    return { runId, analysisCount: 0, findingCount: 0, errorBatchCount: 0 };
-  }
 
-  const batches = batchCandidates(toProcess, params.batchSize);
-  let totalAnalyses = 0;
-  let totalFindings = 0;
-  let totalCostUsd = 0;
-  let totalInputTokens = 0;
-  let totalOutputTokens = 0;
-  let totalDurationMs = 0;
-  let batchesCompleted = 0;
-  let batchesFailed = 0;
-  let batchesInFlight = 0;
-  const concurrency = params.concurrency ?? defaultConcurrency();
+    if (toProcess.length === 0) {
+      emitProgress({
+        type: "all_complete",
+        message: "No files to process",
+      });
+      completeRun(projectId, runId, "done", { filesProcessed: 0 });
+      return { runId, analysisCount: 0, findingCount: 0, errorBatchCount: 0 };
+    }
 
-  // Quota cancellation: when one batch throws QuotaExhaustedError, every
-  // other in-flight batch is using the same exhausted credential and will
-  // fail on its next API call. Aborting the controller cancels the SDK's
-  // in-flight HTTP request so workers exit immediately instead of waiting
-  // for a polling tick. The captured `quotaExhausted` is returned to the
-  // caller so the CLI can render a tailored remediation message.
-  const quotaAbort = new AbortController();
-  let quotaExhausted: { source: QuotaSource; rawMessage: string } | undefined;
+    // Apply path filter
+    if (params.filter) {
+      toProcess = toProcess.filter((r) => r.filePath.startsWith(params.filter!));
+    }
 
-  async function processBatch(batch: FileRecord[], i: number) {
-    batchesInFlight++;
-    emitProgress({
-      type: "batch_started",
-      message: `Processing batch ${i + 1}/${batches.length} (${batch.length} files, ${batchesInFlight} in flight)`,
-      batchIndex: i,
-      totalBatches: batches.length,
-    });
+    // Apply limit
+    if (params.limit && toProcess.length > params.limit) {
+      toProcess = toProcess.slice(0, params.limit);
+    }
 
+    // Atomic claim under a per-project mutex. Without serializing this
+    // section, two `process()` invocations against the same project both
+    // see the same pending records, both write status="processing" with
+    // their own runId, and the loser's lock + later writes get clobbered.
+    // The lock is held only for the few seconds of disk I/O it takes to
+    // re-read each record and write a fresh lock — the real work runs
+    // outside it, so concurrent runs against disjoint file sets don't
+    // block each other. See acquireProcessLock for the mkdir-based atomic
+    // primitive and the 1h stale-lock cutoff.
+    const lockedAt = new Date().toISOString();
+    const claimed: FileRecord[] = [];
+    const inForceMode = !!reinvestigate || params.filePaths !== undefined;
+    const releaseProcessLock = await acquireProcessLock(projectId, runId);
     try {
-      // When using the modular assembled prompt, INFO.md is already
-      // injected by `assemblePrompt()` (between `---` separators after
-      // the threat highlights). Pass `""` to the agent layer to avoid a
-      // second `## Project Context` block being appended on top of it.
-      // Custom-template callers don't go through the assembler, so they
-      // still need the agent layer to inject INFO.md for them.
-      const projectInfoForAgent = customPromptTemplate === undefined ? "" : projectInfo;
-      const gen = agent.investigate({
-        batch,
-        projectRoot: effectiveRootPath,
-        promptTemplate: buildBatchPrompt(batch),
-        projectInfo: projectInfoForAgent,
-        config,
-        signal: quotaAbort.signal,
+      for (const record of toProcess) {
+        let current: FileRecord;
+        try {
+          const fresh = readFileRecord(projectId, record.filePath);
+          if (!fresh) continue;
+          current = fresh;
+        } catch {
+          continue;
+        }
+
+        const isOurs = current.lockedByRunId === runId;
+        const isFreelyClaimable =
+          current.status === "pending" ||
+          current.status === "error" ||
+          (current.status === "processing" &&
+            current.lockedByRunId !== runId &&
+            isReclaimableLock(current));
+        if (!isOurs && !isFreelyClaimable && !inForceMode) {
+          continue;
+        }
+
+        current.status = "processing";
+        current.lockedByRunId = runId;
+        current.lockedAt = lockedAt;
+        writeFileRecord(current);
+
+        // Mutate the in-memory snapshot we'll process from so downstream code
+        // sees the same lock state.
+        record.status = current.status;
+        record.lockedByRunId = current.lockedByRunId;
+        record.lockedAt = current.lockedAt;
+        claimed.push(record);
+      }
+    } finally {
+      releaseProcessLock();
+    }
+    toProcess = claimed;
+    if (toProcess.length === 0) {
+      emitProgress({
+        type: "all_complete",
+        message: "Nothing to claim — another run owned every candidate file.",
+      });
+      completeRun(projectId, runId, "done", { filesProcessed: 0 });
+      return { runId, analysisCount: 0, findingCount: 0, errorBatchCount: 0 };
+    }
+
+    const batches = batchCandidates(toProcess, params.batchSize);
+    let totalAnalyses = 0;
+    let totalFindings = 0;
+    let totalCostUsd = 0;
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalDurationMs = 0;
+    let batchesCompleted = 0;
+    let batchesFailed = 0;
+    let batchesInFlight = 0;
+    const concurrency = params.concurrency ?? defaultConcurrency();
+
+    // Quota cancellation: when one batch throws QuotaExhaustedError, every
+    // other in-flight batch is using the same exhausted credential and will
+    // fail on its next API call. Aborting the controller cancels the SDK's
+    // in-flight HTTP request so workers exit immediately instead of waiting
+    // for a polling tick. The captured `quotaExhausted` is returned to the
+    // caller so the CLI can render a tailored remediation message.
+    const quotaAbort = new AbortController();
+    let quotaExhausted: { source: QuotaSource; rawMessage: string } | undefined;
+
+    async function processBatch(batch: FileRecord[], i: number) {
+      batchesInFlight++;
+      emitProgress({
+        type: "batch_started",
+        message: `Processing batch ${i + 1}/${batches.length} (${batch.length} files, ${batchesInFlight} in flight)`,
+        batchIndex: i,
+        totalBatches: batches.length,
       });
 
-      let result = await gen.next();
-      while (!result.done) {
+      try {
+        // When using the modular assembled prompt, INFO.md is already
+        // injected by `assemblePrompt()` (between `---` separators after
+        // the threat highlights). Pass `""` to the agent layer to avoid a
+        // second `## Project Context` block being appended on top of it.
+        // Custom-template callers don't go through the assembler, so they
+        // still need the agent layer to inject INFO.md for them.
+        const projectInfoForAgent = customPromptTemplate === undefined ? "" : projectInfo;
+        const gen = agent.investigate({
+          batch,
+          projectRoot: effectiveRootPath,
+          promptTemplate: buildBatchPrompt(batch),
+          projectInfo: projectInfoForAgent,
+          config,
+          signal: quotaAbort.signal,
+        });
+
+        let result = await gen.next();
+        while (!result.done) {
+          emitProgress({
+            type: "agent_progress",
+            message: (result.value as AgentProgress).message,
+            batchIndex: i,
+            totalBatches: batches.length,
+            agentProgress: result.value as AgentProgress,
+          });
+          result = await gen.next();
+        }
+
+        const output = result.value as InvestigateOutput;
+        const { results, meta: batchMeta } = output;
+
+        // Accumulate run-level stats
+        totalCostUsd += batchMeta.costUsd ?? 0;
+        totalInputTokens += batchMeta.usage?.inputTokens ?? 0;
+        totalOutputTokens += batchMeta.usage?.outputTokens ?? 0;
+        totalDurationMs += batchMeta.durationMs;
+
+        // Cost / tokens / duration / turns are batch-level — one agent call
+        // covers all files in the batch. Stamping the batch total onto every
+        // file's analysisHistory entry inflates `metrics` totals by ~batch
+        // size. Divide evenly so summing per-file entries gives the correct
+        // run total. We split by the count of records that will actually
+        // get an entry (results that match a record in the batch) — silent
+        // skips don't dilute the share.
+        const validResultCount = results.reduce(
+          (n, r) => n + (batch.some((b) => b.filePath === r.filePath) ? 1 : 0),
+          0,
+        );
+        const splitN = Math.max(1, validResultCount);
+        const perFileCost = batchMeta.costUsd != null ? batchMeta.costUsd / splitN : undefined;
+        const perFileUsage = batchMeta.usage
+          ? {
+              inputTokens: batchMeta.usage.inputTokens / splitN,
+              outputTokens: batchMeta.usage.outputTokens / splitN,
+              cacheReadInputTokens: batchMeta.usage.cacheReadInputTokens / splitN,
+              cacheCreationInputTokens: batchMeta.usage.cacheCreationInputTokens / splitN,
+            }
+          : undefined;
+        const perFileDurationMs = batchMeta.durationMs / splitN;
+        const perFileDurationApiMs =
+          batchMeta.durationApiMs != null ? batchMeta.durationApiMs / splitN : undefined;
+        const perFileNumTurns =
+          batchMeta.numTurns != null ? batchMeta.numTurns / splitN : undefined;
+
+        // Update file records with results + metadata.
+        //
+        // Re-investigation always *merges* — existing findings are preserved
+        // and only the agent's net-new findings (signature not already on the
+        // file) get appended. Signature: vulnSlug + normalized title
+        // (lowercase, trimmed). This tolerates minor wording drift while still
+        // suppressing duplicates from re-runs. The first analysis on a file
+        // (no prior findings) lands as-is.
+        for (const res of results) {
+          const record = batch.find((r) => r.filePath === res.filePath);
+          if (!record) continue;
+
+          const sig = (slug: string | undefined, title: string | undefined) =>
+            `${slug ?? ""}::${(title ?? "").trim().toLowerCase()}`;
+          const existing = new Set((record.findings ?? []).map((f) => sig(f.vulnSlug, f.title)));
+          const newFindings = res.findings
+            .filter((f) => !existing.has(sig(f.vulnSlug, f.title)))
+            // Stamp the originating run so PR comments and post-run
+            // tooling can filter to net-new findings only. Findings from
+            // earlier runs keep their (older) producedByRunId — or
+            // undefined for findings written before this field existed.
+            .map((f) => ({ ...f, producedByRunId: runId }));
+          record.findings = [...(record.findings ?? []), ...newFindings];
+          const findingsForHistoryCount = newFindings.length;
+
+          record.analysisHistory.push({
+            runId,
+            investigatedAt: new Date().toISOString(),
+            durationMs: perFileDurationMs,
+            durationApiMs: perFileDurationApiMs,
+            agentType,
+            model,
+            modelConfig: config,
+            agentSessionId: batchMeta.agentSessionId,
+            findingCount: findingsForHistoryCount,
+            numTurns: perFileNumTurns,
+            phase: "process",
+            costUsd: perFileCost,
+            usage: perFileUsage,
+            refusal: batchMeta.refusal,
+            codexStderr: batchMeta.codexStderr,
+            reinvestigateMarker: typeof reinvestigate === "number" ? reinvestigate : undefined,
+          });
+          record.status = "analyzed";
+          record.lockedByRunId = undefined;
+          record.lockedAt = undefined;
+          try {
+            enrichFileRecord(record, effectiveRootPath);
+          } catch (e) {
+            console.error(
+              `[deepsec] enrich failed for ${record.filePath}: ${e instanceof Error ? e.message : e}`,
+            );
+          }
+          writeFileRecord(record);
+
+          totalAnalyses++;
+          // Count net-new only — re-runs of analyzed files that produce
+          // duplicates of existing findings shouldn't inflate the run
+          // total (and shouldn't fail the CLI exit gate in direct mode).
+          totalFindings += newFindings.length;
+        }
+
+        // Mark any files not in results as error
+        for (const record of batch) {
+          if (!results.some((r) => r.filePath === record.filePath)) {
+            record.status = "error";
+            record.lockedByRunId = undefined;
+            record.lockedAt = undefined;
+            writeFileRecord(record);
+          }
+        }
+
+        batchesInFlight--;
+        batchesCompleted++;
         emitProgress({
-          type: "agent_progress",
-          message: (result.value as AgentProgress).message,
+          type: "batch_complete",
+          message: `Batch ${i + 1}/${batches.length} complete: ${results.length} analyses, ${results.reduce((s, r) => s + r.findings.length, 0)} findings (${batchesInFlight} in flight, ${batchesCompleted}/${batches.length} done)`,
           batchIndex: i,
           totalBatches: batches.length,
-          agentProgress: result.value as AgentProgress,
         });
-        result = await gen.next();
-      }
-
-      const output = result.value as InvestigateOutput;
-      const { results, meta: batchMeta } = output;
-
-      // Accumulate run-level stats
-      totalCostUsd += batchMeta.costUsd ?? 0;
-      totalInputTokens += batchMeta.usage?.inputTokens ?? 0;
-      totalOutputTokens += batchMeta.usage?.outputTokens ?? 0;
-      totalDurationMs += batchMeta.durationMs;
-
-      // Cost / tokens / duration / turns are batch-level — one agent call
-      // covers all files in the batch. Stamping the batch total onto every
-      // file's analysisHistory entry inflates `metrics` totals by ~batch
-      // size. Divide evenly so summing per-file entries gives the correct
-      // run total. We split by the count of records that will actually
-      // get an entry (results that match a record in the batch) — silent
-      // skips don't dilute the share.
-      const validResultCount = results.reduce(
-        (n, r) => n + (batch.some((b) => b.filePath === r.filePath) ? 1 : 0),
-        0,
-      );
-      const splitN = Math.max(1, validResultCount);
-      const perFileCost = batchMeta.costUsd != null ? batchMeta.costUsd / splitN : undefined;
-      const perFileUsage = batchMeta.usage
-        ? {
-            inputTokens: batchMeta.usage.inputTokens / splitN,
-            outputTokens: batchMeta.usage.outputTokens / splitN,
-            cacheReadInputTokens: batchMeta.usage.cacheReadInputTokens / splitN,
-            cacheCreationInputTokens: batchMeta.usage.cacheCreationInputTokens / splitN,
-          }
-        : undefined;
-      const perFileDurationMs = batchMeta.durationMs / splitN;
-      const perFileDurationApiMs =
-        batchMeta.durationApiMs != null ? batchMeta.durationApiMs / splitN : undefined;
-      const perFileNumTurns = batchMeta.numTurns != null ? batchMeta.numTurns / splitN : undefined;
-
-      // Update file records with results + metadata.
-      //
-      // Re-investigation always *merges* — existing findings are preserved
-      // and only the agent's net-new findings (signature not already on the
-      // file) get appended. Signature: vulnSlug + normalized title
-      // (lowercase, trimmed). This tolerates minor wording drift while still
-      // suppressing duplicates from re-runs. The first analysis on a file
-      // (no prior findings) lands as-is.
-      for (const res of results) {
-        const record = batch.find((r) => r.filePath === res.filePath);
-        if (!record) continue;
-
-        const sig = (slug: string | undefined, title: string | undefined) =>
-          `${slug ?? ""}::${(title ?? "").trim().toLowerCase()}`;
-        const existing = new Set((record.findings ?? []).map((f) => sig(f.vulnSlug, f.title)));
-        const newFindings = res.findings
-          .filter((f) => !existing.has(sig(f.vulnSlug, f.title)))
-          // Stamp the originating run so PR comments and post-run
-          // tooling can filter to net-new findings only. Findings from
-          // earlier runs keep their (older) producedByRunId — or
-          // undefined for findings written before this field existed.
-          .map((f) => ({ ...f, producedByRunId: runId }));
-        record.findings = [...(record.findings ?? []), ...newFindings];
-        const findingsForHistoryCount = newFindings.length;
-
-        record.analysisHistory.push({
-          runId,
-          investigatedAt: new Date().toISOString(),
-          durationMs: perFileDurationMs,
-          durationApiMs: perFileDurationApiMs,
-          agentType,
-          model,
-          modelConfig: config,
-          agentSessionId: batchMeta.agentSessionId,
-          findingCount: findingsForHistoryCount,
-          numTurns: perFileNumTurns,
-          phase: "process",
-          costUsd: perFileCost,
-          usage: perFileUsage,
-          refusal: batchMeta.refusal,
-          codexStderr: batchMeta.codexStderr,
-          reinvestigateMarker: typeof reinvestigate === "number" ? reinvestigate : undefined,
-        });
-        record.status = "analyzed";
-        record.lockedByRunId = undefined;
-        record.lockedAt = undefined;
-        try {
-          enrichFileRecord(record, effectiveRootPath);
-        } catch (e) {
-          console.error(
-            `[deepsec] enrich failed for ${record.filePath}: ${e instanceof Error ? e.message : e}`,
-          );
+      } catch (err) {
+        batchesInFlight--;
+        batchesCompleted++;
+        batchesFailed++;
+        // Capture quota exhaustion exactly once: the first batch to trip
+        // wins, and subsequent batches that also throw QuotaExhaustedError
+        // (because they were already in-flight against the same empty
+        // credential) get their classifier silently dropped — no point
+        // logging "quota exhausted" N times. The abort below cancels them.
+        if (err instanceof QuotaExhaustedError && !quotaExhausted) {
+          quotaExhausted = { source: err.source, rawMessage: err.rawMessage };
+          quotaAbort.abort(err);
         }
-        writeFileRecord(record);
-
-        totalAnalyses++;
-        // Count net-new only — re-runs of analyzed files that produce
-        // duplicates of existing findings shouldn't inflate the run
-        // total (and shouldn't fail the CLI exit gate in direct mode).
-        totalFindings += newFindings.length;
-      }
-
-      // Mark any files not in results as error
-      for (const record of batch) {
-        if (!results.some((r) => r.filePath === record.filePath)) {
+        for (const record of batch) {
           record.status = "error";
           record.lockedByRunId = undefined;
           record.lockedAt = undefined;
           writeFileRecord(record);
         }
-      }
-
-      batchesInFlight--;
-      batchesCompleted++;
-      emitProgress({
-        type: "batch_complete",
-        message: `Batch ${i + 1}/${batches.length} complete: ${results.length} analyses, ${results.reduce((s, r) => s + r.findings.length, 0)} findings (${batchesInFlight} in flight, ${batchesCompleted}/${batches.length} done)`,
-        batchIndex: i,
-        totalBatches: batches.length,
-      });
-    } catch (err) {
-      batchesInFlight--;
-      batchesCompleted++;
-      batchesFailed++;
-      // Capture quota exhaustion exactly once: the first batch to trip
-      // wins, and subsequent batches that also throw QuotaExhaustedError
-      // (because they were already in-flight against the same empty
-      // credential) get their classifier silently dropped — no point
-      // logging "quota exhausted" N times. The abort below cancels them.
-      if (err instanceof QuotaExhaustedError && !quotaExhausted) {
-        quotaExhausted = { source: err.source, rawMessage: err.rawMessage };
-        quotaAbort.abort(err);
-      }
-      for (const record of batch) {
-        record.status = "error";
-        record.lockedByRunId = undefined;
-        record.lockedAt = undefined;
-        writeFileRecord(record);
-      }
-      emitProgress({
-        type: "batch_complete",
-        message: `Batch ${i + 1}/${batches.length} failed: ${err instanceof Error ? err.message : String(err)} (${batchesInFlight} in flight, ${batchesCompleted}/${batches.length} done)`,
-        batchIndex: i,
-        totalBatches: batches.length,
-      });
-    }
-  }
-
-  if (concurrency <= 1) {
-    // Sequential
-    for (let i = 0; i < batches.length; i++) {
-      // Stop pulling new batches once any earlier batch has tripped quota
-      // — the credential is empty for the whole run.
-      if (quotaAbort.signal.aborted) break;
-      await processBatch(batches[i], i);
-    }
-  } else {
-    // Concurrent with limited parallelism
-    let nextIdx = 0;
-    async function worker() {
-      while (nextIdx < batches.length) {
-        if (quotaAbort.signal.aborted) return;
-        const idx = nextIdx++;
-        await processBatch(batches[idx], idx);
+        emitProgress({
+          type: "batch_complete",
+          message: `Batch ${i + 1}/${batches.length} failed: ${err instanceof Error ? err.message : String(err)} (${batchesInFlight} in flight, ${batchesCompleted}/${batches.length} done)`,
+          batchIndex: i,
+          totalBatches: batches.length,
+        });
       }
     }
-    const workers = Array.from({ length: Math.min(concurrency, batches.length) }, () => worker());
-    await Promise.all(workers);
-  }
 
-  completeRun(projectId, runId, "done", {
-    filesProcessed: totalAnalyses,
-    findingsCount: totalFindings,
-    totalCostUsd,
-    totalInputTokens,
-    totalOutputTokens,
-    totalDurationMs,
-  });
+    if (concurrency <= 1) {
+      // Sequential
+      for (let i = 0; i < batches.length; i++) {
+        // Stop pulling new batches once any earlier batch has tripped quota
+        // — the credential is empty for the whole run.
+        if (quotaAbort.signal.aborted) break;
+        await processBatch(batches[i], i);
+      }
+    } else {
+      // Concurrent with limited parallelism
+      let nextIdx = 0;
+      async function worker() {
+        while (nextIdx < batches.length) {
+          if (quotaAbort.signal.aborted) return;
+          const idx = nextIdx++;
+          await processBatch(batches[idx], idx);
+        }
+      }
+      const workers = Array.from({ length: Math.min(concurrency, batches.length) }, () => worker());
+      await Promise.all(workers);
+    }
 
-  emitProgress({
-    type: "all_complete",
-    message: quotaExhausted
-      ? `Processing stopped: ${quotaExhausted.source} quota/credits exhausted (${totalAnalyses} analyses, ${batchesFailed} batch(es) failed before stop)`
-      : `Processing complete: ${totalAnalyses} analyses, ${totalFindings} findings${batchesFailed > 0 ? `, ${batchesFailed} batch(es) failed` : ""}`,
-  });
+    completeRun(projectId, runId, "done", {
+      filesProcessed: totalAnalyses,
+      findingsCount: totalFindings,
+      totalCostUsd,
+      totalInputTokens,
+      totalOutputTokens,
+      totalDurationMs,
+    });
 
-  return {
-    runId,
-    analysisCount: totalAnalyses,
-    findingCount: totalFindings,
-    errorBatchCount: batchesFailed,
-    quotaExhausted,
-  };
+    emitProgress({
+      type: "all_complete",
+      message: quotaExhausted
+        ? `Processing stopped: ${quotaExhausted.source} quota/credits exhausted (${totalAnalyses} analyses, ${batchesFailed} batch(es) failed before stop)`
+        : `Processing complete: ${totalAnalyses} analyses, ${totalFindings} findings${batchesFailed > 0 ? `, ${batchesFailed} batch(es) failed` : ""}`,
+    });
+
+    return {
+      runId,
+      analysisCount: totalAnalyses,
+      findingCount: totalFindings,
+      errorBatchCount: batchesFailed,
+      quotaExhausted,
+    };
   } catch (err) {
     // Body threw before completing. Flip phase to "error" so the
     // run's locks become reclaimable on the next call rather than
@@ -911,270 +914,273 @@ export async function revalidate(params: {
   const unregisterRun = registerActiveRun(projectId, runId);
 
   try {
-  const registry = createDefaultAgentRegistry();
-  const maybeAgent = registry.get(agentType);
-  if (!maybeAgent) {
-    throw new Error(`Unknown agent type: ${agentType}`);
-  }
-  const agent = maybeAgent;
+    const registry = createDefaultAgentRegistry();
+    const maybeAgent = registry.get(agentType);
+    if (!maybeAgent) {
+      throw new Error(`Unknown agent type: ${agentType}`);
+    }
+    const agent = maybeAgent;
 
-  // Load files that have findings needing revalidation
-  const revalOnlySet =
-    params.onlySlugs && params.onlySlugs.length > 0 ? new Set(params.onlySlugs) : undefined;
-  const revalSkipSet =
-    params.skipSlugs && params.skipSlugs.length > 0 ? new Set(params.skipSlugs) : undefined;
-  const allRecords = loadAllFileRecords(projectId);
-  let toRevalidate = allRecords.filter((r) => {
-    if (r.findings.length === 0) return false;
-    if (params.filter && !r.filePath.startsWith(params.filter)) return false;
+    // Load files that have findings needing revalidation
+    const revalOnlySet =
+      params.onlySlugs && params.onlySlugs.length > 0 ? new Set(params.onlySlugs) : undefined;
+    const revalSkipSet =
+      params.skipSlugs && params.skipSlugs.length > 0 ? new Set(params.skipSlugs) : undefined;
+    const allRecords = loadAllFileRecords(projectId);
+    let toRevalidate = allRecords.filter((r) => {
+      if (r.findings.length === 0) return false;
+      if (params.filter && !r.filePath.startsWith(params.filter)) return false;
 
-    const unrevalidated = r.findings.filter((f) => {
-      if (!force && f.revalidation) return false;
-      if (minSeverity && SEVERITY_ORDER[f.severity] > SEVERITY_ORDER[minSeverity]) return false;
-      if (revalOnlySet && !revalOnlySet.has(f.vulnSlug)) return false;
-      if (revalSkipSet?.has(f.vulnSlug)) return false;
-      return true;
-    });
-    return unrevalidated.length > 0;
-  });
-
-  // Apply manifest filter (exact file list from sandbox orchestrator)
-  if (manifestFilePaths) {
-    toRevalidate = toRevalidate.filter((r) => manifestFilePaths!.has(r.filePath));
-  }
-
-  // Sort by severity (CRITICAL first) then noise tier
-  toRevalidate.sort((a, b) => {
-    const aBest = Math.min(...a.findings.map((f) => SEVERITY_ORDER[f.severity]));
-    const bBest = Math.min(...b.findings.map((f) => SEVERITY_ORDER[f.severity]));
-    if (aBest !== bBest) return aBest - bBest;
-    return (
-      noiseScore(a.candidates.map((c) => c.vulnSlug)) -
-      noiseScore(b.candidates.map((c) => c.vulnSlug))
-    );
-  });
-
-  if (params.limit && toRevalidate.length > params.limit) {
-    toRevalidate = toRevalidate.slice(0, params.limit);
-  }
-
-  if (toRevalidate.length === 0) {
-    emitProgress({
-      type: "all_complete",
-      message: "No findings to revalidate",
-    });
-    completeRun(projectId, runId, "done", { findingsRevalidated: 0 });
-    return {
-      runId,
-      revalidated: 0,
-      truePositives: 0,
-      falsePositives: 0,
-      fixed: 0,
-      uncertain: 0,
-    };
-  }
-
-  let totalRevalidated = 0;
-  let totalTP = 0;
-  let totalFP = 0;
-  let totalFixed = 0;
-  let totalUncertain = 0;
-  let totalCostUsd = 0;
-  let batchesCompleted = 0;
-  let batchesInFlight = 0;
-  const concurrency = params.concurrency ?? defaultConcurrency();
-  const batchSize = params.batchSize ?? 5;
-
-  const batches = batchCandidates(toRevalidate, batchSize);
-
-  // Same quota-cancellation pattern as process(); see that block for why.
-  const quotaAbort = new AbortController();
-  let quotaExhausted: { source: QuotaSource; rawMessage: string } | undefined;
-
-  async function revalidateBatch(batch: FileRecord[], idx: number) {
-    batchesInFlight++;
-    const findingCount = batch.reduce(
-      (s, f) => s + f.findings.filter((ff) => (!force ? !ff.revalidation : true)).length,
-      0,
-    );
-    emitProgress({
-      type: "batch_started",
-      message: `Revalidating batch ${idx + 1}/${batches.length} (${batch.length} files, ${findingCount} findings, ${batchesInFlight} in flight)`,
-      batchIndex: idx,
-      totalBatches: batches.length,
+      const unrevalidated = r.findings.filter((f) => {
+        if (!force && f.revalidation) return false;
+        if (minSeverity && SEVERITY_ORDER[f.severity] > SEVERITY_ORDER[minSeverity]) return false;
+        if (revalOnlySet && !revalOnlySet.has(f.vulnSlug)) return false;
+        if (revalSkipSet?.has(f.vulnSlug)) return false;
+        return true;
+      });
+      return unrevalidated.length > 0;
     });
 
-    try {
-      const gen = agent.revalidate({
-        batch,
-        projectRoot: effectiveRootPath,
-        projectInfo,
-        config,
-        force,
-        signal: quotaAbort.signal,
+    // Apply manifest filter (exact file list from sandbox orchestrator)
+    if (manifestFilePaths) {
+      toRevalidate = toRevalidate.filter((r) => manifestFilePaths!.has(r.filePath));
+    }
+
+    // Sort by severity (CRITICAL first) then noise tier
+    toRevalidate.sort((a, b) => {
+      const aBest = Math.min(...a.findings.map((f) => SEVERITY_ORDER[f.severity]));
+      const bBest = Math.min(...b.findings.map((f) => SEVERITY_ORDER[f.severity]));
+      if (aBest !== bBest) return aBest - bBest;
+      return (
+        noiseScore(a.candidates.map((c) => c.vulnSlug)) -
+        noiseScore(b.candidates.map((c) => c.vulnSlug))
+      );
+    });
+
+    if (params.limit && toRevalidate.length > params.limit) {
+      toRevalidate = toRevalidate.slice(0, params.limit);
+    }
+
+    if (toRevalidate.length === 0) {
+      emitProgress({
+        type: "all_complete",
+        message: "No findings to revalidate",
+      });
+      completeRun(projectId, runId, "done", { findingsRevalidated: 0 });
+      return {
+        runId,
+        revalidated: 0,
+        truePositives: 0,
+        falsePositives: 0,
+        fixed: 0,
+        uncertain: 0,
+      };
+    }
+
+    let totalRevalidated = 0;
+    let totalTP = 0;
+    let totalFP = 0;
+    let totalFixed = 0;
+    let totalUncertain = 0;
+    let totalCostUsd = 0;
+    let batchesCompleted = 0;
+    let batchesInFlight = 0;
+    const concurrency = params.concurrency ?? defaultConcurrency();
+    const batchSize = params.batchSize ?? 5;
+
+    const batches = batchCandidates(toRevalidate, batchSize);
+
+    // Same quota-cancellation pattern as process(); see that block for why.
+    const quotaAbort = new AbortController();
+    let quotaExhausted: { source: QuotaSource; rawMessage: string } | undefined;
+
+    async function revalidateBatch(batch: FileRecord[], idx: number) {
+      batchesInFlight++;
+      const findingCount = batch.reduce(
+        (s, f) => s + f.findings.filter((ff) => (!force ? !ff.revalidation : true)).length,
+        0,
+      );
+      emitProgress({
+        type: "batch_started",
+        message: `Revalidating batch ${idx + 1}/${batches.length} (${batch.length} files, ${findingCount} findings, ${batchesInFlight} in flight)`,
+        batchIndex: idx,
+        totalBatches: batches.length,
       });
 
-      let result = await gen.next();
-      while (!result.done) {
+      try {
+        const gen = agent.revalidate({
+          batch,
+          projectRoot: effectiveRootPath,
+          projectInfo,
+          config,
+          force,
+          signal: quotaAbort.signal,
+        });
+
+        let result = await gen.next();
+        while (!result.done) {
+          emitProgress({
+            type: "agent_progress",
+            message: (result.value as AgentProgress).message,
+            batchIndex: idx,
+            totalBatches: batches.length,
+            agentProgress: result.value as AgentProgress,
+          });
+          result = await gen.next();
+        }
+
+        const output = result.value as RevalidateOutput;
+        const batchMeta = output.meta;
+        totalCostUsd += batchMeta.costUsd ?? 0;
+
+        // Match verdicts to findings across all files in the batch
+        for (const verdict of output.verdicts) {
+          const file = batch.find((f) => f.filePath === verdict.filePath);
+          if (!file) continue;
+          const finding = file.findings.find((f) => f.title === verdict.title);
+          if (!finding) continue;
+          finding.revalidation = {
+            verdict: verdict.verdict,
+            reasoning: verdict.reasoning,
+            adjustedSeverity: verdict.adjustedSeverity,
+            revalidatedAt: new Date().toISOString(),
+            runId,
+            model,
+          };
+          if (verdict.adjustedSeverity) {
+            finding.severity = verdict.adjustedSeverity;
+          }
+          totalRevalidated++;
+          if (verdict.verdict === "true-positive") totalTP++;
+          else if (verdict.verdict === "false-positive") totalFP++;
+          else if (verdict.verdict === "fixed") totalFixed++;
+          else totalUncertain++;
+        }
+
+        // Push a per-file `analysisHistory` entry for this revalidate batch.
+        // Without this, revalidate cost is only ever recorded in
+        // `runMeta.stats.totalCostUsd` and is invisible to the `metrics`
+        // command (which aggregates strictly off `record.analysisHistory`).
+        // We split batch-level cost / tokens / duration / turns evenly over
+        // the files in the batch so the per-file totals add up to the
+        // batch's actual spend.
+        const splitN = Math.max(1, batch.length);
+        const perFileCost = batchMeta.costUsd != null ? batchMeta.costUsd / splitN : undefined;
+        const perFileUsage = batchMeta.usage
+          ? {
+              inputTokens: batchMeta.usage.inputTokens / splitN,
+              outputTokens: batchMeta.usage.outputTokens / splitN,
+              cacheReadInputTokens: batchMeta.usage.cacheReadInputTokens / splitN,
+              cacheCreationInputTokens: batchMeta.usage.cacheCreationInputTokens / splitN,
+            }
+          : undefined;
+        const perFileDurationMs = batchMeta.durationMs / splitN;
+        const perFileDurationApiMs =
+          batchMeta.durationApiMs != null ? batchMeta.durationApiMs / splitN : undefined;
+        const perFileNumTurns =
+          batchMeta.numTurns != null ? batchMeta.numTurns / splitN : undefined;
+        const investigatedAt = new Date().toISOString();
+
+        for (const file of batch) {
+          const verdictsForFile = output.verdicts.filter(
+            (v) => v.filePath === file.filePath,
+          ).length;
+          file.analysisHistory.push({
+            runId,
+            investigatedAt,
+            durationMs: perFileDurationMs,
+            durationApiMs: perFileDurationApiMs,
+            agentType,
+            model,
+            modelConfig: config,
+            agentSessionId: batchMeta.agentSessionId,
+            findingCount: verdictsForFile,
+            numTurns: perFileNumTurns,
+            phase: "revalidate",
+            costUsd: perFileCost,
+            usage: perFileUsage,
+            refusal: batchMeta.refusal,
+            codexStderr: batchMeta.codexStderr,
+          });
+
+          try {
+            enrichFileRecord(file, effectiveRootPath);
+          } catch (e) {
+            console.error(
+              `[deepsec] enrich failed for ${file.filePath}: ${e instanceof Error ? e.message : e}`,
+            );
+          }
+          writeFileRecord(file);
+        }
+
+        batchesInFlight--;
+        batchesCompleted++;
         emitProgress({
-          type: "agent_progress",
-          message: (result.value as AgentProgress).message,
+          type: "batch_complete",
+          message: `Batch ${idx + 1}/${batches.length}: ${output.verdicts.length} verdicts (${batchesInFlight} in flight, ${batchesCompleted}/${batches.length} done)`,
           batchIndex: idx,
           totalBatches: batches.length,
-          agentProgress: result.value as AgentProgress,
         });
-        result = await gen.next();
-      }
-
-      const output = result.value as RevalidateOutput;
-      const batchMeta = output.meta;
-      totalCostUsd += batchMeta.costUsd ?? 0;
-
-      // Match verdicts to findings across all files in the batch
-      for (const verdict of output.verdicts) {
-        const file = batch.find((f) => f.filePath === verdict.filePath);
-        if (!file) continue;
-        const finding = file.findings.find((f) => f.title === verdict.title);
-        if (!finding) continue;
-        finding.revalidation = {
-          verdict: verdict.verdict,
-          reasoning: verdict.reasoning,
-          adjustedSeverity: verdict.adjustedSeverity,
-          revalidatedAt: new Date().toISOString(),
-          runId,
-          model,
-        };
-        if (verdict.adjustedSeverity) {
-          finding.severity = verdict.adjustedSeverity;
+      } catch (err) {
+        batchesInFlight--;
+        batchesCompleted++;
+        if (err instanceof QuotaExhaustedError && !quotaExhausted) {
+          quotaExhausted = { source: err.source, rawMessage: err.rawMessage };
+          quotaAbort.abort(err);
         }
-        totalRevalidated++;
-        if (verdict.verdict === "true-positive") totalTP++;
-        else if (verdict.verdict === "false-positive") totalFP++;
-        else if (verdict.verdict === "fixed") totalFixed++;
-        else totalUncertain++;
-      }
-
-      // Push a per-file `analysisHistory` entry for this revalidate batch.
-      // Without this, revalidate cost is only ever recorded in
-      // `runMeta.stats.totalCostUsd` and is invisible to the `metrics`
-      // command (which aggregates strictly off `record.analysisHistory`).
-      // We split batch-level cost / tokens / duration / turns evenly over
-      // the files in the batch so the per-file totals add up to the
-      // batch's actual spend.
-      const splitN = Math.max(1, batch.length);
-      const perFileCost = batchMeta.costUsd != null ? batchMeta.costUsd / splitN : undefined;
-      const perFileUsage = batchMeta.usage
-        ? {
-            inputTokens: batchMeta.usage.inputTokens / splitN,
-            outputTokens: batchMeta.usage.outputTokens / splitN,
-            cacheReadInputTokens: batchMeta.usage.cacheReadInputTokens / splitN,
-            cacheCreationInputTokens: batchMeta.usage.cacheCreationInputTokens / splitN,
-          }
-        : undefined;
-      const perFileDurationMs = batchMeta.durationMs / splitN;
-      const perFileDurationApiMs =
-        batchMeta.durationApiMs != null ? batchMeta.durationApiMs / splitN : undefined;
-      const perFileNumTurns = batchMeta.numTurns != null ? batchMeta.numTurns / splitN : undefined;
-      const investigatedAt = new Date().toISOString();
-
-      for (const file of batch) {
-        const verdictsForFile = output.verdicts.filter((v) => v.filePath === file.filePath).length;
-        file.analysisHistory.push({
-          runId,
-          investigatedAt,
-          durationMs: perFileDurationMs,
-          durationApiMs: perFileDurationApiMs,
-          agentType,
-          model,
-          modelConfig: config,
-          agentSessionId: batchMeta.agentSessionId,
-          findingCount: verdictsForFile,
-          numTurns: perFileNumTurns,
-          phase: "revalidate",
-          costUsd: perFileCost,
-          usage: perFileUsage,
-          refusal: batchMeta.refusal,
-          codexStderr: batchMeta.codexStderr,
+        emitProgress({
+          type: "batch_complete",
+          message: `Batch ${idx + 1}/${batches.length} failed: ${err instanceof Error ? err.message : String(err)} (${batchesInFlight} in flight, ${batchesCompleted}/${batches.length} done)`,
+          batchIndex: idx,
+          totalBatches: batches.length,
         });
+      }
+    }
 
-        try {
-          enrichFileRecord(file, effectiveRootPath);
-        } catch (e) {
-          console.error(
-            `[deepsec] enrich failed for ${file.filePath}: ${e instanceof Error ? e.message : e}`,
-          );
+    if (concurrency <= 1) {
+      for (let i = 0; i < batches.length; i++) {
+        if (quotaAbort.signal.aborted) break;
+        await revalidateBatch(batches[i], i);
+      }
+    } else {
+      let nextIdx = 0;
+      async function worker() {
+        while (nextIdx < batches.length) {
+          if (quotaAbort.signal.aborted) return;
+          const idx = nextIdx++;
+          await revalidateBatch(batches[idx], idx);
         }
-        writeFileRecord(file);
       }
-
-      batchesInFlight--;
-      batchesCompleted++;
-      emitProgress({
-        type: "batch_complete",
-        message: `Batch ${idx + 1}/${batches.length}: ${output.verdicts.length} verdicts (${batchesInFlight} in flight, ${batchesCompleted}/${batches.length} done)`,
-        batchIndex: idx,
-        totalBatches: batches.length,
-      });
-    } catch (err) {
-      batchesInFlight--;
-      batchesCompleted++;
-      if (err instanceof QuotaExhaustedError && !quotaExhausted) {
-        quotaExhausted = { source: err.source, rawMessage: err.rawMessage };
-        quotaAbort.abort(err);
-      }
-      emitProgress({
-        type: "batch_complete",
-        message: `Batch ${idx + 1}/${batches.length} failed: ${err instanceof Error ? err.message : String(err)} (${batchesInFlight} in flight, ${batchesCompleted}/${batches.length} done)`,
-        batchIndex: idx,
-        totalBatches: batches.length,
-      });
+      await Promise.all(
+        Array.from({ length: Math.min(concurrency, batches.length) }, () => worker()),
+      );
     }
-  }
 
-  if (concurrency <= 1) {
-    for (let i = 0; i < batches.length; i++) {
-      if (quotaAbort.signal.aborted) break;
-      await revalidateBatch(batches[i], i);
-    }
-  } else {
-    let nextIdx = 0;
-    async function worker() {
-      while (nextIdx < batches.length) {
-        if (quotaAbort.signal.aborted) return;
-        const idx = nextIdx++;
-        await revalidateBatch(batches[idx], idx);
-      }
-    }
-    await Promise.all(
-      Array.from({ length: Math.min(concurrency, batches.length) }, () => worker()),
-    );
-  }
+    completeRun(projectId, runId, "done", {
+      findingsRevalidated: totalRevalidated,
+      truePositives: totalTP,
+      falsePositives: totalFP,
+      fixed: totalFixed,
+      uncertain: totalUncertain,
+      totalCostUsd,
+    });
 
-  completeRun(projectId, runId, "done", {
-    findingsRevalidated: totalRevalidated,
-    truePositives: totalTP,
-    falsePositives: totalFP,
-    fixed: totalFixed,
-    uncertain: totalUncertain,
-    totalCostUsd,
-  });
+    emitProgress({
+      type: "all_complete",
+      message: quotaExhausted
+        ? `Revalidation stopped: ${quotaExhausted.source} quota/credits exhausted (${totalRevalidated} verdicts before stop)`
+        : `Revalidation complete: ${totalRevalidated} findings — TP: ${totalTP}, FP: ${totalFP}, Fixed: ${totalFixed}, Uncertain: ${totalUncertain}`,
+    });
 
-  emitProgress({
-    type: "all_complete",
-    message: quotaExhausted
-      ? `Revalidation stopped: ${quotaExhausted.source} quota/credits exhausted (${totalRevalidated} verdicts before stop)`
-      : `Revalidation complete: ${totalRevalidated} findings — TP: ${totalTP}, FP: ${totalFP}, Fixed: ${totalFixed}, Uncertain: ${totalUncertain}`,
-  });
-
-  return {
-    runId,
-    revalidated: totalRevalidated,
-    truePositives: totalTP,
-    falsePositives: totalFP,
-    fixed: totalFixed,
-    uncertain: totalUncertain,
-    quotaExhausted,
-  };
+    return {
+      runId,
+      revalidated: totalRevalidated,
+      truePositives: totalTP,
+      falsePositives: totalFP,
+      fixed: totalFixed,
+      uncertain: totalUncertain,
+      quotaExhausted,
+    };
   } catch (err) {
     try {
       completeRun(projectId, runId, "error");

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type { FileRecord, Severity } from "@deepsec/core";
 import {
@@ -8,10 +9,12 @@ import {
   dataDir,
   defaultConcurrency,
   getRegistry,
+  isPidAlive,
   loadAllFileRecords,
   readFileRecord,
   readProjectConfig,
   readRunMeta,
+  registerActiveRun,
   writeFileRecord,
   writeRunMeta,
 } from "@deepsec/core";
@@ -276,6 +279,14 @@ export async function process(params: {
     runId = meta.runId;
   }
 
+  // Catch SIGINT/SIGTERM and any thrown error path: flip the run's
+  // phase to "error" so its locks become immediately reclaimable by
+  // the next invocation instead of waiting out STALE_LOCK_MS (1h).
+  // Hard kills (SIGKILL/OOM/power) bypass this; those are handled by
+  // the PID-liveness branch in isReclaimableLock.
+  const unregisterRun = registerActiveRun(projectId, runId);
+
+  try {
   const registry = createDefaultAgentRegistry();
   const maybeAgent = registry.get(agentType);
   if (!maybeAgent) {
@@ -289,35 +300,55 @@ export async function process(params: {
   // run grabs files the first run is mid-investigation on, both write
   // back, and findings/history get clobbered.
   //
-  // A lock is reclaimable when EITHER:
+  // A lock is reclaimable when ANY of:
   //   1. The owning run's RunMeta says it's done/error/missing — the
-  //      lock won't be released by the original owner, ever.
-  //   2. The lock is older than STALE_LOCK_MS and the owning run's
-  //      RunMeta phase is still "running" (likely a hard crash; the
-  //      heartbeat would update lockedAt during normal progress).
+  //      lock won't be released by the original owner, ever. Covers the
+  //      graceful-shutdown path (SIGINT/SIGTERM) where we proactively
+  //      flip the run to `error` before exiting.
+  //   2. The owning run was started on this host and its PID is no
+  //      longer alive — the run crashed (SIGKILL / OOM / power loss)
+  //      without flipping phase. PID liveness gives us instant recovery
+  //      instead of waiting out STALE_LOCK_MS.
+  //   3. The lock is older than STALE_LOCK_MS — backstop for cross-host
+  //      stale runs and any case where neither phase nor PID tell us.
   //
   // STALE_LOCK_MS is generous (1h) because individual investigations
   // can legitimately take 20–40 minutes on big repos with max
   // thinking. False reclaims are catastrophic; false rejections only
   // cost a retry on the next run.
   const STALE_LOCK_MS = 60 * 60 * 1000;
+  const localHostname = os.hostname();
   const isReclaimableLock = (r: FileRecord): boolean => {
     if (!r.lockedByRunId) return true;
     // Cross-check the owning run's status. A done/error/missing run's
     // lock is always safe to reclaim — nobody is going to flip the
     // record back to "analyzed".
-    let ownerPhase: "running" | "done" | "error" | undefined;
+    let ownerMeta: Awaited<ReturnType<typeof readRunMeta>> | undefined;
     try {
-      ownerPhase = readRunMeta(projectId, r.lockedByRunId).phase;
+      ownerMeta = readRunMeta(projectId, r.lockedByRunId);
     } catch {
       // Missing/corrupt run-meta — owning run is gone, reclaim safely.
       return true;
     }
-    if (ownerPhase === "done" || ownerPhase === "error") return true;
-    // Owner reports running — only reclaim after a stale-lock timeout
-    // (hard crashes leave phase=running forever). Records written
-    // before lockedAt existed have no timestamp; treat those as old
-    // enough to reclaim so we can recover legacy locked state.
+    if (ownerMeta.phase === "done" || ownerMeta.phase === "error") return true;
+    // Owner reports running — but it may have crashed without updating
+    // phase. If the run was started on this host and we recorded its
+    // PID, check whether the process is still alive. A dead PID means
+    // the run is genuinely gone and the lock can be reclaimed now,
+    // without waiting out STALE_LOCK_MS. Cross-host (different
+    // hostname) we can't probe, so we fall through to the timestamp
+    // check.
+    if (
+      ownerMeta.pid !== undefined &&
+      ownerMeta.hostname !== undefined &&
+      ownerMeta.hostname === localHostname &&
+      !isPidAlive(ownerMeta.pid)
+    ) {
+      return true;
+    }
+    // Records written before lockedAt existed have no timestamp; treat
+    // those as old enough to reclaim so we can recover legacy locked
+    // state.
     if (!r.lockedAt) return true;
     const ageMs = Date.now() - new Date(r.lockedAt).getTime();
     return ageMs >= STALE_LOCK_MS;
@@ -754,6 +785,20 @@ export async function process(params: {
     errorBatchCount: batchesFailed,
     quotaExhausted,
   };
+  } catch (err) {
+    // Body threw before completing. Flip phase to "error" so the
+    // run's locks become reclaimable on the next call rather than
+    // staying "running" with a live PID (which the same-process
+    // case would otherwise treat as a healthy owner).
+    try {
+      completeRun(projectId, runId, "error");
+    } catch {
+      // best-effort
+    }
+    throw err;
+  } finally {
+    unregisterRun();
+  }
 }
 
 // --- Revalidation ---
@@ -859,6 +904,13 @@ export async function revalidate(params: {
     runId = meta.runId;
   }
 
+  // Same shutdown handling as process(): revalidate doesn't lock
+  // FileRecords, but the RunMeta itself can otherwise be stranded at
+  // phase="running" forever on Ctrl+C, which is misleading in status
+  // listings.
+  const unregisterRun = registerActiveRun(projectId, runId);
+
+  try {
   const registry = createDefaultAgentRegistry();
   const maybeAgent = registry.get(agentType);
   if (!maybeAgent) {
@@ -1123,4 +1175,14 @@ export async function revalidate(params: {
     uncertain: totalUncertain,
     quotaExhausted,
   };
+  } catch (err) {
+    try {
+      completeRun(projectId, runId, "error");
+    } catch {
+      // best-effort
+    }
+    throw err;
+  } finally {
+    unregisterRun();
+  }
 }


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
