### PR TITLE
Bump codex version

### DIFF
--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -34,8 +34,8 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.158",
     "@earendil-works/pi-coding-agent": "0.79.10",
-    "@openai/codex": "^0.125.0",
-    "@openai/codex-sdk": "^0.125.0",
+    "@openai/codex": "^0.144.0",
+    "@openai/codex-sdk": "^0.144.0",
     "@vercel/oidc": "^3.4.0",
     "@vercel/sandbox": "^1.9.0",
     "jiti": "^2.4.0",

--- a/packages/deepsec/src/sandbox/setup.ts
+++ b/packages/deepsec/src/sandbox/setup.ts
@@ -759,13 +759,18 @@ async function installAgentTools(sandbox: Sandbox, onLog: (msg: string) => void)
 
 /**
  * Codex CLI ships a vendored Rust binary via platform-specific optional
- * dependencies (e.g. `@openai/codex-linux-x64`). pnpm running on the bootstrap
- * host (Mac arm64 typically) installs only host-matching optional deps, so the
- * sandbox often comes up without the linux binary it needs.
+ * dependencies (e.g. `@openai/codex-linux-x64` → `@openai/codex@<ver>-linux-x64`).
+ * pnpm running on the bootstrap host (Mac arm64 typically) installs only
+ * host-matching optional deps, so the sandbox often comes up without the
+ * linux binary it needs.
  *
  * We resolve the SDK version, force-install the linux variant matching the
- * sandbox arch via `npm pack`, and place its `vendor/<triple>/codex/` tree
- * where the bin script (`bin/codex.js`) looks it up via `require.resolve`.
+ * sandbox arch via `npm pack`, and place its `vendor/<triple>/` tree where
+ * `bin/codex.js` looks it up via `require.resolve("@openai/codex-linux-*")`.
+ *
+ * Layout note (Codex ≥0.144): the Mach-O/ELF lives at
+ * `vendor/<triple>/bin/codex` (older releases used `vendor/<triple>/codex/codex`).
+ * We accept either path so a mid-flight pin doesn't break bootstrap.
  *
  * Codex linux binaries are statically linked musl, so they run on glibc
  * sandboxes too — no libc detection needed.
@@ -778,6 +783,7 @@ async function ensureCodexNativeBinary(
 set -e
 cd ${DEEPSEC_DIR}
 SDK_VER=""
+CODEX_PKG_DIR=""
 for CANDIDATE in \\
   ./node_modules/@openai/codex \\
   ./packages/processor/node_modules/@openai/codex \\
@@ -785,55 +791,85 @@ for CANDIDATE in \\
   ./node_modules/.pnpm/@openai+codex@*/node_modules/@openai/codex; do
   for DIR in $CANDIDATE; do
     if [ -f "$DIR/package.json" ]; then
-      SDK_VER=$(node -p "require('$DIR/package.json').version" 2>/dev/null)
-      break 2
+      VER=$(node -p "require('$DIR/package.json').version" 2>/dev/null || true)
+      # Skip platform-suffixed packages (e.g. 0.144.0-darwin-arm64).
+      case "\$VER" in
+        *-linux-*|*-darwin-*|*-win32-*) continue ;;
+      esac
+      if [ -n "\$VER" ]; then
+        SDK_VER="\$VER"
+        # Absolute path — the alias step below runs after cd'ing elsewhere.
+        CODEX_PKG_DIR="\$(cd "\$DIR" && pwd)"
+        break 2
+      fi
     fi
   done
 done
-if [ -z "$SDK_VER" ]; then
+if [ -z "\$SDK_VER" ]; then
   echo "Could not detect Codex CLI version"
   exit 1
 fi
-echo "Detected Codex CLI version: $SDK_VER"
+echo "Detected Codex CLI version: \$SDK_VER"
 
 # Map sandbox arch to platform package + vendor triple
 UNAME_M=$(uname -m)
-case "$UNAME_M" in
+case "\$UNAME_M" in
   x86_64) ARCH=x64; TRIPLE=x86_64-unknown-linux-musl ;;
   aarch64|arm64) ARCH=arm64; TRIPLE=aarch64-unknown-linux-musl ;;
-  *) echo "Unsupported arch: $UNAME_M"; exit 1 ;;
+  *) echo "Unsupported arch: \$UNAME_M"; exit 1 ;;
 esac
-echo "  Sandbox arch: $UNAME_M (linux-\${ARCH}, $TRIPLE)"
+echo "  Sandbox arch: \$UNAME_M (linux-\${ARCH}, \$TRIPLE)"
 
 # The platform package's actual published version is "<sdk_ver>-linux-<arch>".
-PLATFORM_PKG="@openai/codex-linux-\${ARCH}"
+# pnpm aliases it as @openai/codex-linux-<arch> → @openai/codex@<ver>-linux-<arch>.
+PLATFORM_ALIAS="@openai/codex-linux-\${ARCH}"
 PLATFORM_VER="\${SDK_VER}-linux-\${ARCH}"
+PNPM_STORE_KEY="@openai+codex@\${PLATFORM_VER}"
+STORE_DEST="${DEEPSEC_DIR}/node_modules/.pnpm/\${PNPM_STORE_KEY}/node_modules/@openai/codex"
 
 echo "  Fetching @openai/codex@\${PLATFORM_VER} (platform binary)..."
 rm -rf /tmp/codex-native-fetch && mkdir -p /tmp/codex-native-fetch
 cd /tmp/codex-native-fetch
 npm pack "@openai/codex@\${PLATFORM_VER}" --silent 2>&1 | tail -1
 tar -xzf ./*.tgz
-if [ ! -f "package/vendor/\${TRIPLE}/codex/codex" ]; then
-  echo "  ERROR: vendor/\${TRIPLE}/codex/codex not present in tarball"
-  ls -la package/vendor/ 2>/dev/null || true
+
+# Codex ≥0.144: vendor/<triple>/bin/codex
+# Codex ≤0.130-ish: vendor/<triple>/codex/codex
+BIN_REL=""
+if [ -f "package/vendor/\${TRIPLE}/bin/codex" ]; then
+  BIN_REL="vendor/\${TRIPLE}/bin/codex"
+elif [ -f "package/vendor/\${TRIPLE}/codex/codex" ]; then
+  BIN_REL="vendor/\${TRIPLE}/codex/codex"
+else
+  echo "  ERROR: neither vendor/\${TRIPLE}/bin/codex nor vendor/\${TRIPLE}/codex/codex present"
+  ls -la package/vendor/\${TRIPLE}/ 2>/dev/null || ls -la package/vendor/ 2>/dev/null || true
   exit 1
 fi
-SIZE=$(stat -c%s "package/vendor/\${TRIPLE}/codex/codex" 2>/dev/null || echo "?")
+SIZE=$(stat -c%s "package/\${BIN_REL}" 2>/dev/null || echo "?")
+echo "  Found binary at \${BIN_REL} (\${SIZE} bytes)"
 
-# pnpm stores platform packages under the alias name — drop the binary at every
-# place pnpm might have created (or expects) the vendor tree.
-PNPM_KEY="@openai+codex-linux-\${ARCH}@\${PLATFORM_VER}"
-DEST_PATHS=(
-  "${DEEPSEC_DIR}/node_modules/.pnpm/\${PNPM_KEY}/node_modules/\${PLATFORM_PKG}"
-  "${DEEPSEC_DIR}/node_modules/\${PLATFORM_PKG}"
+# Materialize the platform package where pnpm would have put it, then alias
+# it as @openai/codex-linux-<arch> next to the host @openai/codex package so
+# bin/codex.js's require.resolve(alias) succeeds inside the sandbox.
+mkdir -p "\${STORE_DEST}"
+rm -rf "\${STORE_DEST}/vendor"
+cp -a package/vendor "\${STORE_DEST}/vendor"
+cp package/package.json "\${STORE_DEST}/package.json"
+chmod +x "\${STORE_DEST}/\${BIN_REL}"
+echo "    → \${STORE_DEST}"
+
+# Alias symlink targets (require.resolve from bin/codex.js walks these).
+ALIAS_TARGETS=(
+  "${DEEPSEC_DIR}/node_modules/.pnpm/@openai+codex@\${SDK_VER}/node_modules/\${PLATFORM_ALIAS}"
+  "${DEEPSEC_DIR}/node_modules/\${PLATFORM_ALIAS}"
 )
-for DEST in "\${DEST_PATHS[@]}"; do
-  mkdir -p "\${DEST}/vendor/\${TRIPLE}/codex"
-  cp "package/vendor/\${TRIPLE}/codex/codex" "\${DEST}/vendor/\${TRIPLE}/codex/codex"
-  chmod +x "\${DEST}/vendor/\${TRIPLE}/codex/codex"
-  cp package/package.json "\${DEST}/package.json"
-  echo "    → \${DEST} (\${SIZE} bytes)"
+if [ -n "\$CODEX_PKG_DIR" ]; then
+  ALIAS_TARGETS+=("\${CODEX_PKG_DIR}/node_modules/\${PLATFORM_ALIAS}")
+fi
+for ALIAS in "\${ALIAS_TARGETS[@]}"; do
+  mkdir -p "\$(dirname "\$ALIAS")"
+  ln -sfn "\${STORE_DEST}" "\$ALIAS"
+  echo "    → alias \$ALIAS"
 done
 rm -rf /tmp/codex-native-fetch
 `;
@@ -862,7 +898,8 @@ rm -rf /tmp/codex-native-fetch
 async function writeCodexConfig(sandbox: Sandbox, onLog: (msg: string) => void): Promise<void> {
   const configToml = `# Written by deepsec sandbox bootstrap. Disables non-AI egress
 # (analytics, update checks, OTEL exporters) so the agent stays within
-# the sandbox firewall allowlist.
+# the sandbox firewall allowlist. Also pins plugins off — Codex 0.143+
+# enables remote_plugin by default, which we don't want in workers.
 check_for_update_on_startup = false
 
 [analytics]
@@ -871,6 +908,10 @@ enabled = false
 [otel]
 metrics_exporter = "none"
 trace_exporter = "none"
+
+[features]
+plugins = false
+remote_plugin = false
 `;
   const mkdir = await sandbox.runCommand({
     cmd: "mkdir",

--- a/packages/processor/package.json
+++ b/packages/processor/package.json
@@ -13,8 +13,8 @@
     "@deepsec/core": "workspace:*",
     "@deepsec/scanner": "workspace:*",
     "@earendil-works/pi-coding-agent": "0.79.10",
-    "@openai/codex": "^0.125.0",
-    "@openai/codex-sdk": "^0.125.0",
+    "@openai/codex": "^0.144.0",
+    "@openai/codex-sdk": "^0.144.0",
     "jsonrepair": "^3.14.0"
   }
 }

--- a/packages/processor/src/__tests__/shared.test.ts
+++ b/packages/processor/src/__tests__/shared.test.ts
@@ -45,7 +45,7 @@ describe("isTransientError", () => {
 describe("classifyQuotaError", () => {
   // Strings in this block were extracted from the actual platform binaries
   // shipped via @anthropic-ai/claude-agent-sdk-darwin-arm64 (claude) and
-  // @openai/codex/vendor/.../codex/codex (codex Rust binary), via
+  // @openai/codex/vendor/.../bin/codex (codex Rust binary), via
   // `strings | grep`. Treat these tests as ground truth — if a binary
   // upgrade breaks them, the regexes need updating.
 

--- a/packages/processor/src/agents/codex-sdk.ts
+++ b/packages/processor/src/agents/codex-sdk.ts
@@ -310,13 +310,23 @@ function buildCodexInvocation(): CodexInvocation {
     if (!process.env.RUST_LOG) extras.RUST_LOG = "info";
   }
 
+  // Codex 0.143+ enables remote_plugin by default. Deepsec never wants
+  // marketplace/plugin installs during investigate/revalidate — pin off
+  // for both subscription and gateway modes.
+  const pluginLockdown = {
+    features: {
+      plugins: false,
+      remote_plugin: false,
+    },
+  };
+
   if (subscriptionHome) {
     // No credentials enter the codex env in subscription mode — auth
     // happens via the mirrored auth.json. The allowlist already drops
     // OPENAI_API_KEY/ANTHROPIC_AUTH_TOKEN/_BASE_URL, so no explicit
     // delete is needed.
     const env = buildCodexEnv(extras);
-    const options: CodexOptions = { env };
+    const options: CodexOptions = { env, config: pluginLockdown };
     if (codexPathOverride) options.codexPathOverride = codexPathOverride;
     return { options, stderrLog, codexHome };
   }
@@ -342,6 +352,7 @@ function buildCodexInvocation(): CodexInvocation {
   }
 
   const config = {
+    ...pluginLockdown,
     model_provider: CUSTOM_PROVIDER_ID,
     model_providers: {
       [CUSTOM_PROVIDER_ID]: providerConfig,

--- a/packages/processor/src/agents/shared.ts
+++ b/packages/processor/src/agents/shared.ts
@@ -50,7 +50,7 @@ export type QuotaAgentHint = "claude" | "codex";
  * Patterns below were extracted from the actual platform binaries via
  * `strings`:
  *   - Claude: `@anthropic-ai/claude-agent-sdk-darwin-arm64/claude`
- *   - Codex:  `@openai/codex/vendor/.../codex/codex`
+ *   - Codex:  `@openai/codex/vendor/.../bin/codex`
  * plus the well-known stable strings from the upstream HTTP error
  * envelopes (Anthropic `billing_error`, OpenAI `insufficient_quota` /
  * "You exceeded your current quota") which don't appear in the bundled

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,11 +46,11 @@ importers:
         specifier: 0.79.10
         version: 0.79.10(@modelcontextprotocol/sdk@1.29.0)(zod@4.4.3)
       '@openai/codex':
-        specifier: ^0.125.0
-        version: 0.125.0
+        specifier: ^0.144.0
+        version: 0.144.0
       '@openai/codex-sdk':
-        specifier: ^0.125.0
-        version: 0.125.0
+        specifier: ^0.144.0
+        version: 0.144.0
       '@vercel/oidc':
         specifier: ^3.4.0
         version: 3.4.0
@@ -104,11 +104,11 @@ importers:
         specifier: 0.79.10
         version: 0.79.10(@modelcontextprotocol/sdk@1.29.0)(zod@4.4.3)
       '@openai/codex':
-        specifier: ^0.125.0
-        version: 0.125.0
+        specifier: ^0.144.0
+        version: 0.144.0
       '@openai/codex-sdk':
-        specifier: ^0.125.0
-        version: 0.125.0
+        specifier: ^0.144.0
+        version: 0.144.0
       jsonrepair:
         specifier: ^3.14.0
         version: 3.14.0
@@ -2286,28 +2286,28 @@ packages:
     engines: {node: '>=12.4.0'}
     dev: true
 
-  /@openai/codex-sdk@0.125.0:
-    resolution: {integrity: sha512-1xCIHdSbQVF880nJ2aVWdPIsWZbSpKODwuP9y/gvtChDYhYfYEW0DKp2H8ZlctkzIjlzS/WzYmP6ZZPHIvs2Dg==}
+  /@openai/codex-sdk@0.144.0:
+    resolution: {integrity: sha512-Avk4tZxfhNfwMhLoD9P+1aFlgaK2Mv11ouy+z9ImkgOKRHDMhDPFw1CbsNECfGNWJix7T0EG9TAU1XVkEKW3DQ==}
     engines: {node: '>=18'}
     dependencies:
-      '@openai/codex': 0.125.0
+      '@openai/codex': 0.144.0
     dev: false
 
-  /@openai/codex@0.125.0:
-    resolution: {integrity: sha512-GiE9wlgL95u/5BRirY5d3EaRLU1tu7Y1R09R8lCHHVmcQdSmhS809FdPDWH3gIYHS7ZriAPqXwJ3aLA0WKl40Q==}
+  /@openai/codex@0.144.0:
+    resolution: {integrity: sha512-QFh6f+v5QUx/Vg0HjIl9HB94p7aDLBDkZjc4IXX5RXUcXHPVCZNb6Hl2R49Og/fqW7orgZkeDcgWfRANUa1WoQ==}
     engines: {node: '>=16'}
     hasBin: true
     optionalDependencies:
-      '@openai/codex-darwin-arm64': /@openai/codex@0.125.0-darwin-arm64
-      '@openai/codex-darwin-x64': /@openai/codex@0.125.0-darwin-x64
-      '@openai/codex-linux-arm64': /@openai/codex@0.125.0-linux-arm64
-      '@openai/codex-linux-x64': /@openai/codex@0.125.0-linux-x64
-      '@openai/codex-win32-arm64': /@openai/codex@0.125.0-win32-arm64
-      '@openai/codex-win32-x64': /@openai/codex@0.125.0-win32-x64
+      '@openai/codex-darwin-arm64': /@openai/codex@0.144.0-darwin-arm64
+      '@openai/codex-darwin-x64': /@openai/codex@0.144.0-darwin-x64
+      '@openai/codex-linux-arm64': /@openai/codex@0.144.0-linux-arm64
+      '@openai/codex-linux-x64': /@openai/codex@0.144.0-linux-x64
+      '@openai/codex-win32-arm64': /@openai/codex@0.144.0-win32-arm64
+      '@openai/codex-win32-x64': /@openai/codex@0.144.0-win32-x64
     dev: false
 
-  /@openai/codex@0.125.0-darwin-arm64:
-    resolution: {integrity: sha512-Gn2fHiSO0XgyHp1OSd5DWUTm66Bv9UEuipW5pVEj1E+hWZCOrdqnYttllKFWtRGj5yiKefNX3JIxONgh/ZwlOQ==}
+  /@openai/codex@0.144.0-darwin-arm64:
+    resolution: {integrity: sha512-rqFAJdOa2I0VRgepVsSZeLxs96+Y+LXTjccOOvH6894FyaFAYPZ/o+6hgpB1iGHxxdoY/DsGa8jrJC8Leqn9Kg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -2315,8 +2315,8 @@ packages:
     dev: false
     optional: true
 
-  /@openai/codex@0.125.0-darwin-x64:
-    resolution: {integrity: sha512-TZ5Lek2X/UXTI9LXFxzarvQaJeuTrqVh4POc7soO/8RclVnCxADnCf15sivxLd5eiFW4t0myGoeVoM4lciRiRg==}
+  /@openai/codex@0.144.0-darwin-x64:
+    resolution: {integrity: sha512-4p2jxRbN+Khg5UQzpkzT9upFj+qkEF/abmdvrtflkkWmVKP6Nt+yi8ospdqv9PDqvQ9SotPvX7iXaFaeUTrtmA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -2324,8 +2324,8 @@ packages:
     dev: false
     optional: true
 
-  /@openai/codex@0.125.0-linux-arm64:
-    resolution: {integrity: sha512-pPnJoJD6rZ2Iin0zNt/up36bO2/EOp2B+1/rPHu/lSq3PJbT3Fmnfut2kJy5LylXb7bGA2XQbtqOogZzIbnlkA==}
+  /@openai/codex@0.144.0-linux-arm64:
+    resolution: {integrity: sha512-k++xhZrn9P3laO00Q92APG6mdOFDD66nUBo+8ExCa1NXi2pjLEMLC4+UNJTUUtUT1PEflOZ5pDKxPXgzaiFFFg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -2333,8 +2333,8 @@ packages:
     dev: false
     optional: true
 
-  /@openai/codex@0.125.0-linux-x64:
-    resolution: {integrity: sha512-K2NTTEeBpz/G+N2x17UGWfauRt3So+ir4f+U/60l5PPnYEJB/w3YZrlXo2G9og8Dm9BqtoBAjoPV74sRv9tWWQ==}
+  /@openai/codex@0.144.0-linux-x64:
+    resolution: {integrity: sha512-GmKtQeX+cO9lN7mQD1FEVcXYEMLMgMByHwZdvlluH0bj/+c2ind3hwbRtE3eECFDekNhEiB80Ez0FfbkyFQqoA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -2342,8 +2342,8 @@ packages:
     dev: false
     optional: true
 
-  /@openai/codex@0.125.0-win32-arm64:
-    resolution: {integrity: sha512-zxoUakw9oIHIFrAyk400XkkLBJFA6nOym0NDq6sQ/jhdcYraKqNSRCII2nsBwZHk+/4zgUvuk52iuutgysY/rQ==}
+  /@openai/codex@0.144.0-win32-arm64:
+    resolution: {integrity: sha512-e2yGSgwdzrT1SoJMoOzWD58WBEsIaAMZpEchuV2VGkE2T955SG7dn7EyVQTQcy7/rdpE8aEDktZ/1eQQfjkdtQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
@@ -2351,8 +2351,8 @@ packages:
     dev: false
     optional: true
 
-  /@openai/codex@0.125.0-win32-x64:
-    resolution: {integrity: sha512-ofpOK+OWH5QFuUZ9pTM0d/PcXUXiIP5z5DpRcE9MlucJoyOl4Zy4Nu3NcuHF4YzCkZMQb6x3j0tjDEPHKqNQzw==}
+  /@openai/codex@0.144.0-win32-x64:
+    resolution: {integrity: sha512-QiholLCYqNeYvNM77HOmPtrOFrY0rQc/N9nXt+sQGXO3rEGmcWjpLzujY4Oegl3CLRHoieWqlep3EqEvFBjoIA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -2780,6 +2780,10 @@ packages:
     resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
     dev: false
 
+  /@radix-ui/primitive@1.1.5:
+    resolution: {integrity: sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==}
+    dev: false
+
   /@radix-ui/react-accessible-icon@1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
     resolution: {integrity: sha512-HQDOFTKwSnmUij6l54wYJJtxTAnxI71+YJLOrjm2ladFB8HAV5Jt7hwaZPhWTGBkYoW4+ZAOfNZrLDh/qvxSYA==}
     peerDependencies:
@@ -2828,8 +2832,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-alert-dialog@1.1.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-6c2cXpNlAgHDhKguK24XcWHHayMpK+lk7/WwBXBco+ZJ4Dv7xP++GBM280KgTD/HCRu3jSdfe8WQiZssonYaIA==}
+  /@radix-ui/react-accordion@1.2.16(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-BpZJNmetujnGgUI6OX0jEhEmlA46WPqgub8Rv09Kyquwd0cc1ndMKpiPYCjmBU6KSSRPAMtgLpEoZSG/tdNIWQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2841,10 +2845,38 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collapsible': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-dialog': 1.1.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
+  /@radix-ui/react-alert-dialog@1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-FA7n1f6D/DwGE0+AWxiY5LacNbbExQuEgMubeG06idEaH+mSLuf9dp/qBNqOnvbTQ+4gZ2ue1RATF1Ub91Mg5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -2892,8 +2924,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-avatar@1.2.1(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-+8PWoLLZv3AVb5m0pvoiOca/bQGzc9vPVb+982HB2x3Un0DpYEPM3zLMl4oqRpBsocJuNqLkiv/HXTnTrlwr4g==}
+  /@radix-ui/react-avatar@1.2.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-sST0qh8GzOB7besQ3tMLWLyngnRuSk0gc/Hm+667KYKQFCt6Y6ZXv25WlqM7dIDK54ULCh5+CHmk4LIolzfz+A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2905,7 +2937,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.6)
@@ -2916,8 +2948,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-checkbox@1.3.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-eUEUoGMDpfkgHWSE97ZZaUJtzR1M7EKnNIpD1Q16+8JR9NWghcaqMulx9PuCQ720w0UclfYn6FEbCdd5Hx087g==}
+  /@radix-ui/react-checkbox@1.3.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-JroKHfQBfh+fDuzpPsBC+pESkhuq8ql4hljTguz8MWnS35cISr3d/Jhl9kYrB44FlDtxCArYdDvTx+BSsJ64rQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2929,10 +2961,10 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.6)
@@ -2970,6 +3002,33 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
+  /@radix-ui/react-collapsible@1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-opfXRe6nnzyGmCDPx+l1Aqo/RbqWtQal2FnsBqF9hhePp6j0LsRoBaRxcMOlTv+uYTJVtWYZKg9t9wTe+BA/ZA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
   /@radix-ui/react-collection@1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
     resolution: {integrity: sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==}
     peerDependencies:
@@ -2993,6 +3052,29 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
+  /@radix-ui/react-collection@1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
   /@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.6):
     resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
     peerDependencies:
@@ -3006,8 +3088,8 @@ packages:
       react: 19.2.6
     dev: false
 
-  /@radix-ui/react-context-menu@2.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-qzsA/ZPhF6yMxBOTIk1nlCkoy2mswSbwYL+ErBa2iP0s4WWrlxmczArYqMcpVfEjmM7KJj/ADPXky0yZfbSxtQ==}
+  /@radix-ui/react-context-menu@2.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-PS+gKE0z2prJ74Y0sM+brAGK4mYOHIR7TlcV5EJgUQ6E0xMvyswkK2X4yRqyganrzsRL+WCSKAPu0NQITICRWg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3019,9 +3101,9 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-menu': 2.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@types/react': 19.2.17
@@ -3032,6 +3114,19 @@ packages:
 
   /@radix-ui/react-context@1.1.4(@types/react@19.2.17)(react@19.2.6):
     resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.2.17
+      react: 19.2.6
+    dev: false
+
+  /@radix-ui/react-context@1.2.0(@types/react@19.2.17)(react@19.2.6):
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3065,6 +3160,39 @@ packages:
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.6)
+    dev: false
+
+  /@radix-ui/react-dialog@1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
@@ -3113,8 +3241,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-dropdown-menu@2.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-HZccBkbK0LOi8nYKIp5jll/zIRW0cCOmG6WWyqsSpmXCU+ZlcBbTqIwlBvPCu886C5RVu6c/kHV7xSP8IgYNHw==}
+  /@radix-ui/react-dismissable-layer@1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3126,11 +3254,35 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
+  /@radix-ui/react-dropdown-menu@2.1.20(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-menu': 2.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@types/react': 19.2.17
@@ -3174,8 +3326,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-form@0.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-0mTMJHv1gQAuEQoq5VDpTD3MRgmfUFdXAVFhpqR7wBeUr+tyRsof0wv/4XdPHLwQrefhoH2FiGHCggrCJhalIw==}
+  /@radix-ui/react-focus-scope@1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3187,9 +3339,31 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
+  /@radix-ui/react-form@0.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-JTX94E4LDL91rzLg7X0mHPdxr0A8JEdVwZEmeOwZJSMDHCGW5DFtSlTSJozUyUs807IQmnvbfzKZFVCK5DmkqQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-label': 2.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
@@ -3199,8 +3373,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-hover-card@1.1.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-rt+Fx4HoCeEwFL2IdoV2QaPltqDLlzxN77i9nwB3Y70scFlfAHh1QCdE2TXKuFJtA1TNygb0oivnFBZifgtZOw==}
+  /@radix-ui/react-hover-card@1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-2KTgMLQtKvicznQgbindEI2RZ3QbDIwU5gabjUPwFJsormjGDz+rUvO4NANmYwzEEpTcTONUt33vBHIfTIVSfw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3212,13 +3386,13 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@types/react': 19.2.17
@@ -3261,8 +3435,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-menu@2.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-Mht9BVd1AIsNFVQr4KG3bIK7XQn5IXF0TL/2ObsrzOdc1loaly/+kBDL5roSCYn8j8XZkvpOD0WYLz2FQtH1Eg==}
+  /@radix-ui/react-menu@2.1.20(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3274,20 +3448,20 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@types/react': 19.2.17
@@ -3298,8 +3472,8 @@ packages:
       react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-menubar@1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-Glt6mebxcgQvLeVkH3HiqV5bgQubE+31ELxLs7q0GlYI5k0XYkOkeuPrhXoylxK8eufvIt9CJjzY1TfFMXK3qw==}
+  /@radix-ui/react-menubar@1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-gzFZvybgmwYsFBWDqanycIoEYnhyk8MMnuLamdFVHUZYGp4COM+sqXiwbnn0VMWqGLeeU7GV7jm+dXRa+Wufag==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3311,15 +3485,15 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-menu': 2.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -3360,8 +3534,41 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-one-time-password-field@0.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-Rsgab65u73E5kPVh8OS6PgPwJgPyf08GFfJDGAbMdF4DL7CgDhFOaDnXuk/DiMEVF6kgQwl0oJmFklvipmiOLg==}
+  /@radix-ui/react-navigation-menu@1.2.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-K9HiuxZ6xCwSaHcIuUpxyhy4w5gpwzWjh9dHTSbMN3Ix4qAyVObS9RlU3zMycb0PO3v9Tpk0BXMwWvXOUbVXew==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
+  /@radix-ui/react-one-time-password-field@0.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-nQLu5OAcORDQp1EHAv6k3mJGV1hjMTw2NTGVAsGE1g/mWeNqAd1R5jyaAs3U+A8ZD/W8XNPY2yKT0ZdQnqo3NA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3374,13 +3581,13 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.6)
@@ -3391,8 +3598,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-password-toggle-field@0.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-pQ3xGp/uemomASPH97Eb3shfXX8QlG11bBJyEvRBV+vwtO4HvQlS06Yj9f31Ao7XepvF98SFrRgVDQ7jv+2xjQ==}
+  /@radix-ui/react-password-toggle-field@0.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-gB1Mr8vzdv1XzDjrtJTXmL0JORRs1B4g7ngUs0F+H2VvMOwXTZMTmLCl0wZZ3m7ylX8TssI7NCvgiSHmLuTm/A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3404,9 +3611,9 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
@@ -3452,6 +3659,40 @@ packages:
       react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.6)
     dev: false
 
+  /@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-jkrTdQVxnIB8fpn0NyyxW9CTB5aCXZZelVz5z+Xmii6g5WxMqS3fInNslZ63puP39+Puu4jYohUK31y3dT87gQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.6)
+    dev: false
+
   /@radix-ui/react-popper@1.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
     resolution: {integrity: sha512-3QXNeMkdshed1MR3LNoiCirBywRFPkD8ETJa/HlPuLwSajaQixf2ro+isoDNJlGABg9ug41XuZpINZJIle4XWg==}
     peerDependencies:
@@ -3469,6 +3710,35 @@ packages:
       '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/rect': 1.1.2
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
+  /@radix-ui/react-popper@1.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.6)
@@ -3522,6 +3792,26 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
+  /@radix-ui/react-presence@1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
   /@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
     resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
     peerDependencies:
@@ -3542,8 +3832,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-progress@1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-KqiGJcFaZDc+BvveAgU3ZhACg2MvSUDrCBx4lRR/ZVRNal0bvt8lBpvnSkep9heeOuF8Qfw3fszLDX4OpQ2NVw==}
+  /@radix-ui/react-progress@1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-ZPHyI0JyzoH/rP0tq2uRaIZTj/4s8+kAbqPz+e2N8+ejHvwPJ889dHhqn+vh7PNvNeq+boAoH9yzqeoShzwF2w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3555,7 +3845,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -3563,8 +3853,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-radio-group@1.4.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-W8Uo9riHnlzLLWy+r2mVHUyuEWqD/+be4PZzbEvaGoFSBDHkm+GYWjtcE6u3AmPKNyfanWpnVfpZ2GqPCdzzsw==}
+  /@radix-ui/react-radio-group@1.4.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-WwZFjWV4s3aC1QtR3k04R+oANHtX2q6fgKlc7MCEiDNlnTxCZ3H8k3mHtEgVlOejystwk1WQgarQhNOQZ2bK1g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3576,13 +3866,13 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.6)
@@ -3620,6 +3910,36 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
+  /@radix-ui/react-roving-focus@1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
   /@radix-ui/react-scroll-area@1.2.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
     resolution: {integrity: sha512-7tncSubo2G0UY1e8rk+72qe3XRzrGnOLtZQ1PL1KoBfRUNX0NrJT5akb+0kfwSCc3gVR4wdHqyhAQBDpDNOwDw==}
     peerDependencies:
@@ -3648,8 +3968,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-select@2.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-brXD6C/V0fVK0DDbscLVw6LsXrjQ+ay8jdOBaN+tLb4vsHsAMm6Gt6eT77wHX1Eq8GPtD5rJ+RxFtfDozsb4+Q==}
+  /@radix-ui/react-scroll-area@1.2.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-bBODCWZK7JTbQLHs0uIP4f73wIWatakK4OS33UzkR1x897wu0PuO658a3f+6P2GEGyDzGYMuHRatMVoAk9WZTw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3662,18 +3982,46 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
+  /@radix-ui/react-select@2.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-L5RQTXz6Anxsf9CCv+pTgiAsUpyVj7rJxsGtmhFaEOJ++cVfXucv4qWfsIO0AIB4NAhi3yovWGVMKKS1Xf1Wrg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
@@ -3709,8 +4057,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-slider@1.4.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-qt5C1ppJz66aUDrH1VccjPrq7aFchK0wBrn6xsxlCHNUyE57dRRQ7lp1QFpF7OscMexZF8MCGBTVBlENHPkNiA==}
+  /@radix-ui/react-slider@1.4.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-CWVVj+XaTom0SKCqw1EUgb0NuiLwS+N3OFG73mVEezKEjgNIvZiu0EevMelSSU+CbX3owbqJweG2gPU31WGC5A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3723,10 +4071,10 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
@@ -3753,8 +4101,8 @@ packages:
       react: 19.2.6
     dev: false
 
-  /@radix-ui/react-switch@1.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-tgRBI3DdNwAJYE4BBZyZcz/HRRCvAsPkRvG1wvKc+41tBGMxPn/a87T/wikXAvyDypNQ9kaZwHbeZe+veHCGpA==}
+  /@radix-ui/react-switch@1.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-1+mlB4/lxJfk5tgJ4g+R5mUCbRpPE1T9+UsEyeLYbGgMtwiMgmuTnfKz4Mw1nHALHjuwyxw4MLd4cSHn6pNSlQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3766,9 +4114,9 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.6)
@@ -3806,8 +4154,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-toast@1.2.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-YNEnTHV47hPep+U0QvVM02OJNka9uygREc+k4Nh5VSZBg4MmE+myI442x3hCGfRpX7N2WSSYSJKws4gE+Z8lgg==}
+  /@radix-ui/react-tabs@1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-nRyXnrAVCwjeXcHbvEbLS6ndbTeKHG1RqCP4A8Gw5L4cemDzPXdD8rAmr6wet0v57R69wGvuIIsFjHSVkZiMzQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3819,13 +4167,40 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    dev: false
+
+  /@radix-ui/react-toast@1.2.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-SxfVZfVOibWKWdkf0Xx1awW2d09fQu4V4PXDY1j5hi4MVf7MWdJZqTBJMa1KWtOr1S6GGtCk02nniZ0Iia+dHw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
@@ -3837,8 +4212,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-toggle-group@1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-TK1vusNKb8IRhF23FTbRgUNZ9zfs5rGIyI7LfR3h26p9LrQ060i0uW9QWeD8baZMddaaP0DBGlIa6pbZG+mitg==}
+  /@radix-ui/react-toggle-group@1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-gIC5Q+Xljg7lmUdzSuDoy0t97yZn1sZl00Ra37ZvKrYdWnQLU6sWLd09yG8cIB9jUAlQfHgJ2ACAG00MFwsqSQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3850,12 +4225,12 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-toggle': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-toggle': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -3863,8 +4238,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-toggle@1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-bI2ILJrzwgmAsH05TsJ9pVrzqQwAip7OM2/krqAdYn0R16bl86UPWbe5VPHsALat0EnqpV01cGtkleaUKPNdNg==}
+  /@radix-ui/react-toggle@1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-QI/hB65XKWACA66P64A+aHxtLUgHJeJLkaQa+awUNXT6T3swndtY5DojeHA+vldrTspMTtFBd7HfZ9QGbM1Qrw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3876,7 +4251,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@types/react': 19.2.17
@@ -3885,8 +4260,8 @@ packages:
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-toolbar@1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-L/EkWVqlnj3lL2toHh4C7PwH2jxfa7OCq6lGfXSCii99ve2S4Ux5rc9HnOa7LN9exHa/Nl9kmCAmP9BuDPy5UA==}
+  /@radix-ui/react-toolbar@1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-t/iEuVjUnXXtrsGK40AA43uIx37sn3AqZ7oAVnPICK6lFJP6dzMzWR3U9b6eCfFjb6wtSEqkJ9Rn9xDjiOx20g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3898,21 +4273,21 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-separator': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-toggle-group': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-toggle-group': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     dev: false
 
-  /@radix-ui/react-tooltip@1.2.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-8XZ6Py3y3W2nEzAUGCN5cfVKaUi+CVApcz1d6lrNVVf2hvYEixMRkq8k9ggPKnQUpRRuOV5avt8uvxViH2jLwA==}
+  /@radix-ui/react-tooltip@1.2.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-U3HoftgWnmla78vzQbLvKKb7bUYJxoiiqYFzp1wu/TBMyDqMZSuCl3aRICsD6EfVEwcJD2mumGDGUXLFVqQHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3924,14 +4299,14 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
@@ -5493,7 +5868,7 @@ packages:
       motion: 12.42.2(react-dom@19.2.6)(react@19.2.6)
       next: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.6)(react@19.2.6)
       next-themes: 0.4.6(react-dom@19.2.6)(react@19.2.6)
-      radix-ui: 1.6.1(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      radix-ui: 1.6.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-player: 3.4.0(@svta/cml-cta@1.0.6)(@svta/cml-structured-field-values@1.1.3)(@svta/cml-utils@1.5.0)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
@@ -10512,8 +10887,8 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
-  /radix-ui@1.6.1(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
-    resolution: {integrity: sha512-QXDXJtB6sK83mLASONYUZCauatcWb+knFviFpN1EhtdbbmlsRmzCLrbZSKztnNiem2KOHIBbiDbauVB7SORXMw==}
+  /radix-ui@1.6.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6):
+    resolution: {integrity: sha512-OwYUjzMwiInCUxgAWpPsavXC3Kh4iyi/49uU1/qZTG3RQDlvegyk1GOMiGvSkjua1RDb3JD3fo3eroL9FV4GQw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -10525,53 +10900,53 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.5
       '@radix-ui/react-accessible-icon': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-accordion': 1.2.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-alert-dialog': 1.1.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-accordion': 1.2.16(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-alert-dialog': 1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-aspect-ratio': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-avatar': 1.2.1(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-checkbox': 1.3.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-collapsible': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-avatar': 1.2.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-checkbox': 1.3.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-collapsible': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-context-menu': 2.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-dialog': 1.1.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.6)
+      '@radix-ui/react-context-menu': 2.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-dropdown-menu': 2.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-dropdown-menu': 2.1.20(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-form': 0.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-hover-card': 1.1.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-form': 0.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-hover-card': 1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-label': 2.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-menu': 2.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-menubar': 1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-navigation-menu': 1.2.17(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-one-time-password-field': 0.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-password-toggle-field': 0.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-popover': 1.1.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-menubar': 1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-navigation-menu': 1.2.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-one-time-password-field': 0.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-password-toggle-field': 0.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-popover': 1.1.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-progress': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-radio-group': 1.4.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-scroll-area': 1.2.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-select': 2.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-progress': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-radio-group': 1.4.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-scroll-area': 1.2.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-select': 2.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-separator': 1.1.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-slider': 1.4.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-slider': 1.4.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.6)
-      '@radix-ui/react-switch': 1.3.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-tabs': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-toast': 1.2.18(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-toggle': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-toggle-group': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-toolbar': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
-      '@radix-ui/react-tooltip': 1.2.11(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-switch': 1.3.3(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-tabs': 1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-toast': 1.2.19(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-toggle': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-toggle-group': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-toolbar': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
+      '@radix-ui/react-tooltip': 1.2.12(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.6)(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.6)
       '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.6)


### PR DESCRIPTION
## What changed

Bumps @openai/codex / @openai/codex-sdk from 0.125 → 0.144, and updates sandbox bootstrap plus agent config for the new native-binary layout and default plugin behavior.

## Why

Codex 0.144 changes how the linux native binary is packaged (vendor/<triple>/bin/codex instead of vendor/<triple>/codex/codex) and how platform packages are aliased under pnpm. Without bootstrap updates, sandboxes fail to resolve the binary when bootstrapped from a Mac host. Codex 0.143+ also enables remote_plugin by default, which we don't want in investigate/revalidate workers.

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

Fixes #100 
