### PR TITLE
feat(pi): add DeepSeek provider support

### DIFF
--- a/packages/processor/src/agents/pi-sdk.ts
+++ b/packages/processor/src/agents/pi-sdk.ts
@@ -465,6 +465,17 @@ async function createPiSession(projectRoot: string, cfg: PiAgentConfig): Promise
   const modelRegistry = ModelRegistry.create(authStorage, path.join(getAgentDir(), "models.json"));
   configureProviderOverrides(modelRegistry, cfg);
 
+  if (process.env.DEEPSEEK_API_KEY) {
+    const dsKey = process.env.DEEPSEEK_API_KEY;
+    const dsBaseUrl = process.env.DEEPSEEK_BASE_URL || "https://api.deepseek.com/v1";
+    authStorage.setRuntimeApiKey("deepseek", dsKey);
+    modelRegistry.registerProvider("deepseek", {
+      baseUrl: dsBaseUrl,
+      apiKey: dsKey,
+      api: "openai-completions",
+    });
+  }
+
   const modelName = cfg.model ?? DEFAULT_MODEL;
   const model = await resolvePiModelWithDynamicGateway(modelRegistry, modelName, cfg);
   const agentDir = getAgentDir();


### PR DESCRIPTION
## Summary

Register DeepSeek as a runtime provider in the Pi SDK when `DEEPSEEK_API_KEY` is set, enabling `deepseek/deepseek-*` models to be used directly without the Vercel AI Gateway.

## Changes

- **`packages/processor/src/agents/pi-sdk.ts`**: In `createPiSession()`, detect `DEEPSEEK_API_KEY` and register the deepseek provider with configurable base URL (`DEEPSEEK_BASE_URL`, defaults to `https://api.deepseek.com/v1`).

## Usage

```bash
export DEEPSEEK_API_KEY=sk-xxx
deepsec scan . --model deepseek/deepseek-v4-flash
```

## Context

DeepSeek models use the OpenAI-compatible API format, so `api: "openai-completions"` is used. The provider registration follows the same pattern as the existing Anthropic and OpenAI handling.

Closes #—