### PR TITLE
Add duplicate as an outcome for revalidate

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -12,9 +12,23 @@ export const revalidationSchema = z.object({
   // finding is a real true-positive, but the team has consciously chosen to
   // live with it — see the "accepted risks" section in the project README.
   // Treated like "false-positive" for PR-comment / report-default filtering.
-  verdict: z.enum(["true-positive", "false-positive", "fixed", "uncertain", "accepted-risk"]),
+  //
+  // "duplicate" means the finding describes the same underlying issue as
+  // another finding in the same file. `duplicateOf` points at the primary
+  // (canonical) finding by `title`. The primary keeps its real verdict;
+  // the processor rejects any DUPE whose `duplicateOf` is missing or
+  // points at another DUPE so each group has exactly one non-DUPE.
+  verdict: z.enum([
+    "true-positive",
+    "false-positive",
+    "fixed",
+    "uncertain",
+    "accepted-risk",
+    "duplicate",
+  ]),
   reasoning: z.string(),
   adjustedSeverity: z.enum(["CRITICAL", "HIGH", "MEDIUM", "HIGH_BUG", "BUG", "LOW"]).optional(),
+  duplicateOf: z.string().optional(),
   revalidatedAt: z.string(),
   runId: z.string(),
   model: z.string(),
@@ -207,6 +221,7 @@ export const runMetaSchema = z.object({
     falsePositives: z.number().optional(),
     fixed: z.number().optional(),
     uncertain: z.number().optional(),
+    duplicates: z.number().optional(),
   }),
 });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -73,6 +73,7 @@ export interface RunMeta {
     falsePositives?: number;
     fixed?: number;
     uncertain?: number;
+    duplicates?: number;
   };
 }
 
@@ -169,12 +170,24 @@ export type RevalidationVerdict =
   // Manual marker (the agent never sets this): real true-positive that
   // the team has consciously chosen to accept. See the schema comment in
   // `schemas.ts` and the "Accepted risks" section of the project README.
-  | "accepted-risk";
+  | "accepted-risk"
+  // The agent flagged this finding as a duplicate of another finding in
+  // the same file. The canonical one keeps its real verdict; duplicates
+  // point at it via `duplicateOf` (the primary's `title`). The processor
+  // enforces that the primary itself is not a duplicate so each
+  // equivalence class has exactly one non-duplicate.
+  | "duplicate";
 
 export interface Revalidation {
   verdict: RevalidationVerdict;
   reasoning: string;
   adjustedSeverity?: Severity;
+  /**
+   * Set iff `verdict === "duplicate"`. Holds the `title` of the primary
+   * finding in the same file. The primary's verdict is the canonical
+   * one for the underlying issue.
+   */
+  duplicateOf?: string;
   revalidatedAt: string;
   runId: string;
   model: string;

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/src/commands/export.ts
+++ b/packages/deepsec/src/commands/export.ts
@@ -450,15 +450,18 @@ export async function exportCommand(opts: {
         if (opts.onlyTruePositive && finding.revalidation?.verdict !== "true-positive") continue;
         // Default behavior: hide every "resolved" verdict. fixed = patched,
         // false-positive = not real, accepted-risk = real but consciously
-        // accepted. None of these are work the export consumer should
-        // action. Pass --include-resolved to surface them anyway (audit /
-        // history use cases). The legacy --exclude-false-positive flag is
-        // now a no-op — preserved so existing scripts don't break.
+        // accepted, duplicate = same issue as another finding in the file
+        // (the primary carries the canonical signal). None of these are
+        // work the export consumer should action. Pass --include-resolved
+        // to surface them anyway (audit / history use cases). The legacy
+        // --exclude-false-positive flag is now a no-op — preserved so
+        // existing scripts don't break.
         if (
           !opts.includeResolved &&
           (finding.revalidation?.verdict === "fixed" ||
             finding.revalidation?.verdict === "false-positive" ||
-            finding.revalidation?.verdict === "accepted-risk")
+            finding.revalidation?.verdict === "accepted-risk" ||
+            finding.revalidation?.verdict === "duplicate")
         ) {
           continue;
         }

--- a/packages/deepsec/src/commands/metrics.ts
+++ b/packages/deepsec/src/commands/metrics.ts
@@ -37,7 +37,14 @@ interface ProjectMetrics {
   byVulnType: Record<string, number>;
   byVulnTypeTP: Record<string, number>;
   byTriage: Record<string, number>;
-  revalidation: { tp: number; fp: number; fixed: number; uncertain: number; pending: number };
+  revalidation: {
+    tp: number;
+    fp: number;
+    fixed: number;
+    uncertain: number;
+    duplicate: number;
+    pending: number;
+  };
   cost: number;
   analysisCount: number;
   tokens: TokenStats;
@@ -72,7 +79,7 @@ function getMetrics(projectId: string, minSeverity?: string): ProjectMetrics {
     byVulnType: {},
     byVulnTypeTP: {},
     byTriage: {},
-    revalidation: { tp: 0, fp: 0, fixed: 0, uncertain: 0, pending: 0 },
+    revalidation: { tp: 0, fp: 0, fixed: 0, uncertain: 0, duplicate: 0, pending: 0 },
     cost: 0,
     analysisCount: 0,
     tokens: emptyTokens(),
@@ -99,6 +106,7 @@ function getMetrics(projectId: string, minSeverity?: string): ProjectMetrics {
       } else if (verdict === "false-positive") m.revalidation.fp++;
       else if (verdict === "fixed") m.revalidation.fixed++;
       else if (verdict === "uncertain") m.revalidation.uncertain++;
+      else if (verdict === "duplicate") m.revalidation.duplicate++;
       else m.revalidation.pending++;
     }
 

--- a/packages/deepsec/src/commands/report.ts
+++ b/packages/deepsec/src/commands/report.ts
@@ -188,12 +188,13 @@ function printStdoutSummary(args: {
     console.log(`  ${color}${padded}${RESET}  ${count}`);
   }
 
-  // Top findings, severity-ordered. Skips false-positive/fixed verdicts —
-  // those are noise once revalidate has run.
+  // Top findings, severity-ordered. Skips false-positive/fixed/duplicate
+  // verdicts — those are noise once revalidate has run (duplicates point
+  // at a primary that's still in the list).
   for (const severity of ACTIONABLE_SEVERITIES) {
     const findings = findingsBySeverity[severity].filter((f) => {
       const v = f.revalidation?.verdict;
-      return v !== "false-positive" && v !== "fixed";
+      return v !== "false-positive" && v !== "fixed" && v !== "duplicate";
     });
     if (findings.length === 0) continue;
 

--- a/packages/deepsec/src/commands/revalidate.ts
+++ b/packages/deepsec/src/commands/revalidate.ts
@@ -109,8 +109,12 @@ export async function revalidateCommand(opts: {
 
   console.log();
   console.log(`${GREEN}Revalidation complete.${RESET} Run: ${BOLD}${result.runId}${RESET}`);
+  const dupeStr =
+    result.duplicates > 0 || result.duplicatesRejected > 0
+      ? `  ${DIM}Dupe: ${result.duplicates}${result.duplicatesRejected ? ` (${result.duplicatesRejected} rejected)` : ""}${RESET}`
+      : "";
   console.log(
-    `  ${GREEN}TP: ${result.truePositives}${RESET}  ${RED}FP: ${result.falsePositives}${RESET}  ${CYAN}Fixed: ${result.fixed}${RESET}  ${YELLOW}Uncertain: ${result.uncertain}${RESET}`,
+    `  ${GREEN}TP: ${result.truePositives}${RESET}  ${RED}FP: ${result.falsePositives}${RESET}  ${CYAN}Fixed: ${result.fixed}${RESET}  ${YELLOW}Uncertain: ${result.uncertain}${RESET}${dupeStr}`,
   );
   if (result.quotaExhausted) {
     console.log(

--- a/packages/deepsec/src/commands/status.ts
+++ b/packages/deepsec/src/commands/status.ts
@@ -62,8 +62,10 @@ export async function statusCommand(opts: { projectId?: string }) {
       const fp = validated.filter((f) => f.revalidation?.verdict === "false-positive").length;
       const fixed = validated.filter((f) => f.revalidation?.verdict === "fixed").length;
       const unc = validated.filter((f) => f.revalidation?.verdict === "uncertain").length;
+      const dup = validated.filter((f) => f.revalidation?.verdict === "duplicate").length;
+      const dupSuffix = dup > 0 ? `  ${DIM}Dupe: ${dup}${RESET}` : "";
       console.log(
-        `    Revalidated: ${validated.length}/${allFindings.length}  ${GREEN}TP: ${tp}${RESET}  ${RED}FP: ${fp}${RESET}  ${CYAN}Fixed: ${fixed}${RESET}  ${YELLOW}Uncertain: ${unc}${RESET}`,
+        `    Revalidated: ${validated.length}/${allFindings.length}  ${GREEN}TP: ${tp}${RESET}  ${RED}FP: ${fp}${RESET}  ${CYAN}Fixed: ${fixed}${RESET}  ${YELLOW}Uncertain: ${unc}${RESET}${dupSuffix}`,
       );
     }
 

--- a/packages/deepsec/src/pr-comment.ts
+++ b/packages/deepsec/src/pr-comment.ts
@@ -56,10 +56,12 @@ export function renderPrComment(params: {
     for (const f of file.findings ?? []) {
       if (f.producedByRunId !== runId) continue;
       // PR comments surface unresolved risk only — drop anything already
-      // resolved (fixed / false-positive / accepted-risk) even if the
-      // resolution was set in the same run that produced the finding.
+      // resolved (fixed / false-positive / accepted-risk) and drop
+      // duplicates (the primary carries the canonical signal; surfacing
+      // the dupes is just noise).
       const v = f.revalidation?.verdict;
-      if (v === "accepted-risk" || v === "false-positive" || v === "fixed") continue;
+      if (v === "accepted-risk" || v === "false-positive" || v === "fixed" || v === "duplicate")
+        continue;
       findingsForRun.push({ file, finding: f });
     }
   }

--- a/packages/processor/src/__tests__/process-revalidate.test.ts
+++ b/packages/processor/src/__tests__/process-revalidate.test.ts
@@ -990,3 +990,331 @@ describe("processor with stub agent", () => {
     expect(stub.calls.revalidateCalls).toHaveLength(0);
   });
 });
+
+describe("revalidate() duplicate verdict", () => {
+  let prevDataRoot: string | undefined;
+
+  beforeEach(() => {
+    prevDataRoot = process.env.DEEPSEC_DATA_ROOT;
+  });
+
+  afterEach(() => {
+    if (prevDataRoot === undefined) delete process.env.DEEPSEC_DATA_ROOT;
+    else process.env.DEEPSEC_DATA_ROOT = prevDataRoot;
+    setLoadedConfig(defineConfig({ projects: [] }));
+  });
+
+  function fileWithFindings(fx: Fixture, relPath: string, titles: string[]): FileRecord {
+    const rec = pendingRecord(fx.projectId, relPath);
+    rec.status = "analyzed";
+    rec.findings = titles.map((title) => ({
+      severity: "HIGH" as const,
+      vulnSlug: "auth-bypass",
+      title,
+      description: `desc for ${title}`,
+      lineNumbers: [1],
+      recommendation: "x",
+      confidence: "high" as const,
+    }));
+    rec.analysisHistory = [
+      {
+        runId: "earlier",
+        investigatedAt: new Date().toISOString(),
+        durationMs: 1,
+        agentType: "stub",
+        model: "stub",
+        modelConfig: {},
+        findingCount: titles.length,
+      },
+    ];
+    fx.writeRecord(rec);
+    return rec;
+  }
+
+  it("applies DUPE when the referenced primary gets a non-duplicate verdict in the same batch", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    fileWithFindings(fx, "app.ts", ["primary issue", "dupe of primary"]);
+
+    const stub = new StubAgent({
+      async *revalidateImpl() {
+        return {
+          verdicts: [
+            {
+              filePath: "app.ts",
+              title: "primary issue",
+              verdict: "true-positive" as const,
+              reasoning: "real",
+            },
+            {
+              filePath: "app.ts",
+              title: "dupe of primary",
+              verdict: "duplicate" as const,
+              reasoning: "same root cause",
+              duplicateOf: "primary issue",
+            },
+          ],
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+    });
+
+    const rec = fx.readRecord("app.ts");
+    const primary = rec.findings.find((f) => f.title === "primary issue");
+    const dupe = rec.findings.find((f) => f.title === "dupe of primary");
+    expect(primary?.revalidation?.verdict).toBe("true-positive");
+    expect(dupe?.revalidation?.verdict).toBe("duplicate");
+    expect(dupe?.revalidation?.duplicateOf).toBe("primary issue");
+    expect(result.truePositives).toBe(1);
+    expect(result.duplicates).toBe(1);
+    expect(result.duplicatesRejected).toBe(0);
+  });
+
+  it("applies DUPE when the primary already has a verdict from a prior run", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    const rec = fileWithFindings(fx, "app.ts", ["primary issue", "new dupe"]);
+    // Mark the primary as already revalidated; only the new dupe should be sent
+    rec.findings[0].revalidation = {
+      verdict: "true-positive",
+      reasoning: "prior run",
+      revalidatedAt: new Date().toISOString(),
+      runId: "earlier",
+      model: "stub",
+    };
+    fx.writeRecord(rec);
+
+    const stub = new StubAgent({
+      async *revalidateImpl() {
+        return {
+          verdicts: [
+            {
+              filePath: "app.ts",
+              title: "new dupe",
+              verdict: "duplicate" as const,
+              reasoning: "same as primary",
+              duplicateOf: "primary issue",
+            },
+          ],
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+    });
+
+    const after = fx.readRecord("app.ts");
+    const dupe = after.findings.find((f) => f.title === "new dupe");
+    expect(dupe?.revalidation?.verdict).toBe("duplicate");
+    expect(dupe?.revalidation?.duplicateOf).toBe("primary issue");
+    expect(result.duplicates).toBe(1);
+    expect(result.duplicatesRejected).toBe(0);
+  });
+
+  it("rejects DUPE that references a non-existent primary", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    fileWithFindings(fx, "app.ts", ["the only one"]);
+
+    const stub = new StubAgent({
+      async *revalidateImpl() {
+        return {
+          verdicts: [
+            {
+              filePath: "app.ts",
+              title: "the only one",
+              verdict: "duplicate" as const,
+              reasoning: "claims to dupe a ghost",
+              duplicateOf: "nonexistent",
+            },
+          ],
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+    });
+
+    const after = fx.readRecord("app.ts");
+    expect(after.findings[0].revalidation).toBeUndefined();
+    expect(result.duplicates).toBe(0);
+    expect(result.duplicatesRejected).toBe(1);
+  });
+
+  it("rejects an all-DUPE group (no valid primary)", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    fileWithFindings(fx, "app.ts", ["a", "b"]);
+
+    const stub = new StubAgent({
+      async *revalidateImpl() {
+        return {
+          verdicts: [
+            {
+              filePath: "app.ts",
+              title: "a",
+              verdict: "duplicate" as const,
+              reasoning: "...",
+              duplicateOf: "b",
+            },
+            {
+              filePath: "app.ts",
+              title: "b",
+              verdict: "duplicate" as const,
+              reasoning: "...",
+              duplicateOf: "a",
+            },
+          ],
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+    });
+
+    const after = fx.readRecord("app.ts");
+    expect(after.findings.every((f) => !f.revalidation)).toBe(true);
+    expect(result.duplicates).toBe(0);
+    expect(result.duplicatesRejected).toBe(2);
+  });
+
+  it("rejects DUPE with missing duplicateOf and self-referential DUPE", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    fileWithFindings(fx, "app.ts", ["self", "blank"]);
+
+    const stub = new StubAgent({
+      async *revalidateImpl() {
+        return {
+          verdicts: [
+            {
+              filePath: "app.ts",
+              title: "self",
+              verdict: "duplicate" as const,
+              reasoning: "...",
+              duplicateOf: "self",
+            },
+            {
+              filePath: "app.ts",
+              title: "blank",
+              verdict: "duplicate" as const,
+              reasoning: "...",
+              // duplicateOf intentionally omitted
+            },
+          ],
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+    });
+
+    const after = fx.readRecord("app.ts");
+    expect(after.findings.every((f) => !f.revalidation)).toBe(true);
+    expect(result.duplicatesRejected).toBe(2);
+  });
+
+  it("accepts multiple DUPEs pointing at the same primary", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    fileWithFindings(fx, "app.ts", ["primary", "d1", "d2"]);
+
+    const stub = new StubAgent({
+      async *revalidateImpl() {
+        return {
+          verdicts: [
+            {
+              filePath: "app.ts",
+              title: "primary",
+              verdict: "false-positive" as const,
+              reasoning: "framework protects this",
+            },
+            {
+              filePath: "app.ts",
+              title: "d1",
+              verdict: "duplicate" as const,
+              reasoning: "same",
+              duplicateOf: "primary",
+            },
+            {
+              filePath: "app.ts",
+              title: "d2",
+              verdict: "duplicate" as const,
+              reasoning: "same",
+              duplicateOf: "primary",
+            },
+          ],
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+    });
+
+    const after = fx.readRecord("app.ts");
+    expect(after.findings.find((f) => f.title === "primary")?.revalidation?.verdict).toBe(
+      "false-positive",
+    );
+    expect(after.findings.find((f) => f.title === "d1")?.revalidation?.verdict).toBe("duplicate");
+    expect(after.findings.find((f) => f.title === "d2")?.revalidation?.verdict).toBe("duplicate");
+    expect(result.duplicates).toBe(2);
+    expect(result.duplicatesRejected).toBe(0);
+    expect(result.falsePositives).toBe(1);
+  });
+});

--- a/packages/processor/src/agents/shared.ts
+++ b/packages/processor/src/agents/shared.ts
@@ -524,8 +524,16 @@ For EACH finding, perform ALL of these steps before rendering a verdict:
 - **false-positive** — Not exploitable. Name the specific mitigation.
 - **fixed** — Was real but has been patched. Cite the change.
 - **uncertain** — Can't determine. Explain what's ambiguous.
+- **duplicate** — This finding describes the **same underlying vulnerability** at the **same code location** as another finding in the **same file** (e.g., two matchers flagged the same line range from different angles, or the same auth bypass surfaced twice with different phrasing). Set \`duplicateOf\` to the exact \`title\` of the primary finding — the one that should keep the canonical verdict. Same vuln class in a different location is **not** a duplicate.
 
 If severity should change, set \`adjustedSeverity\`. Omit if correct.
+
+### Duplicate rules (read carefully)
+
+- \`duplicate\` is only valid within a single file. Cross-file similarity does **not** count.
+- For any equivalence class of duplicates, **exactly one finding stays primary** with a real verdict (true-positive / false-positive / fixed / uncertain). The other(s) are \`duplicate\` with \`duplicateOf\` pointing at the primary's title.
+- The primary you reference in \`duplicateOf\` **must itself have a non-duplicate verdict** in your output (or already in the file's prior revalidation). If you mark every member of a group as duplicate, all of them will be rejected.
+- Pick the primary as the most precise / highest-confidence statement of the issue. The duplicates should add context in their \`reasoning\`, not repeat the full analysis.
 
 ## Output Format
 
@@ -534,14 +542,15 @@ If severity should change, set \`adjustedSeverity\`. Omit if correct.
   {
     "filePath": "exact/path/to/file.ts",
     "title": "exact title from the finding",
-    "verdict": "true-positive" | "false-positive" | "fixed" | "uncertain",
+    "verdict": "true-positive" | "false-positive" | "fixed" | "uncertain" | "duplicate",
     "adjustedSeverity": "CRITICAL" | "HIGH" | "MEDIUM" | "HIGH_BUG" | "BUG",
+    "duplicateOf": "title of the primary finding (only when verdict is duplicate)",
     "reasoning": "Detailed explanation (5-10 sentences). Show your work."
   }
 ]
 \`\`\`
 
-**Include \`filePath\` for every verdict** so we can match verdicts to the correct file. \`adjustedSeverity\` is optional.
+**Include \`filePath\` for every verdict** so we can match verdicts to the correct file. \`adjustedSeverity\` is optional. \`duplicateOf\` is required iff \`verdict === "duplicate"\` and is otherwise ignored.
 
 **Your reasoning is the most important part.** A verdict without thorough reasoning is worthless.`;
 

--- a/packages/processor/src/agents/types.ts
+++ b/packages/processor/src/agents/types.ts
@@ -72,6 +72,13 @@ export interface RevalidateVerdict {
   verdict: RevalidationVerdict;
   reasoning: string;
   adjustedSeverity?: "CRITICAL" | "HIGH" | "MEDIUM" | "HIGH_BUG" | "BUG";
+  /**
+   * Required when `verdict === "duplicate"`. `title` of the primary
+   * finding in the same file — the canonical one that should keep its
+   * real verdict. The processor rejects DUPEs that don't reference a
+   * non-DUPE primary in the same file.
+   */
+  duplicateOf?: string;
 }
 
 export interface RevalidateOutput {

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -842,6 +842,14 @@ export async function revalidate(params: {
   falsePositives: number;
   fixed: number;
   uncertain: number;
+  duplicates: number;
+  /**
+   * DUPE verdicts the agent produced that we discarded because they
+   * pointed at no primary, at a non-existent primary, at themselves, or
+   * at another duplicate. They stay unrevalidated and will be retried
+   * on the next run.
+   */
+  duplicatesRejected: number;
   /** Same semantics as `process()` — see that return type. */
   quotaExhausted?: { source: QuotaSource; rawMessage: string };
 }> {
@@ -974,6 +982,8 @@ export async function revalidate(params: {
         falsePositives: 0,
         fixed: 0,
         uncertain: 0,
+        duplicates: 0,
+        duplicatesRejected: 0,
       };
     }
 
@@ -982,6 +992,8 @@ export async function revalidate(params: {
     let totalFP = 0;
     let totalFixed = 0;
     let totalUncertain = 0;
+    let totalDuplicate = 0;
+    let totalDupeRejected = 0;
     let totalCostUsd = 0;
     let batchesCompleted = 0;
     let batchesInFlight = 0;
@@ -1033,8 +1045,23 @@ export async function revalidate(params: {
         const batchMeta = output.meta;
         totalCostUsd += batchMeta.costUsd ?? 0;
 
-        // Match verdicts to findings across all files in the batch
+        // Two-pass match + writeback. Pass 1 applies every non-duplicate
+        // verdict. Pass 2 applies "duplicate" verdicts, but only when the
+        // referenced primary (within the same file) has a non-duplicate
+        // verdict — either freshly applied in pass 1 or already on the
+        // file from a prior revalidation run. This is the invariant
+        // enforcement: every equivalence class of duplicates must have
+        // exactly one non-duplicate primary, so an agent that marks
+        // every member of a group as duplicate has all of those DUPEs
+        // rejected (they just stay unrevalidated and get retried on
+        // the next pass).
+        const dupeVerdicts: typeof output.verdicts = [];
+        const nowIso = new Date().toISOString();
         for (const verdict of output.verdicts) {
+          if (verdict.verdict === "duplicate") {
+            dupeVerdicts.push(verdict);
+            continue;
+          }
           const file = batch.find((f) => f.filePath === verdict.filePath);
           if (!file) continue;
           const finding = file.findings.find((f) => f.title === verdict.title);
@@ -1043,7 +1070,7 @@ export async function revalidate(params: {
             verdict: verdict.verdict,
             reasoning: verdict.reasoning,
             adjustedSeverity: verdict.adjustedSeverity,
-            revalidatedAt: new Date().toISOString(),
+            revalidatedAt: nowIso,
             runId,
             model,
           };
@@ -1055,6 +1082,41 @@ export async function revalidate(params: {
           else if (verdict.verdict === "false-positive") totalFP++;
           else if (verdict.verdict === "fixed") totalFixed++;
           else totalUncertain++;
+        }
+
+        for (const verdict of dupeVerdicts) {
+          const file = batch.find((f) => f.filePath === verdict.filePath);
+          if (!file) continue;
+          const finding = file.findings.find((f) => f.title === verdict.title);
+          if (!finding) continue;
+          // Reject self-reference, missing reference, and pointing at
+          // another DUPE — these all violate the single-primary
+          // invariant. The agent will re-see this finding as
+          // unrevalidated on the next run and can re-classify it.
+          const ref = verdict.duplicateOf;
+          if (!ref || ref === verdict.title) {
+            totalDupeRejected++;
+            continue;
+          }
+          const primary = file.findings.find((f) => f.title === ref);
+          if (!primary) {
+            totalDupeRejected++;
+            continue;
+          }
+          if (!primary.revalidation || primary.revalidation.verdict === "duplicate") {
+            totalDupeRejected++;
+            continue;
+          }
+          finding.revalidation = {
+            verdict: "duplicate",
+            reasoning: verdict.reasoning,
+            duplicateOf: ref,
+            revalidatedAt: nowIso,
+            runId,
+            model,
+          };
+          totalRevalidated++;
+          totalDuplicate++;
         }
 
         // Push a per-file `analysisHistory` entry for this revalidate batch.
@@ -1162,14 +1224,16 @@ export async function revalidate(params: {
       falsePositives: totalFP,
       fixed: totalFixed,
       uncertain: totalUncertain,
+      duplicates: totalDuplicate,
       totalCostUsd,
     });
 
+    const dupeRejectedSuffix = totalDupeRejected > 0 ? `, ${totalDupeRejected} DUPE rejected` : "";
     emitProgress({
       type: "all_complete",
       message: quotaExhausted
         ? `Revalidation stopped: ${quotaExhausted.source} quota/credits exhausted (${totalRevalidated} verdicts before stop)`
-        : `Revalidation complete: ${totalRevalidated} findings — TP: ${totalTP}, FP: ${totalFP}, Fixed: ${totalFixed}, Uncertain: ${totalUncertain}`,
+        : `Revalidation complete: ${totalRevalidated} findings — TP: ${totalTP}, FP: ${totalFP}, Fixed: ${totalFixed}, Uncertain: ${totalUncertain}, Dupe: ${totalDuplicate}${dupeRejectedSuffix}`,
     });
 
     return {
@@ -1179,6 +1243,8 @@ export async function revalidate(params: {
       falsePositives: totalFP,
       fixed: totalFixed,
       uncertain: totalUncertain,
+      duplicates: totalDuplicate,
+      duplicatesRejected: totalDupeRejected,
       quotaExhausted,
     };
   } catch (err) {


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
