### PR TITLE
Try to avoid OOM from sandboxes. Caps the size of log lines

### DIFF
--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/src/__tests__/output-cap.test.ts
+++ b/packages/deepsec/src/__tests__/output-cap.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { capStream } from "../output-cap.js";
+
+function makeSink() {
+  const written: string[] = [];
+  return {
+    written,
+    stream: {
+      write(chunk: unknown, encoding?: unknown, callback?: unknown): boolean {
+        if (typeof encoding === "function") {
+          callback = encoding;
+        }
+        written.push(String(chunk));
+        if (typeof callback === "function") (callback as () => void)();
+        return true;
+      },
+    },
+  };
+}
+
+describe("capStream", () => {
+  it("passes short writes through untouched", () => {
+    const { stream, written } = makeSink();
+    capStream(stream, { remainingBytes: 1024, exhausted: false });
+    stream.write("hello\n");
+    expect(written).toEqual(["hello\n"]);
+  });
+
+  it("truncates individual long lines", () => {
+    const { stream, written } = makeSink();
+    capStream(stream, { remainingBytes: 1024 * 1024, exhausted: false });
+    stream.write(`short\n${"x".repeat(5000)}\nend\n`);
+    expect(written).toHaveLength(1);
+    const lines = written[0].split("\n");
+    expect(lines[0]).toBe("short");
+    expect(lines[1]).toContain("[line truncated]");
+    expect(lines[1].length).toBeLessThan(2100);
+    expect(lines[2]).toBe("end");
+  });
+
+  it("suppresses output after the byte budget is exhausted", () => {
+    const { stream, written } = makeSink();
+    const state = { remainingBytes: 10, exhausted: false };
+    capStream(stream, state);
+    stream.write("0123456789ABC");
+    expect(written[0]).toContain("output cap reached");
+    stream.write("more\n");
+    expect(written).toHaveLength(1);
+    expect(state.exhausted).toBe(true);
+  });
+
+  it("shares one budget across two streams", () => {
+    const out = makeSink();
+    const err = makeSink();
+    const state = { remainingBytes: 10, exhausted: false };
+    capStream(out.stream, state);
+    capStream(err.stream, state);
+    out.stream.write("0123456789ABC");
+    err.stream.write("never shown\n");
+    expect(out.written).toHaveLength(1);
+    expect(err.written).toHaveLength(0);
+  });
+
+  it("still invokes callbacks while suppressing", () => {
+    const { stream } = makeSink();
+    capStream(stream, { remainingBytes: 0, exhausted: true });
+    let called = false;
+    stream.write("dropped", () => {
+      called = true;
+    });
+    expect(called).toBe(true);
+  });
+
+  it("decodes Buffer chunks", () => {
+    const { stream, written } = makeSink();
+    capStream(stream, { remainingBytes: 1024, exhausted: false });
+    stream.write(Buffer.from("buf\n"));
+    expect(written).toEqual(["buf\n"]);
+  });
+});

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -20,8 +20,11 @@ import { scanCommand } from "./commands/scan.js";
 import { statusCommand } from "./commands/status.js";
 import { triageCommand } from "./commands/triage.js";
 import { loadConfig } from "./load-config.js";
+import { installSandboxOutputCap } from "./output-cap.js";
 import { applyAiGatewayDefaults } from "./preflight.js";
 import { getDeepsecVersion } from "./version.js";
+
+installSandboxOutputCap();
 
 const program = new Command();
 

--- a/packages/deepsec/src/output-cap.ts
+++ b/packages/deepsec/src/output-cap.ts
@@ -1,0 +1,74 @@
+// Caps stdout/stderr of the deepsec worker when it runs inside a sandbox.
+//
+// Everything the worker writes flows back to the orchestrator through the
+// sandbox NDJSON log stream, which is parsed with unbounded JSON.parse in
+// @vercel/sandbox. The orchestrator caps what it *consumes*
+// (see sandbox/orchestrator.ts), but a single oversized record can still
+// OOM the SDK before that cap applies — so the worker must never emit one.
+// Long lines are truncated at the source and, once the total budget is
+// spent, all further output is dropped.
+//
+// The orchestrator only pattern-matches batch-complete lines as a sync
+// nudge; its download poller has a 15s timer fallback, so suppressed
+// output degrades politeness, not correctness.
+
+const MAX_LINE_CHARS = 2_000;
+const MAX_TOTAL_BYTES = 8 * 1024 * 1024;
+
+type CapState = { remainingBytes: number; exhausted: boolean };
+
+type MinimalWritable = {
+  write(chunk: unknown, encoding?: unknown, callback?: unknown): boolean;
+};
+
+function truncateLines(text: string): string {
+  if (text.length <= MAX_LINE_CHARS) return text;
+  return text
+    .split("\n")
+    .map((line) =>
+      line.length > MAX_LINE_CHARS ? `${line.slice(0, MAX_LINE_CHARS)}… [line truncated]` : line,
+    )
+    .join("\n");
+}
+
+/** Exported for tests. Patches `stream.write` against a shared budget. */
+export function capStream(stream: MinimalWritable, state: CapState): void {
+  const orig = stream.write.bind(stream);
+  stream.write = (chunk: unknown, encoding?: unknown, callback?: unknown): boolean => {
+    if (typeof encoding === "function") {
+      callback = encoding;
+      encoding = undefined;
+    }
+    if (state.exhausted) {
+      if (typeof callback === "function") (callback as () => void)();
+      return true;
+    }
+    const text = truncateLines(
+      typeof chunk === "string"
+        ? chunk
+        : Buffer.isBuffer(chunk)
+          ? chunk.toString("utf8")
+          : String(chunk),
+    );
+    state.remainingBytes -= Buffer.byteLength(text);
+    if (state.remainingBytes <= 0) {
+      state.exhausted = true;
+      return orig(
+        `${text}\n[deepsec: sandbox output cap reached; further logs suppressed]\n`,
+        callback,
+      );
+    }
+    return orig(text, encoding, callback);
+  };
+}
+
+/**
+ * No-op outside a sandbox (DEEPSEC_INSIDE_SANDBOX !== "1"). Inside one,
+ * caps process.stdout and process.stderr against a shared byte budget.
+ */
+export function installSandboxOutputCap(): void {
+  if (process.env.DEEPSEC_INSIDE_SANDBOX !== "1") return;
+  const state: CapState = { remainingBytes: MAX_TOTAL_BYTES, exhausted: false };
+  capStream(process.stdout, state);
+  capStream(process.stderr, state);
+}

--- a/packages/deepsec/src/sandbox/orchestrator.ts
+++ b/packages/deepsec/src/sandbox/orchestrator.ts
@@ -57,6 +57,83 @@ function buildSandboxInvocation(
 
 const PARTITIONABLE_COMMANDS = new Set(["process", "revalidate"]);
 
+// An agent inside a sandbox can emit pathological output volume (e.g.
+// `rg '^'` over a large repo). The log stream is parsed record-by-record
+// with unbounded JSON.parse inside @vercel/sandbox, so without a cap it
+// can OOM this orchestrator process. Budget is per command stream.
+const MAX_LOG_BYTES_PER_SANDBOX = 10 * 1024 * 1024;
+const MAX_LOG_LINE_CHARS = 2_000;
+
+/**
+ * Stream a command's logs through onLog with a byte budget and per-line
+ * truncation. Once the budget is exhausted the stream is aborted; the
+ * caller's cmd.wait() remains the arbiter of completion. Never throws.
+ *
+ * onRawLine receives each untruncated line (used for batch-complete
+ * detection) before display truncation is applied.
+ */
+type LoggableCommand = {
+  logs(opts?: { signal?: AbortSignal }): AsyncIterable<{ stream?: string; data: string }>;
+};
+
+async function streamLogsCapped(
+  cmd: LoggableCommand,
+  prefix: string,
+  onLog: (msg: string) => void,
+  onRawLine?: (line: string) => void,
+): Promise<void> {
+  const aborter = new AbortController();
+  let remaining = MAX_LOG_BYTES_PER_SANDBOX;
+  try {
+    for await (const log of cmd.logs({ signal: aborter.signal })) {
+      remaining -= Buffer.byteLength(log.data);
+      const lines = log.data.trim();
+      if (lines) {
+        for (const line of lines.split("\n")) {
+          onRawLine?.(line);
+          const shown =
+            line.length > MAX_LOG_LINE_CHARS
+              ? `${line.slice(0, MAX_LOG_LINE_CHARS)}… [line truncated]`
+              : line;
+          onLog(`${prefix} ${shown}`);
+        }
+      }
+      if (remaining <= 0) {
+        onLog(
+          `${prefix} [log stream exceeded ${Math.round(MAX_LOG_BYTES_PER_SANDBOX / 1024 / 1024)}MiB; further output suppressed]`,
+        );
+        aborter.abort();
+        break;
+      }
+    }
+  } catch {
+    // Stream errors (including our own abort) are non-fatal here.
+  }
+}
+
+/**
+ * Read a command's stderr via the log stream, aborting once maxChars have
+ * been collected. cmd.stderr() accumulates the entire stream into memory
+ * with no cap, so it must not be called on agent-driven commands.
+ */
+async function readStderrCapped(cmd: LoggableCommand, maxChars: number): Promise<string> {
+  const aborter = new AbortController();
+  let out = "";
+  try {
+    for await (const log of cmd.logs({ signal: aborter.signal })) {
+      if (log.stream !== "stderr") continue;
+      out += log.data;
+      if (out.length >= maxChars) {
+        aborter.abort();
+        break;
+      }
+    }
+  } catch {
+    // Stream errors (including our own abort) are non-fatal here.
+  }
+  return out.slice(0, maxChars);
+}
+
 // --- Upload prep ---
 
 /**
@@ -424,19 +501,10 @@ export async function collect(
 
       if (cmd.exitCode === null) {
         onLog(`[sandbox-${entry.index}] Still running, waiting...`);
-        try {
-          for await (const log of cmd.logs()) {
-            const lines = log.data.trim();
-            if (lines) {
-              for (const line of lines.split("\n")) {
-                onLog(`[sandbox-${entry.index}] ${line}`);
-              }
-            }
-          }
-        } catch {}
+        await streamLogsCapped(cmd, `[sandbox-${entry.index}]`, onLog);
         const finished = await cmd.wait();
         if (finished.exitCode !== 0) {
-          const stderr = await finished.stderr();
+          const stderr = await readStderrCapped(finished, 500);
           onLog(`[sandbox-${entry.index}] Failed (exit ${finished.exitCode})`);
           try {
             await sandbox.stop();
@@ -450,7 +518,7 @@ export async function collect(
           };
         }
       } else if (cmd.exitCode !== 0) {
-        const stderr = await cmd.stderr();
+        const stderr = await readStderrCapped(cmd, 500);
         onLog(`[sandbox-${entry.index}] Was failed (exit ${cmd.exitCode})`);
         try {
           await sandbox.stop();
@@ -730,21 +798,13 @@ async function runOnSandboxAttached(
       detached: true,
     });
 
-    try {
-      for await (const log of cmd.logs()) {
-        const lines = log.data.trim();
-        if (lines) {
-          for (const line of lines.split("\n")) {
-            onLog(`[sandbox-${index}] ${line}`);
-            if (nudge && BATCH_COMPLETE_RE.test(line)) {
-              // Kick the streaming download loop to sync now — a batch
-              // just finished and wrote file records to disk.
-              nudge.signal();
-            }
-          }
-        }
+    await streamLogsCapped(cmd, `[sandbox-${index}]`, onLog, (line) => {
+      if (nudge && BATCH_COMPLETE_RE.test(line)) {
+        // Kick the streaming download loop to sync now — a batch
+        // just finished and wrote file records to disk.
+        nudge.signal();
       }
-    } catch {}
+    });
     const tLogsClosed = Date.now();
 
     const result = await cmd.wait();
@@ -755,7 +815,7 @@ async function runOnSandboxAttached(
     }
 
     if (result.exitCode !== 0) {
-      const stderr = await result.stderr();
+      const stderr = await readStderrCapped(result, 500);
       instance.status = "error";
       instance.error = `Exit code ${result.exitCode}: ${stderr.slice(0, 500)}`;
       onLog(`[sandbox-${index}] ${config.command} failed (exit ${result.exitCode})`);


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
