### PR TITLE
Add Kubernetes privileged workload matcher

### DIFF
--- a/packages/scanner/src/__tests__/matchers.test.ts
+++ b/packages/scanner/src/__tests__/matchers.test.ts
@@ -173,6 +173,32 @@ spec:
     expect(matches[0].lineNumbers).toEqual([8]);
   });
 
+  it("supports indentationless capability sequences without scanning sibling lists", () => {
+    const dangerous = `apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - securityContext:
+        capabilities:
+          add:
+          - SYS_ADMIN`;
+    const matches = k8sPrivilegedWorkloadMatcher.match(dangerous, "deploy/pod.yaml");
+    expect(matches.map((match) => match.matchedPattern)).toEqual(["dangerous Linux capability"]);
+    expect(matches[0].lineNumbers).toEqual([8]);
+
+    const dropped = `apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - securityContext:
+        capabilities:
+          add:
+          - CHOWN
+          drop:
+          - SYS_ADMIN`;
+    expect(k8sPrivilegedWorkloadMatcher.match(dropped, "deploy/pod.yaml")).toEqual([]);
+  });
+
   it("ignores non-workload documents and capabilities being dropped", () => {
     const content = `apiVersion: v1
 kind: ConfigMap

--- a/packages/scanner/src/__tests__/matchers.test.ts
+++ b/packages/scanner/src/__tests__/matchers.test.ts
@@ -158,4 +158,87 @@ spec:
       [],
     );
   });
+
+  it("detects block-list capabilities and first-party Helm charts", () => {
+    const content = `apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - securityContext:
+        capabilities:
+          add:
+            - SYS_ADMIN`;
+    const matches = k8sPrivilegedWorkloadMatcher.match(content, "charts/app/templates/pod.yaml");
+    expect(matches.map((match) => match.matchedPattern)).toEqual(["dangerous Linux capability"]);
+    expect(matches[0].lineNumbers).toEqual([8]);
+  });
+
+  it("ignores non-workload documents and capabilities being dropped", () => {
+    const content = `apiVersion: v1
+kind: ConfigMap
+data:
+  settings.yaml: |
+    privileged: true
+---
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - securityContext:
+        capabilities:
+          drop:
+            - SYS_ADMIN`;
+    expect(k8sPrivilegedWorkloadMatcher.match(content, "deploy/resources.yaml")).toEqual([]);
+  });
+
+  it("reports global line numbers from workload documents only", () => {
+    const content = `apiVersion: v1
+kind: ConfigMap
+data:
+  privileged: true
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      hostNetwork: true`;
+    const matches = k8sPrivilegedWorkloadMatcher.match(content, "deploy/resources.yaml");
+    expect(matches.map((match) => match.matchedPattern)).toEqual(["host namespace shared"]);
+    expect(matches[0].lineNumbers).toEqual([11]);
+  });
+
+  it("does not split a document on an indented YAML block scalar", () => {
+    const content = `apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    example.com/config: |
+      ---
+      nested: content
+spec:
+  hostPID: true`;
+    const matches = k8sPrivilegedWorkloadMatcher.match(content, "deploy/pod.yaml");
+    expect(matches.map((match) => match.matchedPattern)).toEqual(["host namespace shared"]);
+    expect(matches[0].lineNumbers).toEqual([9]);
+  });
+
+  it("ignores YAML-looking text outside the workload spec or inside scalar data", () => {
+    const content = `apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    hostPID: true
+spec:
+  containers:
+    - name: app
+      env:
+        - name: CONFIG
+          value: |
+            privileged: true
+            capabilities:
+              add:
+                - SYS_ADMIN`;
+    expect(k8sPrivilegedWorkloadMatcher.match(content, "deploy/pod.yaml")).toEqual([]);
+  });
 });

--- a/packages/scanner/src/__tests__/matchers.test.ts
+++ b/packages/scanner/src/__tests__/matchers.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { authBypassMatcher } from "../matchers/auth-bypass.js";
 import { insecureCryptoMatcher } from "../matchers/insecure-crypto.js";
+import { k8sPrivilegedWorkloadMatcher } from "../matchers/k8s-privileged-workload.js";
 import { missingAuthMatcher } from "../matchers/missing-auth.js";
 import { openRedirectMatcher } from "../matchers/open-redirect.js";
 import { pathTraversalMatcher } from "../matchers/path-traversal.js";
@@ -119,5 +120,42 @@ describe("open-redirect matcher", () => {
     const content = readFixture("utils/redirect.ts");
     const matches = openRedirectMatcher.match(content, "src/utils/redirect.ts");
     expect(matches.length).toBeGreaterThan(0);
+  });
+});
+
+describe("k8s-privileged-workload matcher", () => {
+  it("detects privileged Kubernetes workload settings", () => {
+    const content = `apiVersion: v1
+kind: Pod
+spec:
+  hostPID: true
+  containers:
+    - securityContext:
+        privileged: true
+        allowPrivilegeEscalation: true`;
+    const matches = k8sPrivilegedWorkloadMatcher.match(content, "deploy/pod.yaml");
+    expect(matches.map((match) => match.matchedPattern)).toEqual([
+      "privileged container",
+      "privilege escalation allowed",
+      "host namespace shared",
+    ]);
+  });
+
+  it("does not flag hardened workloads or non-Kubernetes YAML", () => {
+    const hardened = `apiVersion: v1
+kind: Pod
+spec:
+  hostPID: false
+  containers:
+    - securityContext:
+        privileged: false
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        capabilities:
+          drop: ["ALL"]`;
+    expect(k8sPrivilegedWorkloadMatcher.match(hardened, "deploy/pod.yaml")).toEqual([]);
+    expect(k8sPrivilegedWorkloadMatcher.match("hostNetwork: true", "config/settings.yaml")).toEqual(
+      [],
+    );
   });
 });

--- a/packages/scanner/src/matchers/index.ts
+++ b/packages/scanner/src/matchers/index.ts
@@ -108,6 +108,7 @@ import { jvmSpringControllerMatcher } from "./jvm-spring-controller.js";
 import { jvmSqlRawMatcher } from "./jvm-sql-raw.js";
 // --- Auth / sessions / env matchers ---
 import { jwtHandlingMatcher } from "./jwt-handling.js";
+import { k8sPrivilegedWorkloadMatcher } from "./k8s-privileged-workload.js";
 import { k8sSecretReferenceMatcher } from "./k8s-secret-reference.js";
 import { k8sSecretsInitContainerMatcher } from "./k8s-secrets-init-container.js";
 import { lambdaAwsHandlerMatcher } from "./lambda-aws-handler.js";
@@ -317,6 +318,7 @@ export function createDefaultRegistry(): MatcherRegistry {
   registry.register(secretsPlaintextExposureMatcher);
   registry.register(k8sSecretReferenceMatcher);
   registry.register(k8sSecretsInitContainerMatcher);
+  registry.register(k8sPrivilegedWorkloadMatcher);
 
   // ConnectRPC / proto / Unix-socket
   registry.register(protoRpcSurfaceMatcher);

--- a/packages/scanner/src/matchers/k8s-privileged-workload.ts
+++ b/packages/scanner/src/matchers/k8s-privileged-workload.ts
@@ -1,5 +1,185 @@
+import type { CandidateMatch } from "@deepsec/core";
 import type { MatcherPlugin } from "../types.js";
 import { regexMatcher } from "./utils.js";
+
+const WORKLOAD_KINDS = new Set([
+  "CronJob",
+  "DaemonSet",
+  "Deployment",
+  "DeploymentConfig",
+  "Job",
+  "Pod",
+  "PodTemplate",
+  "ReplicaSet",
+  "ReplicationController",
+  "Rollout",
+  "StatefulSet",
+]);
+
+const PATTERNS = [
+  { regex: /^\s*privileged\s*:\s*true\s*(?:#.*)?$/, label: "privileged container" },
+  {
+    regex: /^\s*allowPrivilegeEscalation\s*:\s*true\s*(?:#.*)?$/,
+    label: "privilege escalation allowed",
+  },
+  {
+    regex: /^\s*host(?:IPC|Network|PID)\s*:\s*true\s*(?:#.*)?$/,
+    label: "host namespace shared",
+  },
+  { regex: /^\s*runAsUser\s*:\s*0\s*(?:#.*)?$/, label: "container runs as root UID" },
+  { regex: /^\s*-?\s*hostPath\s*:/, label: "host filesystem mount" },
+  { regex: /^\s*procMount\s*:\s*["']?Unmasked["']?\s*$/, label: "unmasked proc mount" },
+];
+
+const MATCH_ORDER = new Map(
+  [...PATTERNS.map(({ label }) => label), "dangerous Linux capability"].map((label, index) => [
+    label,
+    index,
+  ]),
+);
+
+function leadingIndent(line: string): number {
+  return line.match(/^\s*/)?.[0].length ?? 0;
+}
+
+function isStructuralLine(line: string): boolean {
+  return Boolean(line.trim()) && !/^\s*(?:#|{{.*}}\s*$)/.test(line);
+}
+
+function topLevelIndent(lines: string[]): number | undefined {
+  const structuralLines = lines.filter(isStructuralLine);
+  if (structuralLines.length === 0) return undefined;
+  return Math.min(...structuralLines.map(leadingIndent));
+}
+
+function isWorkloadDocument(lines: string[]): boolean {
+  const rootIndent = topLevelIndent(lines);
+  if (rootIndent === undefined) return false;
+  const topLevel = lines.filter(
+    (line) => isStructuralLine(line) && leadingIndent(line) === rootIndent,
+  );
+  if (!topLevel.some((line) => /^\s*apiVersion\s*:/.test(line))) return false;
+
+  const kindLine = topLevel.find((line) => /^\s*kind\s*:/.test(line));
+  const kind = kindLine?.match(/^\s*kind\s*:\s*["']?([^\s"'#]+)["']?\s*(?:#.*)?$/)?.[1];
+  return kind !== undefined && WORKLOAD_KINDS.has(kind);
+}
+
+function workloadSpecLines(lines: string[]): string[] {
+  const rootIndent = topLevelIndent(lines);
+  if (rootIndent === undefined) return lines.map(() => "");
+
+  const specIndex = lines.findIndex(
+    (line) => leadingIndent(line) === rootIndent && /^\s*spec\s*:/.test(line),
+  );
+  if (specIndex === -1) return lines.map(() => "");
+
+  let inSpec = true;
+  return lines.map((line, index) => {
+    if (index < specIndex || !inSpec) return "";
+    if (index === specIndex || !isStructuralLine(line)) return line;
+    if (leadingIndent(line) <= rootIndent) {
+      inSpec = false;
+      return "";
+    }
+    return line;
+  });
+}
+
+function withoutBlockScalarContent(lines: string[]): string[] {
+  let scalarIndent: number | undefined;
+  return lines.map((line) => {
+    if (scalarIndent !== undefined) {
+      if (!line.trim() || leadingIndent(line) > scalarIndent) return "";
+      scalarIndent = undefined;
+    }
+    if (/:\s*[|>](?:[1-9][+-]?|[+-][1-9]?)?\s*(?:#.*)?$/.test(line)) {
+      scalarIndent = leadingIndent(line);
+    }
+    return line;
+  });
+}
+
+function workloadDocuments(content: string): Array<{ lines: string[]; lineOffset: number }> {
+  const lines = content.split("\n");
+  const documents: Array<{ lines: string[]; lineOffset: number }> = [];
+  let start = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^---(?:\s+#.*)?\s*$/.test(lines[i])) continue;
+    const documentLines = lines.slice(start, i);
+    if (isWorkloadDocument(documentLines)) {
+      documents.push({ lines: documentLines, lineOffset: start });
+    }
+    start = i + 1;
+  }
+
+  const documentLines = lines.slice(start);
+  if (isWorkloadDocument(documentLines)) {
+    documents.push({ lines: documentLines, lineOffset: start });
+  }
+  return documents;
+}
+
+function parentIsCapabilities(lines: string[], lineIndex: number, indent: number): boolean {
+  for (let i = lineIndex - 1; i >= 0; i--) {
+    if (!lines[i].trim() || /^\s*#/.test(lines[i])) continue;
+    if (leadingIndent(lines[i]) >= indent) continue;
+    return /^\s*capabilities\s*:\s*(?:#.*)?$/.test(lines[i]);
+  }
+  return false;
+}
+
+function dangerousCapabilityMatch(lines: string[]): CandidateMatch | undefined {
+  const dangerous = /(?:^|[,\s["'])(?:ALL|NET_ADMIN|SYS_ADMIN|SYS_PTRACE)(?=$|[,\s\]"'])/;
+  const hitLines: number[] = [];
+  let firstContext: string | undefined;
+
+  for (let i = 0; i < lines.length; i++) {
+    const add = lines[i].match(/^(\s*)add\s*:\s*(.*)$/);
+    if (!add || !parentIsCapabilities(lines, i, add[1].length)) continue;
+
+    const inline = add[2].trim();
+    if (inline.startsWith("[") && dangerous.test(inline)) {
+      hitLines.push(i + 1);
+    } else if (!inline || inline.startsWith("#")) {
+      for (let j = i + 1; j < lines.length; j++) {
+        if (!lines[j].trim() || /^\s*#/.test(lines[j])) continue;
+        if (leadingIndent(lines[j]) <= add[1].length) break;
+        if (/^\s*-\s*["']?(?:ALL|NET_ADMIN|SYS_ADMIN|SYS_PTRACE)["']?\s*(?:#.*)?$/.test(lines[j])) {
+          hitLines.push(j + 1);
+        }
+      }
+    }
+
+    if (firstContext === undefined && hitLines.length > 0) {
+      const firstHit = hitLines[0] - 1;
+      firstContext = lines.slice(Math.max(0, firstHit - 2), firstHit + 3).join("\n");
+    }
+  }
+
+  if (hitLines.length === 0) return undefined;
+  return {
+    vulnSlug: "k8s-privileged-workload",
+    lineNumbers: hitLines,
+    snippet: firstContext ?? "",
+    matchedPattern: "dangerous Linux capability",
+  };
+}
+
+function mergeMatch(
+  matches: Map<string, CandidateMatch>,
+  match: CandidateMatch,
+  lineOffset: number,
+): void {
+  const adjustedLines = match.lineNumbers.map((line) => line + lineOffset);
+  const existing = matches.get(match.matchedPattern);
+  if (existing) {
+    existing.lineNumbers.push(...adjustedLines);
+    return;
+  }
+  matches.set(match.matchedPattern, { ...match, lineNumbers: adjustedLines });
+}
 
 export const k8sPrivilegedWorkloadMatcher: MatcherPlugin = {
   noiseTier: "precise" as const,
@@ -16,32 +196,24 @@ export const k8sPrivilegedWorkloadMatcher: MatcherPlugin = {
     `apiVersion: v1\nkind: Pod\nspec:\n  volumes:\n    - hostPath:\n        path: /`,
     `apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - securityContext:\n        procMount: Unmasked`,
     `apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - securityContext:\n        capabilities:\n          add: ["SYS_ADMIN"]`,
+    `apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - securityContext:\n        capabilities:\n          add:\n            - NET_ADMIN`,
   ],
   match(content, filePath) {
-    if (/(?:^|\/)(?:node_modules|vendor|charts|\.github)\//.test(filePath)) return [];
-    if (!/^\s*apiVersion\s*:/m.test(content) || !/^\s*kind\s*:/m.test(content)) return [];
+    if (/(?:^|\/)(?:node_modules|vendor|\.github)\//.test(filePath)) return [];
 
-    return regexMatcher(
-      "k8s-privileged-workload",
-      [
-        { regex: /^\s*privileged\s*:\s*true\s*(?:#.*)?$/, label: "privileged container" },
-        {
-          regex: /^\s*allowPrivilegeEscalation\s*:\s*true\s*(?:#.*)?$/,
-          label: "privilege escalation allowed",
-        },
-        {
-          regex: /^\s*host(?:IPC|Network|PID)\s*:\s*true\s*(?:#.*)?$/,
-          label: "host namespace shared",
-        },
-        { regex: /^\s*runAsUser\s*:\s*0\s*(?:#.*)?$/, label: "container runs as root UID" },
-        { regex: /^\s*-?\s*hostPath\s*:/, label: "host filesystem mount" },
-        { regex: /^\s*procMount\s*:\s*["']?Unmasked["']?\s*$/, label: "unmasked proc mount" },
-        {
-          regex: /^\s*add\s*:\s*\[[^\]]*["']?(?:ALL|NET_ADMIN|SYS_ADMIN|SYS_PTRACE)["']?[^\]]*\]/,
-          label: "dangerous Linux capability",
-        },
-      ],
-      content,
+    const matches = new Map<string, CandidateMatch>();
+    for (const document of workloadDocuments(content)) {
+      const scanLines = withoutBlockScalarContent(workloadSpecLines(document.lines));
+      const documentContent = scanLines.join("\n");
+      for (const match of regexMatcher("k8s-privileged-workload", PATTERNS, documentContent)) {
+        mergeMatch(matches, match, document.lineOffset);
+      }
+      const capabilityMatch = dangerousCapabilityMatch(scanLines);
+      if (capabilityMatch) mergeMatch(matches, capabilityMatch, document.lineOffset);
+    }
+
+    return [...matches.values()].sort(
+      (a, b) => MATCH_ORDER.get(a.matchedPattern)! - MATCH_ORDER.get(b.matchedPattern)!,
     );
   },
 };

--- a/packages/scanner/src/matchers/k8s-privileged-workload.ts
+++ b/packages/scanner/src/matchers/k8s-privileged-workload.ts
@@ -1,0 +1,47 @@
+import type { MatcherPlugin } from "../types.js";
+import { regexMatcher } from "./utils.js";
+
+export const k8sPrivilegedWorkloadMatcher: MatcherPlugin = {
+  noiseTier: "precise" as const,
+  slug: "k8s-privileged-workload",
+  description:
+    "Kubernetes workload enabling privileged execution, host access, or dangerous capabilities",
+  filePatterns: ["**/*.yaml", "**/*.yml"],
+  examples: [
+    `apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - securityContext:\n        privileged: true`,
+    `apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      hostNetwork: true`,
+    `apiVersion: v1\nkind: Pod\nspec:\n  hostPID: true`,
+    `apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - securityContext:\n        allowPrivilegeEscalation: true`,
+    `apiVersion: v1\nkind: Pod\nspec:\n  securityContext:\n    runAsUser: 0`,
+    `apiVersion: v1\nkind: Pod\nspec:\n  volumes:\n    - hostPath:\n        path: /`,
+    `apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - securityContext:\n        procMount: Unmasked`,
+    `apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - securityContext:\n        capabilities:\n          add: ["SYS_ADMIN"]`,
+  ],
+  match(content, filePath) {
+    if (/(?:^|\/)(?:node_modules|vendor|charts|\.github)\//.test(filePath)) return [];
+    if (!/^\s*apiVersion\s*:/m.test(content) || !/^\s*kind\s*:/m.test(content)) return [];
+
+    return regexMatcher(
+      "k8s-privileged-workload",
+      [
+        { regex: /^\s*privileged\s*:\s*true\s*(?:#.*)?$/, label: "privileged container" },
+        {
+          regex: /^\s*allowPrivilegeEscalation\s*:\s*true\s*(?:#.*)?$/,
+          label: "privilege escalation allowed",
+        },
+        {
+          regex: /^\s*host(?:IPC|Network|PID)\s*:\s*true\s*(?:#.*)?$/,
+          label: "host namespace shared",
+        },
+        { regex: /^\s*runAsUser\s*:\s*0\s*(?:#.*)?$/, label: "container runs as root UID" },
+        { regex: /^\s*-?\s*hostPath\s*:/, label: "host filesystem mount" },
+        { regex: /^\s*procMount\s*:\s*["']?Unmasked["']?\s*$/, label: "unmasked proc mount" },
+        {
+          regex: /^\s*add\s*:\s*\[[^\]]*["']?(?:ALL|NET_ADMIN|SYS_ADMIN|SYS_PTRACE)["']?[^\]]*\]/,
+          label: "dangerous Linux capability",
+        },
+      ],
+      content,
+    );
+  },
+};

--- a/packages/scanner/src/matchers/k8s-privileged-workload.ts
+++ b/packages/scanner/src/matchers/k8s-privileged-workload.ts
@@ -145,7 +145,10 @@ function dangerousCapabilityMatch(lines: string[]): CandidateMatch | undefined {
     } else if (!inline || inline.startsWith("#")) {
       for (let j = i + 1; j < lines.length; j++) {
         if (!lines[j].trim() || /^\s*#/.test(lines[j])) continue;
-        if (leadingIndent(lines[j]) <= add[1].length) break;
+        const indent = leadingIndent(lines[j]);
+        const isSequenceEntry = /^\s*-/.test(lines[j]);
+        if (indent < add[1].length) break;
+        if (indent === add[1].length && !isSequenceEntry) break;
         if (/^\s*-\s*["']?(?:ALL|NET_ADMIN|SYS_ADMIN|SYS_PTRACE)["']?\s*(?:#.*)?$/.test(lines[j])) {
           hitLines.push(j + 1);
         }


### PR DESCRIPTION
## What changed

Adds and registers a reusable `k8s-privileged-workload` matcher for privileged execution, host access, root UID, unmasked proc mounts, and dangerous Linux capabilities.

The matcher now:

- limits findings to recognized Kubernetes workload documents and their real top-level `spec`
- handles multi-document YAML while preserving global line numbers
- detects inline and block-list dangerous capabilities under `capabilities.add`
- scans first-party Helm charts
- ignores ConfigMaps, `capabilities.drop`, annotations, and YAML-looking block-scalar data

## Why

DeepSec already reviews Kubernetes secret handling but had no built-in workload privilege coverage. Document and `spec` scoping keeps this high-value rule in the `precise` noise tier instead of flagging configuration text that only resembles a workload setting.

## Verification

- [x] `pnpm --filter @deepsec/scanner build` passes
- [x] 1,859 scanner matcher and matcher-example tests pass
- [x] Biome passes on the changed TypeScript files
- [x] `git diff --check` passes
- [x] Adversarial cases cover Helm paths, block capabilities, mixed YAML documents, ConfigMaps, dropped capabilities, block scalars, and source line preservation

## Notes for reviewer

Generated dependencies and workflow paths remain excluded; first-party `charts/**/templates` manifests are intentionally scanned. The branch is based on the current `main`.
