### PR TITLE
Use a forgiving JSON parser to avoid failing runs for minor reasons

### DIFF
--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/processor/package.json
+++ b/packages/processor/package.json
@@ -14,6 +14,7 @@
     "@deepsec/scanner": "workspace:*",
     "@earendil-works/pi-coding-agent": "0.79.10",
     "@openai/codex": "^0.125.0",
-    "@openai/codex-sdk": "^0.125.0"
+    "@openai/codex-sdk": "^0.125.0",
+    "jsonrepair": "^3.14.0"
   }
 }

--- a/packages/processor/src/__tests__/shared.test.ts
+++ b/packages/processor/src/__tests__/shared.test.ts
@@ -310,6 +310,18 @@ describe("parseInvestigateResults", () => {
     expect(out.find((r) => r.filePath === "b.ts")?.findings).toEqual([]);
   });
 
+  it("repairs common malformed model JSON before parsing findings", () => {
+    const text =
+      'Confirmed:\n```json\n[{"filePath":"a.ts","findings":[{"severity":"MEDIUM","description":"Uses "signature !== expectedHash" comparison",}]}';
+
+    const out = parseInvestigateResults(text, batch);
+
+    expect(out.find((r) => r.filePath === "a.ts")?.findings[0]?.description).toBe(
+      'Uses "signature !== expectedHash" comparison',
+    );
+    expect(out.find((r) => r.filePath === "b.ts")?.findings).toEqual([]);
+  });
+
   it("throws on parse failure (fail-loud, never silently empty)", () => {
     // Silently returning empty findings on malformed JSON would mask
     // model truncation, prompt-injection-driven non-JSON output, and
@@ -335,6 +347,16 @@ describe("parseRevalidateVerdicts", () => {
     const v = parseRevalidateVerdicts(text);
     expect(v).toHaveLength(1);
     expect(v[0].verdict).toBe("true-positive");
+  });
+
+  it("repairs common malformed model JSON before parsing verdicts", () => {
+    const text =
+      'Here are the verdicts:\n```json\n[{"filePath":"a.ts","title":"x","verdict":"true-positive","reasoning":"Line says "unsafe" but is mitigated",}]';
+
+    const v = parseRevalidateVerdicts(text);
+
+    expect(v).toHaveLength(1);
+    expect(v[0].reasoning).toBe('Line says "unsafe" but is mitigated');
   });
 
   it("throws on parse failure", () => {

--- a/packages/processor/src/agents/shared.ts
+++ b/packages/processor/src/agents/shared.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { dataDir, type FileRecord, type Finding, type RefusalReport } from "@deepsec/core";
+import { jsonrepair } from "jsonrepair";
 import type { InvestigateResult, RevalidateVerdict } from "./types.js";
 
 // --- Retry / backoff -------------------------------------------------------
@@ -442,6 +443,8 @@ export function buildInvestigateJsonRepairPrompt(batch: FileRecord[]): string {
 
 Do not redo the investigation and do not use tools. Re-output the same conclusions from your previous response as ONLY one valid JSON array. No prose before or after. No "Confirmed:" preface. A \`\`\`json fenced block is acceptable, but the content inside must be valid JSON.
 
+Keep string values compact. Escape double quotes inside strings as \`\\"\`, escape newlines as \`\\n\`, and do not put raw line breaks inside JSON string values.
+
 Include exactly these target files, with an empty findings array for any file where you found no real issue:
 
 ${fileListForRepairPrompt(batch)}
@@ -474,6 +477,8 @@ export function buildRevalidateJsonRepairPrompt(): string {
   return `Your previous response was not valid JSON, so the scanner could not parse it.
 
 Do not redo the revalidation and do not use tools. Re-output the same verdicts and reasoning from your previous response as ONLY one valid JSON array. No prose before or after. No "Confirmed:" preface. A \`\`\`json fenced block is acceptable, but the content inside must be valid JSON.
+
+Keep string values compact. Escape double quotes inside strings as \`\\"\`, escape newlines as \`\\n\`, and do not put raw line breaks inside JSON string values.
 
 Use this exact schema:
 
@@ -508,34 +513,85 @@ export function jsonRepairFailureError(originalError: unknown, repairError: unkn
   );
 }
 
+function extractAgentJsonPayload(resultText: string): string {
+  const fenced = resultText.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenced) return fenced[1].trim();
+
+  const openFence = resultText.match(/```(?:json)?\s*([\s\S]*)$/i);
+  if (openFence) return openFence[1].trim();
+
+  return resultText.trim();
+}
+
+function extractArrayCandidateForRepair(jsonPayload: string): string {
+  const trimmed = jsonPayload.trim();
+  if (trimmed.startsWith("[")) return trimmed;
+
+  const arrayStart = /\[\s*(?:\{|\])/.exec(trimmed);
+  if (!arrayStart) return trimmed;
+
+  const candidate = trimmed.slice(arrayStart.index);
+  const lastClose = candidate.lastIndexOf("]");
+  return lastClose >= 0 ? candidate.slice(0, lastClose + 1) : candidate;
+}
+
+function parseAgentJsonArray(params: {
+  resultText: string;
+  parseFailurePrefix: string;
+  nonArrayMessage: (parsed: unknown) => string;
+}): unknown[] {
+  const { resultText, parseFailurePrefix, nonArrayMessage } = params;
+  const jsonPayload = extractAgentJsonPayload(resultText);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonPayload);
+  } catch (strictErr) {
+    const repairCandidate = extractArrayCandidateForRepair(jsonPayload);
+    try {
+      parsed = JSON.parse(jsonrepair(repairCandidate));
+    } catch (repairErr) {
+      const excerpt = resultText.slice(0, 400).replace(/\s+/g, " ");
+      throw new Error(
+        `${parseFailurePrefix}: ${strictErr instanceof Error ? strictErr.message : strictErr}. ` +
+          `Tolerant jsonrepair failed: ${repairErr instanceof Error ? repairErr.message : repairErr}. ` +
+          `First 400 chars: ${excerpt}`,
+      );
+    }
+
+    if (!Array.isArray(parsed)) {
+      const excerpt = resultText.slice(0, 400).replace(/\s+/g, " ");
+      throw new Error(
+        `${parseFailurePrefix}: ${strictErr instanceof Error ? strictErr.message : strictErr}. ` +
+          `Tolerant jsonrepair returned ${typeof parsed}, not an array. ` +
+          `First 400 chars: ${excerpt}`,
+      );
+    }
+
+    return parsed;
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(nonArrayMessage(parsed));
+  }
+
+  return parsed;
+}
+
 export function parseInvestigateResults(
   resultText: string,
   batch: FileRecord[],
 ): InvestigateResult[] {
-  const jsonMatch = resultText.match(/```json\s*([\s\S]*?)```/);
-  const jsonStr = jsonMatch ? jsonMatch[1].trim() : resultText.trim();
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(jsonStr);
-  } catch (err) {
-    // Fail loud — a malformed JSON response is indistinguishable from
-    // a "found nothing" run if we silently return empty findings, and
-    // for a security tool that's the worst possible failure mode
-    // (truncated model output, rate-limit splice, prompt-injection
-    // override could all suppress real findings). The processor's
-    // batch-level catch fires from this throw, marks files status=error,
-    // increments errorBatchCount, and the CLI exits non-zero.
-    const excerpt = resultText.slice(0, 400).replace(/\s+/g, " ");
-    throw new Error(
-      `Agent produced output that wasn't a parseable JSON findings array: ${err instanceof Error ? err.message : err}. ` +
-        `First 400 chars: ${excerpt}`,
-    );
-  }
-
-  if (!Array.isArray(parsed)) {
-    throw new Error(`Agent produced JSON but not an array of file findings. Got: ${typeof parsed}`);
-  }
+  // Fail loud when neither strict JSON nor tolerant jsonrepair can produce
+  // an array. A malformed response is otherwise indistinguishable from a
+  // clean "found nothing" run, which would mask truncation, gateway splice,
+  // or prompt-injection-driven non-JSON output.
+  const parsed = parseAgentJsonArray({
+    resultText,
+    parseFailurePrefix: "Agent produced output that wasn't a parseable JSON findings array",
+    nonArrayMessage: (parsed) =>
+      `Agent produced JSON but not an array of file findings. Got: ${typeof parsed}`,
+  });
 
   const typedParsed = parsed as Array<{ filePath: string; findings: Finding[] }>;
   const results: InvestigateResult[] = [];
@@ -677,24 +733,14 @@ If severity should change, set \`adjustedSeverity\`. Omit if correct.
 }
 
 export function parseRevalidateVerdicts(resultText: string): RevalidateVerdict[] {
-  const jsonMatch = resultText.match(/```json\s*([\s\S]*?)```/);
-  const jsonStr = jsonMatch ? jsonMatch[1].trim() : resultText.trim();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(jsonStr);
-  } catch (err) {
-    // Same fail-loud rationale as parseInvestigateResults: silently
-    // returning [] for malformed output would mark a batch of findings
-    // as "no verdicts produced" instead of erroring, suppressing
-    // intended revalidation results.
-    const excerpt = resultText.slice(0, 400).replace(/\s+/g, " ");
-    throw new Error(
-      `Agent produced revalidation output that wasn't parseable JSON: ${err instanceof Error ? err.message : err}. ` +
-        `First 400 chars: ${excerpt}`,
-    );
-  }
-  if (!Array.isArray(parsed)) {
-    throw new Error(`Agent produced revalidation JSON but not an array. Got: ${typeof parsed}`);
-  }
+  // Same fail-loud rationale as parseInvestigateResults: only accept a
+  // strict or repaired JSON array. Anything else should mark the batch as
+  // errored instead of looking like "no verdicts produced".
+  const parsed = parseAgentJsonArray({
+    resultText,
+    parseFailurePrefix: "Agent produced revalidation output that wasn't parseable JSON",
+    nonArrayMessage: (parsed) =>
+      `Agent produced revalidation JSON but not an array. Got: ${typeof parsed}`,
+  });
   return parsed as RevalidateVerdict[];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@openai/codex-sdk':
         specifier: ^0.125.0
         version: 0.125.0
+      jsonrepair:
+        specifier: ^3.14.0
+        version: 3.14.0
 
   packages/scanner:
     dependencies:
@@ -3190,6 +3193,11 @@ packages:
 
   /jsonlines@0.1.1:
     resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
+    dev: false
+
+  /jsonrepair@3.14.0:
+    resolution: {integrity: sha512-tWPGKMZf/8UPim+fcW2EfcQ/d/7aKUrP6IECz9G3Tu6Q5dX0orSleqJ9z6sSw7qrQkjF8/Edo4DvsWBZ8H+HNg==}
+    hasBin: true
     dev: false
 
   /jwa@2.0.1:


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
