### PR TITLE
Switch claude to default to Opus 4.8

### DIFF
--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/src/agent-defaults.ts
+++ b/packages/deepsec/src/agent-defaults.ts
@@ -7,6 +7,6 @@ export function defaultModelForAgent(agentType: string): string {
     case "codex":
       return "gpt-5.5";
     default:
-      return "claude-opus-4-7";
+      return "claude-opus-4-8";
   }
 }

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -136,7 +136,7 @@ program
   )
   .option(
     "--model <model>",
-    "Model to use (default: claude-opus-4-7 for claude, gpt-5.5 for codex)",
+    "Model to use (default: claude-opus-4-8 for claude, gpt-5.5 for codex)",
   )
   .option("--max-turns <n>", "Max conversation turns per batch (default: 150)", parseInt)
   .option(
@@ -196,7 +196,7 @@ program
   )
   .option(
     "--model <model>",
-    "Model to use (default: claude-opus-4-7 for claude, gpt-5.5 for codex)",
+    "Model to use (default: claude-opus-4-8 for claude, gpt-5.5 for codex)",
   )
   .option("--max-turns <n>", "Max conversation turns per batch (default: 150)", parseInt)
   .option(

--- a/packages/processor/src/agents/claude-agent-sdk.ts
+++ b/packages/processor/src/agents/claude-agent-sdk.ts
@@ -176,7 +176,7 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
 
   async *investigate(params: InvestigateParams): AsyncGenerator<AgentProgress, InvestigateOutput> {
     const { batch, projectRoot, promptTemplate, projectInfo, config, signal, projectId } = params;
-    const model = (config.model as string) ?? "claude-opus-4-7";
+    const model = (config.model as string) ?? "claude-opus-4-8";
     const maxTurns = (config.maxTurns as number) ?? 150;
     // Bridge the processor-supplied AbortSignal to an AbortController the
     // SDK can consume — the SDK API takes an `AbortController` instance,
@@ -420,7 +420,7 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
 
   async *revalidate(params: RevalidateParams): AsyncGenerator<AgentProgress, RevalidateOutput> {
     const { batch, projectRoot, projectInfo, config, force = false, signal, projectId } = params;
-    const model = (config.model as string) ?? "claude-opus-4-7";
+    const model = (config.model as string) ?? "claude-opus-4-8";
     const maxTurns = (config.maxTurns as number) ?? 150;
 
     // See investigate() — bridges processor's abort signal into the SDK's

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -245,7 +245,7 @@ export async function process(params: {
     return prompt;
   };
 
-  const model = (config.model as string) ?? "claude-opus-4-7";
+  const model = (config.model as string) ?? "claude-opus-4-8";
 
   // Create or resume run
   let runId: string;
@@ -900,7 +900,7 @@ export async function revalidate(params: {
     projectInfo = fs.readFileSync(infoPath, "utf-8");
   } catch {}
 
-  const model = (config.model as string) ?? "claude-opus-4-7";
+  const model = (config.model as string) ?? "claude-opus-4-8";
 
   let runId: string;
   if (params.runId) {


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
