### PR TITLE
[codex] Fix bundle e2e symlink cleanup

### DIFF
--- a/e2e/bundle.test.ts
+++ b/e2e/bundle.test.ts
@@ -33,6 +33,18 @@ function makeWorkspace(): string {
   return dir;
 }
 
+function removeSymlinkIfPresent(linkPath: string): void {
+  try {
+    if (fs.lstatSync(linkPath).isSymbolicLink()) {
+      fs.unlinkSync(linkPath);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+}
+
 describe("bundle e2e", () => {
   beforeAll(() => {
     if (!fs.existsSync(BUNDLE)) {
@@ -160,7 +172,7 @@ export default defineConfig({
       expect(stdout).toContain("webapp-debug-flag");
       expect(stdout).toContain("webapp-route-no-rate-limit");
     } finally {
-      fs.rmSync(link, { force: true });
+      removeSymlinkIfPresent(link);
       fs.rmSync(path.join(sampleDir, "data"), { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary
- Fix the bundle e2e sample cleanup so directory symlinks are unlinked safely.
- Preserve real sample-local node_modules directories while cleaning generated symlinks and data.

## Root cause
The `samples/webapp` bundle e2e test creates a `node_modules` symlink so the sample config can resolve `deepsec/config`. Its cleanup used `fs.rmSync(link, { force: true })`, which can throw `Path is a directory` for a directory symlink, leaving ignored sample artifacts behind and failing the suite.

## Validation
- `pnpm exec vitest run --project e2e e2e/bundle.test.ts -t "samples/webapp"`
- `pnpm deepsec process --diff origin/main --agent codex --no-ignore --concurrency 1 --batch-size 1 --comment-out tmp/deepsec-codex-comment.md` (1 analysis, 0 findings)
- `pnpm validate`

## Review
- Thermonuclear code review pass: scoped to one test file, no production surface change, no structural regression found.