### PR TITLE
If JSON parsing fails, write debug output for postmortem analysis

### DIFF
--- a/packages/deepsec/src/__tests__/tarball.test.ts
+++ b/packages/deepsec/src/__tests__/tarball.test.ts
@@ -89,6 +89,26 @@ describe("extractTarballLocally — strict allowlist", () => {
     expect(fs.existsSync(path.join(destDir, "reports", "report.md"))).toBe(true);
   });
 
+  it("accepts parse-failure debug dumps under debug/*.txt", async () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-tar-debug-"));
+    fs.mkdirSync(path.join(src, "debug"));
+    fs.writeFileSync(
+      path.join(src, "debug", "parse-error-investigate-2026-01-01T00-00-00-000Z.txt"),
+      "not actually json {",
+    );
+    const stats = await makeTarball(src, []);
+    fs.rmSync(src, { recursive: true, force: true });
+
+    const count = await extractTarballLocally(stats.tarPath, destDir);
+    fs.unlinkSync(stats.tarPath);
+    expect(count).toBe(1);
+    expect(
+      fs.existsSync(
+        path.join(destDir, "debug", "parse-error-investigate-2026-01-01T00-00-00-000Z.txt"),
+      ),
+    ).toBe(true);
+  });
+
   it("refuses a tarball with a disallowed extension and writes nothing", async () => {
     const src = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-tar-bad-"));
     fs.mkdirSync(path.join(src, "files"));
@@ -96,7 +116,10 @@ describe("extractTarballLocally — strict allowlist", () => {
       path.join(src, "files", "record.ts.json"),
       JSON.stringify(validRecord(path.basename(destDir), "record.ts")),
     );
-    fs.writeFileSync(path.join(src, "files", "secret.txt"), "uh oh");
+    // `.sh` is outside the allowlist (.json/.md/.csv/.txt). Plain `.txt`
+    // is now allowed for parse-failure debug dumps, so we pick an
+    // extension that's still rejected for the extension check itself.
+    fs.writeFileSync(path.join(src, "files", "secret.sh"), "uh oh");
     const stats = await makeTarball(src, []);
     fs.rmSync(src, { recursive: true, force: true });
 

--- a/packages/deepsec/src/sandbox/download.ts
+++ b/packages/deepsec/src/sandbox/download.ts
@@ -6,11 +6,15 @@ import * as tar from "tar";
 import { mergeAfterExtract, snapshotFileRecords } from "./merge-records.js";
 import { DATA_DIR } from "./setup.js";
 
-// Sandbox results are JSON file records, run metadata, and reports —
-// nothing else. Lock the extract to these extensions so a tampered or
-// buggy tarball can't smuggle anything else onto the host. If the
-// sandbox legitimately needs to return a new file type, add it here.
-const ALLOWED_EXTENSIONS = new Set([".json", ".md", ".csv"]);
+// Sandbox results are JSON file records, run metadata, reports, and
+// debug dumps — nothing else. Lock the extract to these extensions so a
+// tampered or buggy tarball can't smuggle anything else onto the host.
+// If the sandbox legitimately needs to return a new file type, add it
+// here. `.txt` is for parse-failure debug dumps (see
+// `writeParseFailureDebug` in the processor); the agent's raw response
+// that failed JSON parsing is preserved verbatim and isn't guaranteed
+// to be valid JSON, hence a separate extension.
+const ALLOWED_EXTENSIONS = new Set([".json", ".md", ".csv", ".txt"]);
 
 // Namespace allowlist applied to every entry path inside the per-project
 // tarball. The sandbox is the explicit trust boundary — even if someone
@@ -32,6 +36,12 @@ const ALLOWED_ENTRY_PATTERNS: RegExp[] = [
   /^\.?\/?files\/(?:[^/\\\0]+\/)*[^/\\\0]+\.json$/,
   /^\.?\/?runs\/[^/\\\0]+\.json$/,
   /^\.?\/?reports\/report[^/\\\0]*\.(?:json|md|csv)$/,
+  // Parse-failure dumps from the processor: a flat directory containing
+  // `parse-error-<phase>-<timestamp>.txt` files. Names use only safe
+  // characters (the timestamp is an ISO string with `:`/`.` replaced by
+  // `-`), but the allowlist character class matches the same broad shape
+  // as the files/ pattern so future debug filenames don't get rejected.
+  /^\.?\/?debug\/[^/\\\0]+\.txt$/,
 ];
 
 // Belt-and-suspenders caps on a sandbox-supplied tarball. The numbers err

--- a/packages/processor/src/__tests__/shared.test.ts
+++ b/packages/processor/src/__tests__/shared.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   classifyQuotaError,
@@ -7,6 +10,7 @@ import {
   parseRefusalReport,
   parseRevalidateVerdicts,
   QuotaExhaustedError,
+  writeParseFailureDebug,
 } from "../agents/shared.js";
 
 describe("isTransientError", () => {
@@ -297,5 +301,49 @@ describe("parseRevalidateVerdicts", () => {
 
   it("throws on parse failure", () => {
     expect(() => parseRevalidateVerdicts("garbage")).toThrow(/wasn't parseable JSON/);
+  });
+});
+
+describe("writeParseFailureDebug", () => {
+  let tmp: string;
+  let prevDataRoot: string | undefined;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-debug-"));
+    prevDataRoot = process.env.DEEPSEC_DATA_ROOT;
+    process.env.DEEPSEC_DATA_ROOT = tmp;
+  });
+  afterEach(() => {
+    if (prevDataRoot === undefined) delete process.env.DEEPSEC_DATA_ROOT;
+    else process.env.DEEPSEC_DATA_ROOT = prevDataRoot;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes raw agent output to data/<projectId>/debug/parse-error-<phase>-<ts>.txt", () => {
+    const written = writeParseFailureDebug({
+      projectId: "demo",
+      phase: "investigate",
+      agentType: "claude-agent-sdk",
+      resultText: "{ not valid json",
+      error: new Error("Unexpected token n"),
+      batch: [],
+    });
+    expect(written).toBeDefined();
+    expect(written!).toMatch(/\/demo\/debug\/parse-error-investigate-.*\.txt$/);
+    const body = fs.readFileSync(written!, "utf-8");
+    expect(body).toContain("# phase: investigate");
+    expect(body).toContain("# agentType: claude-agent-sdk");
+    expect(body).toContain("Unexpected token n");
+    expect(body).toContain("{ not valid json");
+  });
+
+  it("is a no-op without a projectId", () => {
+    expect(
+      writeParseFailureDebug({
+        phase: "revalidate",
+        agentType: "codex",
+        resultText: "garbage",
+        error: new Error("x"),
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/processor/src/agents/claude-agent-sdk.ts
+++ b/packages/processor/src/agents/claude-agent-sdk.ts
@@ -20,8 +20,10 @@ import type {
   BatchMeta,
   InvestigateOutput,
   InvestigateParams,
+  InvestigateResult,
   RevalidateOutput,
   RevalidateParams,
+  RevalidateVerdict,
 } from "./types.js";
 
 /**
@@ -391,7 +393,7 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
       );
     }
 
-    let results;
+    let results: InvestigateResult[];
     try {
       results = parseInvestigateResults(resultText, batch);
     } catch (err) {
@@ -548,7 +550,7 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
     }
 
     const durationMs = Date.now() - startTime;
-    let verdicts;
+    let verdicts: RevalidateVerdict[];
     try {
       verdicts = parseRevalidateVerdicts(resultText);
     } catch (err) {

--- a/packages/processor/src/agents/claude-agent-sdk.ts
+++ b/packages/processor/src/agents/claude-agent-sdk.ts
@@ -12,6 +12,7 @@ import {
   parseRevalidateVerdicts,
   QuotaExhaustedError,
   REFUSAL_FOLLOWUP_PROMPT,
+  writeParseFailureDebug,
 } from "./shared.js";
 import type {
   AgentPlugin,
@@ -172,7 +173,7 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
   type = "claude-agent-sdk";
 
   async *investigate(params: InvestigateParams): AsyncGenerator<AgentProgress, InvestigateOutput> {
-    const { batch, projectRoot, promptTemplate, projectInfo, config, signal } = params;
+    const { batch, projectRoot, promptTemplate, projectInfo, config, signal, projectId } = params;
     const model = (config.model as string) ?? "claude-opus-4-7";
     const maxTurns = (config.maxTurns as number) ?? 150;
     // Bridge the processor-supplied AbortSignal to an AbortController the
@@ -390,8 +391,23 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
       );
     }
 
+    let results;
+    try {
+      results = parseInvestigateResults(resultText, batch);
+    } catch (err) {
+      writeParseFailureDebug({
+        projectId,
+        phase: "investigate",
+        agentType: this.type,
+        resultText,
+        error: err,
+        batch,
+      });
+      throw err;
+    }
+
     return {
-      results: parseInvestigateResults(resultText, batch),
+      results,
       meta: {
         durationMs,
         ...sdkMeta,
@@ -401,7 +417,7 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
   }
 
   async *revalidate(params: RevalidateParams): AsyncGenerator<AgentProgress, RevalidateOutput> {
-    const { batch, projectRoot, projectInfo, config, force = false, signal } = params;
+    const { batch, projectRoot, projectInfo, config, force = false, signal, projectId } = params;
     const model = (config.model as string) ?? "claude-opus-4-7";
     const maxTurns = (config.maxTurns as number) ?? 150;
 
@@ -532,7 +548,20 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
     }
 
     const durationMs = Date.now() - startTime;
-    const verdicts = parseRevalidateVerdicts(resultText);
+    let verdicts;
+    try {
+      verdicts = parseRevalidateVerdicts(resultText);
+    } catch (err) {
+      writeParseFailureDebug({
+        projectId,
+        phase: "revalidate",
+        agentType: this.type,
+        resultText,
+        error: err,
+        batch,
+      });
+      throw err;
+    }
 
     const refusal = await runRefusalFollowUp(sdkMeta.agentSessionId, model, projectRoot);
     if (refusal?.refused) {

--- a/packages/processor/src/agents/codex-sdk.ts
+++ b/packages/processor/src/agents/codex-sdk.ts
@@ -32,8 +32,10 @@ import type {
   BatchMeta,
   InvestigateOutput,
   InvestigateParams,
+  InvestigateResult,
   RevalidateOutput,
   RevalidateParams,
+  RevalidateVerdict,
 } from "./types.js";
 
 const DEFAULT_MODEL = "gpt-5.5";
@@ -843,7 +845,7 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
         );
       }
 
-      let parsed;
+      let parsed: InvestigateResult[];
       try {
         parsed = parseInvestigateResults(resultText, batch);
       } catch (err) {
@@ -1073,7 +1075,7 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
         );
       }
 
-      let verdicts;
+      let verdicts: RevalidateVerdict[];
       try {
         verdicts = parseRevalidateVerdicts(resultText);
       } catch (err) {

--- a/packages/processor/src/agents/codex-sdk.ts
+++ b/packages/processor/src/agents/codex-sdk.ts
@@ -24,6 +24,7 @@ import {
   parseRevalidateVerdicts,
   QuotaExhaustedError,
   REFUSAL_FOLLOWUP_PROMPT,
+  writeParseFailureDebug,
 } from "./shared.js";
 import type {
   AgentPlugin,
@@ -627,7 +628,7 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
   type = "codex";
 
   async *investigate(params: InvestigateParams): AsyncGenerator<AgentProgress, InvestigateOutput> {
-    const { batch, projectRoot, promptTemplate, projectInfo, config, signal } = params;
+    const { batch, projectRoot, promptTemplate, projectInfo, config, signal, projectId } = params;
     const model = (config.model as string) ?? DEFAULT_MODEL;
     const effort = (config.reasoningEffort as ModelReasoningEffort) ?? DEFAULT_EFFORT;
 
@@ -842,7 +843,20 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
         );
       }
 
-      const parsed = parseInvestigateResults(resultText, batch);
+      let parsed;
+      try {
+        parsed = parseInvestigateResults(resultText, batch);
+      } catch (err) {
+        writeParseFailureDebug({
+          projectId,
+          phase: "investigate",
+          agentType: this.type,
+          resultText,
+          error: err,
+          batch,
+        });
+        throw err;
+      }
       if (DEBUG) {
         const matched = parsed.filter((r) => r.findings.length > 0).length;
         const totalFindings = parsed.reduce((s, r) => s + r.findings.length, 0);
@@ -873,7 +887,7 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
   }
 
   async *revalidate(params: RevalidateParams): AsyncGenerator<AgentProgress, RevalidateOutput> {
-    const { batch, projectRoot, projectInfo, config, force = false, signal } = params;
+    const { batch, projectRoot, projectInfo, config, force = false, signal, projectId } = params;
     const model = (config.model as string) ?? DEFAULT_MODEL;
     const effort = (config.reasoningEffort as ModelReasoningEffort) ?? DEFAULT_EFFORT;
 
@@ -1059,7 +1073,20 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
         );
       }
 
-      const verdicts = parseRevalidateVerdicts(resultText);
+      let verdicts;
+      try {
+        verdicts = parseRevalidateVerdicts(resultText);
+      } catch (err) {
+        writeParseFailureDebug({
+          projectId,
+          phase: "revalidate",
+          agentType: this.type,
+          resultText,
+          error: err,
+          batch,
+        });
+        throw err;
+      }
       if (DEBUG) {
         yield {
           type: "thinking",

--- a/packages/processor/src/agents/shared.ts
+++ b/packages/processor/src/agents/shared.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from "node:child_process";
-import type { FileRecord, Finding, RefusalReport } from "@deepsec/core";
+import fs from "node:fs";
+import path from "node:path";
+import { dataDir, type FileRecord, type Finding, type RefusalReport } from "@deepsec/core";
 import type { InvestigateResult, RevalidateVerdict } from "./types.js";
 
 // --- Retry / backoff -------------------------------------------------------
@@ -387,6 +389,48 @@ After your investigation, output a JSON block with your findings for EACH file. 
 **vulnSlug** can be any of the known categories OR a custom slug for issues not covered by the scanner. Use \`"other"\` as the slug prefix for novel findings (e.g., \`"other-race-condition"\`, \`"other-logic-bug"\`, \`"other-info-disclosure"\`).
 
 If a file has no real vulnerabilities after thorough investigation, include it with an empty findings array.`;
+}
+
+/**
+ * Persist the raw agent output that failed to parse as JSON to a debug
+ * location. Lives at `data/<projectId>/debug/parse-error-<phase>-<ts>.txt`
+ * so a sandbox run picks it up in the normal results tarball — the
+ * sandbox download allowlist explicitly accepts `debug/*.txt`.
+ *
+ * Best-effort: never throws (callers are already on the error path and
+ * we don't want to mask the original JSON-parse error with a disk-full
+ * EIO). Returns the path written to, or undefined on failure.
+ */
+export function writeParseFailureDebug(params: {
+  projectId?: string;
+  phase: "investigate" | "revalidate";
+  agentType: string;
+  resultText: string;
+  error: unknown;
+  batch?: FileRecord[];
+}): string | undefined {
+  const { projectId, phase, agentType, resultText, error, batch } = params;
+  if (!projectId) return undefined;
+  try {
+    const dir = path.join(dataDir(projectId), "debug");
+    fs.mkdirSync(dir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const file = path.join(dir, `parse-error-${phase}-${ts}.txt`);
+    const errMsg = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+    const filesList = batch?.map((b) => `  - ${b.filePath}`).join("\n") ?? "  (none)";
+    const header =
+      `# deepsec parse-failure debug dump\n` +
+      `# phase: ${phase}\n` +
+      `# agentType: ${agentType}\n` +
+      `# timestamp: ${new Date().toISOString()}\n` +
+      `# error: ${errMsg}\n` +
+      `# batch (${batch?.length ?? 0} files):\n${filesList}\n` +
+      `# --- raw agent output begins on next line ---\n`;
+    fs.writeFileSync(file, header + resultText, "utf-8");
+    return file;
+  } catch {
+    return undefined;
+  }
 }
 
 export function parseInvestigateResults(

--- a/packages/processor/src/agents/types.ts
+++ b/packages/processor/src/agents/types.ts
@@ -21,6 +21,13 @@ export interface InvestigateParams {
    * request rather than waiting for the next polled message.
    */
   signal?: AbortSignal;
+  /**
+   * Project id, used by agent plugins for debug-log placement (e.g.
+   * raw agent output that failed JSON parsing is written under
+   * `data/<projectId>/debug/` so it survives a sandbox run via the
+   * normal tarball download).
+   */
+  projectId?: string;
 }
 
 export interface InvestigateResult {
@@ -64,6 +71,8 @@ export interface RevalidateParams {
   force?: boolean;
   /** See InvestigateParams.signal — same semantics for revalidation. */
   signal?: AbortSignal;
+  /** See InvestigateParams.projectId — used for debug-log placement. */
+  projectId?: string;
 }
 
 export interface RevalidateVerdict {

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -585,6 +585,7 @@ export async function process(params: {
           projectInfo: projectInfoForAgent,
           config,
           signal: quotaAbort.signal,
+          projectId,
         });
 
         let result = await gen.next();
@@ -1015,6 +1016,7 @@ export async function revalidate(params: {
           config,
           force,
           signal: quotaAbort.signal,
+          projectId,
         });
 
         let result = await gen.next();


### PR DESCRIPTION
  - packages/processor/src/agents/shared.ts — added writeParseFailureDebug({ projectId, phase, agentType, resultText, error, batch }) that writes the
  raw agent output to data/<projectId>/debug/parse-error-<phase>-<timestamp>.txt with a small header (phase, agentType, error, batch files).
  Best-effort: never throws and no-ops without a projectId.
  - packages/processor/src/agents/types.ts — added optional projectId to InvestigateParams and RevalidateParams.
  - packages/processor/src/index.ts — pipes projectId through to agent.investigate(...) and agent.revalidate(...).
  - packages/processor/src/agents/claude-agent-sdk.ts + codex-sdk.ts — wrap parseInvestigateResults and parseRevalidateVerdicts in try/catch; on
  failure, call writeParseFailureDebug with the raw resultText then re-throw so the existing fail-loud behavior is preserved.
  - packages/deepsec/src/sandbox/download.ts — added .txt to ALLOWED_EXTENSIONS and debug/*.txt to ALLOWED_ENTRY_PATTERNS so sandbox runs return debug
  dumps in the normal tarball. mergeAfterExtract only walks files/, so the new tree is left alone.
  - Tests — added coverage for writeParseFailureDebug and for debug/*.txt extraction; fixed the existing extension-rejection test to use .sh (now that
  .txt is allowed). 2103/2103 unit tests pass.