### PR TITLE
Fix unbounded memory growth during sandbox downloads

### DIFF
--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/src/__tests__/merge-records.test.ts
+++ b/packages/deepsec/src/__tests__/merge-records.test.ts
@@ -196,11 +196,11 @@ describe("snapshotFileRecords + mergeAfterExtract", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("returns an empty snapshot when files/ doesn't exist", () => {
-    expect(snapshotFileRecords(dir).size).toBe(0);
+  it("returns an empty snapshot when the requested records don't exist", () => {
+    expect(snapshotFileRecords(dir, ["files/missing.ts.json"]).size).toBe(0);
   });
 
-  it("walks files/ recursively and indexes records by relative path", () => {
+  it("reads only the requested relative paths", () => {
     const inner = path.join(dir, "files", "src", "nested");
     fs.mkdirSync(inner, { recursive: true });
     fs.writeFileSync(
@@ -212,11 +212,17 @@ describe("snapshotFileRecords + mergeAfterExtract", () => {
       JSON.stringify(record({ filePath: "shallow.ts" })),
     );
 
-    const snap = snapshotFileRecords(dir);
+    const snap = snapshotFileRecords(dir, ["files/src/nested/deep.ts.json"]);
 
-    expect(snap.size).toBe(2);
-    expect(snap.has(path.join("files", "src", "nested", "deep.ts.json"))).toBe(true);
-    expect(snap.has(path.join("files", "shallow.ts.json"))).toBe(true);
+    expect(snap.size).toBe(1);
+    expect(snap.has("files/src/nested/deep.ts.json")).toBe(true);
+    expect(snap.has("files/shallow.ts.json")).toBe(false);
+  });
+
+  it("ignores requested paths outside files/", () => {
+    fs.mkdirSync(path.join(dir, "runs"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "runs", "r1.json"), JSON.stringify({ runId: "r1" }));
+    expect(snapshotFileRecords(dir, ["runs/r1.json"]).size).toBe(0);
   });
 
   it("rewrites only files that existed in both the host snapshot and the post-extract state", () => {
@@ -234,7 +240,8 @@ describe("snapshotFileRecords + mergeAfterExtract", () => {
         }),
       ),
     );
-    const snap = snapshotFileRecords(dir);
+    const tarballEntries = ["files/src/foo.ts.json", "files/src/bar.ts.json"];
+    const snap = snapshotFileRecords(dir, tarballEntries);
 
     // Simulate a tar extract overwriting that file with [codexB] only —
     // the pattern that drops history without merging.
@@ -261,7 +268,7 @@ describe("snapshotFileRecords + mergeAfterExtract", () => {
       ),
     );
 
-    const merged = mergeAfterExtract(dir, snap, "p");
+    const merged = mergeAfterExtract(dir, snap, "p", tarballEntries);
     expect(merged).toBe(1);
 
     const fooAfter = JSON.parse(fs.readFileSync(recPath, "utf-8"));
@@ -281,7 +288,7 @@ describe("snapshotFileRecords + mergeAfterExtract", () => {
     fs.writeFileSync(path.join(filesDir, "broken.ts.json"), "{not valid json");
     fs.writeFileSync(path.join(filesDir, "ok.ts.json"), JSON.stringify(record()));
 
-    const snap = snapshotFileRecords(dir);
+    const snap = snapshotFileRecords(dir, ["files/broken.ts.json", "files/ok.ts.json"]);
     expect(snap.size).toBe(1);
   });
 });

--- a/packages/deepsec/src/__tests__/tarball.test.ts
+++ b/packages/deepsec/src/__tests__/tarball.test.ts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -203,9 +204,12 @@ describe("extractTarballLocally — strict allowlist", () => {
       path.join(src, "files", "ok.ts.json"),
       JSON.stringify(validRecord(projectId, "ok.ts")),
     );
-    // Just over the 64MiB per-file cap. Zeros compress to almost nothing,
-    // so the tarball itself stays tiny and fast.
-    fs.writeFileSync(path.join(src, "files", "fat.ts.json"), Buffer.alloc(64 * 1024 * 1024 + 1));
+    // Just over the 64MiB per-file cap. Random bytes, not zeros — tar's
+    // decompression-bomb guard rejects archives with a >1000x ratio.
+    fs.writeFileSync(
+      path.join(src, "files", "fat.ts.json"),
+      crypto.randomBytes(64 * 1024 * 1024 + 1),
+    );
     const stats = await makeTarball(src, []);
     fs.rmSync(src, { recursive: true, force: true });
 

--- a/packages/deepsec/src/__tests__/tarball.test.ts
+++ b/packages/deepsec/src/__tests__/tarball.test.ts
@@ -195,6 +195,34 @@ describe("extractTarballLocally — strict allowlist", () => {
     expect("files/../etc/passwd.json".split("/").includes("..")).toBe(true);
   });
 
+  it("skips an oversized entry but extracts the rest of the tarball", async () => {
+    const projectId = path.basename(destDir);
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-tar-fat-"));
+    fs.mkdirSync(path.join(src, "files"));
+    fs.writeFileSync(
+      path.join(src, "files", "ok.ts.json"),
+      JSON.stringify(validRecord(projectId, "ok.ts")),
+    );
+    // Just over the 64MiB per-file cap. Zeros compress to almost nothing,
+    // so the tarball itself stays tiny and fast.
+    fs.writeFileSync(path.join(src, "files", "fat.ts.json"), Buffer.alloc(64 * 1024 * 1024 + 1));
+    const stats = await makeTarball(src, []);
+    fs.rmSync(src, { recursive: true, force: true });
+
+    const skipped: { entryPath: string; sizeBytes: number }[] = [];
+    const count = await extractTarballLocally(stats.tarPath, destDir, (entryPath, sizeBytes) =>
+      skipped.push({ entryPath, sizeBytes }),
+    );
+    fs.unlinkSync(stats.tarPath);
+
+    expect(count).toBe(1);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].entryPath.endsWith("files/fat.ts.json")).toBe(true);
+    expect(skipped[0].sizeBytes).toBe(64 * 1024 * 1024 + 1);
+    expect(fs.existsSync(path.join(destDir, "files", "ok.ts.json"))).toBe(true);
+    expect(fs.existsSync(path.join(destDir, "files", "fat.ts.json"))).toBe(false);
+  });
+
   it("refuses a tarball containing a symlink entry", async () => {
     // Build a tarball directly via tar.create that intentionally
     // includes a symlink — bypassing makeTarball's own filter — so

--- a/packages/deepsec/src/sandbox/download.ts
+++ b/packages/deepsec/src/sandbox/download.ts
@@ -51,10 +51,11 @@ const ALLOWED_ENTRY_PATTERNS: RegExp[] = [
 const MAX_TARBALL_BYTES = 256 * 1024 * 1024; // 256 MiB compressed
 const MAX_UNCOMPRESSED_BYTES = 1024 * 1024 * 1024; // 1 GiB total
 const MAX_ENTRIES = 50_000;
-// Sized with headroom over the largest real-world record we've seen: the
-// next.js dataset's record for a compiled webpack bundle is 34.2 MiB, and
-// rejection is all-or-nothing for the tarball, so a too-tight cap blocks
-// the whole download.
+// Per-file size is a soft cap: oversized entries are skipped during
+// extraction (and reported) rather than failing the whole tarball, since a
+// single fat record — e.g. for a large compiled bundle — shouldn't discard
+// every other result from the run. The other caps stay hard/all-or-nothing:
+// they defend against decompression bombs and smuggled content.
 const MAX_PER_FILE_BYTES = 64 * 1024 * 1024; // 64 MiB per record
 
 const SETUP_MARKER = "/tmp/deepsec-setup-done";
@@ -160,7 +161,11 @@ export async function downloadResults(
   const localProjectDir = dataDir(projectId);
   fs.mkdirSync(localProjectDir, { recursive: true });
 
-  const count = await extractTarballLocally(localTarPath, localProjectDir);
+  const count = await extractTarballLocally(localTarPath, localProjectDir, (entryPath, bytes) => {
+    onLog(
+      `[sandbox-${sandboxIndex}] Skipped oversized result file "${entryPath}" (${(bytes / 1024 / 1024).toFixed(1)}MB > ${(MAX_PER_FILE_BYTES / 1024 / 1024).toFixed(0)}MB cap)`,
+    );
+  });
   try {
     fs.unlinkSync(localTarPath);
   } catch {}
@@ -201,7 +206,11 @@ async function withExtractLock<T>(destDir: string, fn: () => Promise<T>): Promis
   }
 }
 
-export async function extractTarballLocally(tarPath: string, destDir: string): Promise<number> {
+export async function extractTarballLocally(
+  tarPath: string,
+  destDir: string,
+  onSkip?: (entryPath: string, sizeBytes: number) => void,
+): Promise<number> {
   // Two-pass: list to validate, then extract. The list pass is hard
   // "all or nothing" — if any entry is disallowed (wrong type or
   // extension), we throw before a single byte hits disk, so callers
@@ -216,6 +225,7 @@ export async function extractTarballLocally(tarPath: string, destDir: string): P
   // the archive is clean by then.
   const violations: string[] = [];
   const entryPaths: string[] = [];
+  const oversized = new Map<string, number>();
   let fileCount = 0;
   let totalUncompressed = 0;
   await tar.list({
@@ -249,13 +259,14 @@ export async function extractTarballLocally(tarPath: string, destDir: string): P
         return;
       }
       const sz = (entry as unknown as { size?: number }).size ?? 0;
+      // Count oversized entries toward the total-size bomb defense even
+      // though we skip them: the archive still streams through the
+      // extractor either way.
+      totalUncompressed += sz;
       if (sz > MAX_PER_FILE_BYTES) {
-        violations.push(
-          `"${entry.path}" is ${(sz / 1024 / 1024).toFixed(1)}MB > per-file cap ${(MAX_PER_FILE_BYTES / 1024 / 1024).toFixed(0)}MB`,
-        );
+        oversized.set(norm, sz);
         return;
       }
-      totalUncompressed += sz;
       fileCount++;
       entryPaths.push(norm);
       if (fileCount > MAX_ENTRIES) {
@@ -284,10 +295,18 @@ export async function extractTarballLocally(tarPath: string, destDir: string): P
   // file. We re-merge after extract. Snapshot and merge are scoped to the
   // tarball's own entry list, and the whole read-modify-write sequence is
   // serialized per destDir — see withExtractLock.
+  for (const [entryPath, sizeBytes] of oversized) {
+    onSkip?.(entryPath, sizeBytes);
+  }
+
   const recordPaths = entryPaths.filter(isFileRecordPath);
   await withExtractLock(destDir, async () => {
     const hostSnapshot = snapshotFileRecords(destDir, recordPaths);
-    await tar.extract({ file: tarPath, cwd: destDir });
+    await tar.extract({
+      file: tarPath,
+      cwd: destDir,
+      filter: (entryPath) => !oversized.has(entryPath.replace(/^\.\//, "")),
+    });
     mergeAfterExtract(destDir, hostSnapshot, path.basename(destDir), recordPaths);
   });
   return fileCount;

--- a/packages/deepsec/src/sandbox/download.ts
+++ b/packages/deepsec/src/sandbox/download.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { dataDir } from "@deepsec/core";
 import type { Sandbox } from "@vercel/sandbox";
 import * as tar from "tar";
-import { mergeAfterExtract, snapshotFileRecords } from "./merge-records.js";
+import { isFileRecordPath, mergeAfterExtract, snapshotFileRecords } from "./merge-records.js";
 import { DATA_DIR } from "./setup.js";
 
 // Sandbox results are JSON file records, run metadata, reports, and
@@ -51,7 +51,11 @@ const ALLOWED_ENTRY_PATTERNS: RegExp[] = [
 const MAX_TARBALL_BYTES = 256 * 1024 * 1024; // 256 MiB compressed
 const MAX_UNCOMPRESSED_BYTES = 1024 * 1024 * 1024; // 1 GiB total
 const MAX_ENTRIES = 50_000;
-const MAX_PER_FILE_BYTES = 32 * 1024 * 1024; // 32 MiB per record
+// Sized with headroom over the largest real-world record we've seen: the
+// next.js dataset's record for a compiled webpack bundle is 34.2 MiB, and
+// rejection is all-or-nothing for the tarball, so a too-tight cap blocks
+// the whole download.
+const MAX_PER_FILE_BYTES = 64 * 1024 * 1024; // 64 MiB per record
 
 const SETUP_MARKER = "/tmp/deepsec-setup-done";
 
@@ -171,6 +175,32 @@ export async function downloadResults(
   return count;
 }
 
+// Serializes snapshot → extract → merge per destination directory. All 30
+// sandbox download loops extract into the same data dir; overlapping
+// sequences would (a) stack pre-extract snapshots in memory and (b) race
+// each other's read-modify-write of shared records, resurrecting stale
+// versions. Extracts are cheap once snapshots are tarball-scoped, so a
+// plain promise-chain mutex costs nothing in throughput.
+const extractLocks = new Map<string, Promise<void>>();
+
+async function withExtractLock<T>(destDir: string, fn: () => Promise<T>): Promise<T> {
+  const key = path.resolve(destDir);
+  const prev = extractLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+  const tail = prev.then(() => gate);
+  extractLocks.set(key, tail);
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (extractLocks.get(key) === tail) extractLocks.delete(key);
+  }
+}
+
 export async function extractTarballLocally(tarPath: string, destDir: string): Promise<number> {
   // Two-pass: list to validate, then extract. The list pass is hard
   // "all or nothing" — if any entry is disallowed (wrong type or
@@ -185,6 +215,7 @@ export async function extractTarballLocally(tarPath: string, destDir: string): P
   // log-and-skip. The extract pass runs with default safety; we know
   // the archive is clean by then.
   const violations: string[] = [];
+  const entryPaths: string[] = [];
   let fileCount = 0;
   let totalUncompressed = 0;
   await tar.list({
@@ -226,6 +257,7 @@ export async function extractTarballLocally(tarPath: string, destDir: string): P
       }
       totalUncompressed += sz;
       fileCount++;
+      entryPaths.push(norm);
       if (fileCount > MAX_ENTRIES) {
         violations.push(`entry count exceeds cap of ${MAX_ENTRIES}`);
       }
@@ -244,13 +276,19 @@ export async function extractTarballLocally(tarPath: string, destDir: string): P
     );
   }
 
-  // Snapshot existing per-file records BEFORE extracting. The tarball
-  // extract is a blind overwrite, so without this any prior on-host
-  // analysisHistory / findings / revalidation / triage entries would
-  // disappear when a concurrently-running sandbox uploads its (older)
-  // view of the same file. We re-merge after extract.
-  const hostSnapshot = snapshotFileRecords(destDir);
-  await tar.extract({ file: tarPath, cwd: destDir });
-  mergeAfterExtract(destDir, hostSnapshot, path.basename(destDir));
+  // Snapshot the per-file records this tarball is about to overwrite
+  // BEFORE extracting. The tarball extract is a blind overwrite, so
+  // without this any prior on-host analysisHistory / findings /
+  // revalidation / triage entries would disappear when a
+  // concurrently-running sandbox uploads its (older) view of the same
+  // file. We re-merge after extract. Snapshot and merge are scoped to the
+  // tarball's own entry list, and the whole read-modify-write sequence is
+  // serialized per destDir — see withExtractLock.
+  const recordPaths = entryPaths.filter(isFileRecordPath);
+  await withExtractLock(destDir, async () => {
+    const hostSnapshot = snapshotFileRecords(destDir, recordPaths);
+    await tar.extract({ file: tarPath, cwd: destDir });
+    mergeAfterExtract(destDir, hostSnapshot, path.basename(destDir), recordPaths);
+  });
   return fileCount;
 }

--- a/packages/deepsec/src/sandbox/merge-records.ts
+++ b/packages/deepsec/src/sandbox/merge-records.ts
@@ -10,42 +10,43 @@ import { type AnalysisEntry, type FileRecord, type Finding, fileRecordSchema } f
 const FILES_SUBDIR = "files";
 
 /**
- * Snapshot all existing file records under `<destDir>/files/` into a map
- * keyed by their path relative to `destDir` (e.g. `"files/src/foo.ts.json"`).
- *
- * Called BEFORE tar extraction so we have the host's pre-extraction state
- * to merge against once the tarball lands.
- *
- * Best-effort: malformed JSON is skipped silently rather than aborting the
- * download — a corrupt host record shouldn't block a sandbox upload, and
- * the incoming version will replace it via the normal extract path.
+ * Return true for tarball entry paths the merge machinery cares about:
+ * file records under `files/**.json`. Run metadata (`runs/*.json`) is
+ * unique per runId, so the tar overwrite is safe there and needs no merge.
  */
-export function snapshotFileRecords(destDir: string): Map<string, FileRecord> {
-  const out = new Map<string, FileRecord>();
-  const filesRoot = path.join(destDir, FILES_SUBDIR);
-  if (!fs.existsSync(filesRoot)) return out;
+export function isFileRecordPath(rel: string): boolean {
+  const norm = rel.replaceAll("\\", "/");
+  return norm.startsWith(`${FILES_SUBDIR}/`) && norm.endsWith(".json");
+}
 
-  const stack: string[] = [filesRoot];
-  while (stack.length > 0) {
-    const dir = stack.pop()!;
-    let entries: fs.Dirent[];
+/**
+ * Snapshot the existing file records at the given `destDir`-relative paths
+ * (e.g. `"files/src/foo.ts.json"`) into a map keyed by that path.
+ *
+ * Called BEFORE tar extraction, with the tarball's own entry list, so we
+ * have the host's pre-extraction state to merge against once the tarball
+ * lands. Deliberately NOT a full walk of `files/**`: projects can hold
+ * tens of thousands of records (~150MB heap per full snapshot), and the
+ * streaming download loop runs this per sandbox — full snapshots stacked
+ * across 30 concurrent loops are what OOM'd the orchestrator.
+ *
+ * Best-effort: missing files and malformed JSON are skipped silently
+ * rather than aborting the download — a corrupt or absent host record
+ * shouldn't block a sandbox upload, and the incoming version will replace
+ * it via the normal extract path.
+ */
+export function snapshotFileRecords(
+  destDir: string,
+  relPaths: Iterable<string>,
+): Map<string, FileRecord> {
+  const out = new Map<string, FileRecord>();
+  for (const rel of relPaths) {
+    if (!isFileRecordPath(rel)) continue;
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
+      const raw = JSON.parse(fs.readFileSync(path.join(destDir, rel), "utf-8"));
+      out.set(rel, raw as FileRecord);
     } catch {
-      continue;
-    }
-    for (const e of entries) {
-      const full = path.join(dir, e.name);
-      if (e.isDirectory()) {
-        stack.push(full);
-      } else if (e.isFile() && e.name.endsWith(".json")) {
-        try {
-          const raw = JSON.parse(fs.readFileSync(full, "utf-8"));
-          out.set(path.relative(destDir, full), raw as FileRecord);
-        } catch {
-          // skip malformed
-        }
-      }
+      // missing or malformed — nothing to merge against
     }
   }
   return out;
@@ -131,8 +132,12 @@ function mergeFinding(host: Finding, incoming: Finding): Finding {
 }
 
 /**
- * After tar extraction, walk `<destDir>/files/**.json` and re-write any
- * record that also existed in `hostSnapshot` with a merged version.
+ * After tar extraction, validate every file record the tarball wrote
+ * (`relPaths` — the same entry list the pre-extract validation pass
+ * produced) and re-write any that also existed in `hostSnapshot` with a
+ * merged version. Records not in the tarball were not touched by the
+ * extract and are left alone — walking the whole tree here would re-parse
+ * and re-validate the entire project dataset on every streaming poll.
  *
  * Sandbox output is the trust boundary, so every incoming record must:
  *   - parse as JSON
@@ -157,64 +162,55 @@ function mergeFinding(host: Finding, incoming: Finding): Finding {
 export function mergeAfterExtract(
   destDir: string,
   hostSnapshot: Map<string, FileRecord>,
-  expectedProjectId?: string,
+  expectedProjectId: string | undefined,
+  relPaths: Iterable<string>,
 ): number {
-  const filesRoot = path.join(destDir, FILES_SUBDIR);
-  if (!fs.existsSync(filesRoot)) return 0;
   const requireProjectId = expectedProjectId ?? path.basename(destDir);
 
   let merged = 0;
-  const stack: string[] = [filesRoot];
-  while (stack.length > 0) {
-    const dir = stack.pop()!;
-    let entries: fs.Dirent[];
+  for (const relRaw of relPaths) {
+    if (!isFileRecordPath(relRaw)) continue;
+    const rel = relRaw.replaceAll("\\", "/");
+    const full = path.join(destDir, rel);
+    const host = hostSnapshot.get(relRaw) ?? hostSnapshot.get(rel);
+
+    let raw: string;
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
+      raw = fs.readFileSync(full, "utf-8");
     } catch {
+      // The tarball listed it but nothing landed on disk — nothing to do.
       continue;
     }
-    for (const e of entries) {
-      const full = path.join(dir, e.name);
-      if (e.isDirectory()) {
-        stack.push(full);
-        continue;
-      }
-      if (!(e.isFile() && e.name.endsWith(".json"))) continue;
-      const rel = path.relative(destDir, full);
-      const host = hostSnapshot.get(rel);
 
-      let raw: unknown;
-      try {
-        raw = JSON.parse(fs.readFileSync(full, "utf-8"));
-      } catch {
-        // Malformed JSON — restore host snapshot if we have one, else drop.
-        restoreOrDrop(full, host);
-        continue;
-      }
-
-      const parsed = fileRecordSchema.safeParse(raw);
-      if (!parsed.success) {
-        restoreOrDrop(full, host);
-        continue;
-      }
-      const incoming = parsed.data;
-
-      // Sandbox tarball came from `data/<projectId>/`, so every record in
-      // it must claim that same projectId, and the on-disk path must match
-      // its declared filePath.
-      const expectedRel = path
-        .join(FILES_SUBDIR, `${incoming.filePath}.json`)
-        .replaceAll("\\", "/");
-      if (incoming.projectId !== requireProjectId || rel.replaceAll("\\", "/") !== expectedRel) {
-        restoreOrDrop(full, host);
-        continue;
-      }
-
-      if (!host) continue;
-      const out = mergeFileRecord(host, incoming);
-      fs.writeFileSync(full, JSON.stringify(out, null, 2) + "\n");
-      merged++;
+    let parsedRaw: unknown;
+    try {
+      parsedRaw = JSON.parse(raw);
+    } catch {
+      // Malformed JSON — restore host snapshot if we have one, else drop.
+      restoreOrDrop(full, host);
+      continue;
     }
+
+    const parsed = fileRecordSchema.safeParse(parsedRaw);
+    if (!parsed.success) {
+      restoreOrDrop(full, host);
+      continue;
+    }
+    const incoming = parsed.data;
+
+    // Sandbox tarball came from `data/<projectId>/`, so every record in
+    // it must claim that same projectId, and the on-disk path must match
+    // its declared filePath.
+    const expectedRel = path.join(FILES_SUBDIR, `${incoming.filePath}.json`).replaceAll("\\", "/");
+    if (incoming.projectId !== requireProjectId || rel !== expectedRel) {
+      restoreOrDrop(full, host);
+      continue;
+    }
+
+    if (!host) continue;
+    const out = mergeFileRecord(host, incoming);
+    fs.writeFileSync(full, JSON.stringify(out, null, 2) + "\n");
+    merged++;
   }
   return merged;
 }

--- a/packages/deepsec/src/sandbox/orchestrator.ts
+++ b/packages/deepsec/src/sandbox/orchestrator.ts
@@ -76,6 +76,41 @@ type LoggableCommand = {
   logs(opts?: { signal?: AbortSignal }): AsyncIterable<{ stream?: string; data: string }>;
 };
 
+// Memory-pressure backstop for the log streams. The SDK's internal pipe()
+// ignores write() backpressure, so a burst producer can buffer log data
+// inside the SDK faster than our consumed-byte caps drain it. That backlog
+// lives mostly in Buffers (external memory, NOT heapUsed), so the trigger
+// must sum heapUsed + external. On pressure, abort every live stream: the
+// abort propagates into the SDK and frees the backlog; cmd.wait() remains
+// the arbiter of command completion.
+const MEMORY_PRESSURE_ABORT_BYTES = 3 * 1024 * 1024 * 1024;
+const activeLogAborters = new Set<AbortController>();
+let memoryWatchdog: NodeJS.Timeout | undefined;
+
+function registerLogAborter(aborter: AbortController): void {
+  activeLogAborters.add(aborter);
+  if (!memoryWatchdog) {
+    memoryWatchdog = setInterval(() => {
+      const m = process.memoryUsage();
+      if (m.heapUsed + m.external > MEMORY_PRESSURE_ABORT_BYTES) {
+        for (const ctl of activeLogAborters) {
+          ctl.abort(new Error("memory pressure"));
+        }
+        activeLogAborters.clear();
+      }
+    }, 1000);
+    memoryWatchdog.unref();
+  }
+}
+
+function unregisterLogAborter(aborter: AbortController): void {
+  activeLogAborters.delete(aborter);
+  if (activeLogAborters.size === 0 && memoryWatchdog) {
+    clearInterval(memoryWatchdog);
+    memoryWatchdog = undefined;
+  }
+}
+
 async function streamLogsCapped(
   cmd: LoggableCommand,
   prefix: string,
@@ -83,6 +118,7 @@ async function streamLogsCapped(
   onRawLine?: (line: string) => void,
 ): Promise<void> {
   const aborter = new AbortController();
+  registerLogAborter(aborter);
   let remaining = MAX_LOG_BYTES_PER_SANDBOX;
   try {
     for await (const log of cmd.logs({ signal: aborter.signal })) {
@@ -108,6 +144,11 @@ async function streamLogsCapped(
     }
   } catch {
     // Stream errors (including our own abort) are non-fatal here.
+  } finally {
+    unregisterLogAborter(aborter);
+  }
+  if (aborter.signal.aborted && remaining > 0) {
+    onLog(`${prefix} [log stream aborted under memory pressure; further output suppressed]`);
   }
 }
 
@@ -118,6 +159,7 @@ async function streamLogsCapped(
  */
 async function readStderrCapped(cmd: LoggableCommand, maxChars: number): Promise<string> {
   const aborter = new AbortController();
+  registerLogAborter(aborter);
   let out = "";
   try {
     for await (const log of cmd.logs({ signal: aborter.signal })) {
@@ -130,6 +172,8 @@ async function readStderrCapped(cmd: LoggableCommand, maxChars: number): Promise
     }
   } catch {
     // Stream errors (including our own abort) are non-fatal here.
+  } finally {
+    unregisterLogAborter(aborter);
   }
   return out.slice(0, maxChars);
 }


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
