### PR TITLE
Fail loud on unparseable triage output instead of dropping the batch

### DIFF
--- a/packages/processor/src/__tests__/triage-parse.test.ts
+++ b/packages/processor/src/__tests__/triage-parse.test.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { FileRecord } from "@deepsec/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// triage() drives the Claude Agent SDK's `query` directly, so stub the SDK to
+// yield a canned (here: malformed) result payload.
+const sdk = vi.hoisted(() => ({ resultText: "" }));
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () =>
+    (async function* () {
+      yield { type: "result", subtype: "success", result: sdk.resultText };
+    })(),
+}));
+
+import { triage } from "../triage.js";
+
+function setupProject(): {
+  projectId: string;
+  writeRecord: (rec: FileRecord) => void;
+  readRecord: (rel: string) => FileRecord;
+} {
+  const projectId = "triage-parse-test";
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-triage-parse-"));
+  const targetRoot = path.join(tmp, "target");
+  const dataRoot = path.join(tmp, "data");
+  fs.mkdirSync(targetRoot, { recursive: true });
+  fs.mkdirSync(path.join(dataRoot, projectId, "files"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dataRoot, projectId, "project.json"),
+    JSON.stringify({ projectId, rootPath: targetRoot, createdAt: new Date().toISOString() }),
+  );
+  process.env.DEEPSEC_DATA_ROOT = dataRoot;
+
+  const recordPath = (rel: string) => path.join(dataRoot, projectId, "files", `${rel}.json`);
+  const writeRecord = (rec: FileRecord): void => {
+    const p = recordPath(rec.filePath);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify(rec));
+  };
+  const readRecord = (rel: string): FileRecord =>
+    JSON.parse(fs.readFileSync(recordPath(rel), "utf-8"));
+  return { projectId, writeRecord, readRecord };
+}
+
+function recordWithFinding(projectId: string, filePath: string, title: string): FileRecord {
+  return {
+    filePath,
+    projectId,
+    candidates: [{ vulnSlug: "ssrf", lineNumbers: [1], snippet: "// stub", matchedPattern: "p" }],
+    lastScannedAt: new Date().toISOString(),
+    lastScannedRunId: "scan-fixture",
+    fileHash: "fixture-hash",
+    findings: [
+      {
+        severity: "MEDIUM",
+        vulnSlug: "ssrf",
+        title,
+        description: "x",
+        lineNumbers: [1],
+        recommendation: "x",
+        confidence: "high",
+      },
+    ],
+    analysisHistory: [],
+    status: "analyzed",
+  };
+}
+
+describe("triage JSON-parse robustness", () => {
+  let prevDataRoot: string | undefined;
+
+  beforeEach(() => {
+    prevDataRoot = process.env.DEEPSEC_DATA_ROOT;
+  });
+
+  afterEach(() => {
+    if (prevDataRoot === undefined) delete process.env.DEEPSEC_DATA_ROOT;
+    else process.env.DEEPSEC_DATA_ROOT = prevDataRoot;
+  });
+
+  it("recovers a trailing-comma verdict array via the tolerant parser", async () => {
+    const fx = setupProject();
+    fx.writeRecord(recordWithFinding(fx.projectId, "a.ts", "SSRF in fetch"));
+
+    // Trailing comma before the closing brace — invalid strict JSON, but a
+    // jsonrepair-class error the tolerant parser recovers. Before the fix a
+    // bare JSON.parse threw, was swallowed, and the finding was left untriaged.
+    sdk.resultText =
+      '```json\n[{"title":"SSRF in fetch","priority":"P0",' +
+      '"exploitability":"trivial","impact":"high","reasoning":"r",}]\n```';
+
+    const result = await triage({ projectId: fx.projectId, concurrency: 1 });
+
+    expect(fx.readRecord("a.ts").findings[0].triage?.priority).toBe("P0");
+    expect(result.triaged).toBe(1);
+  });
+
+  it("surfaces a batch as failed when the output is unparseable, not silently empty", async () => {
+    const fx = setupProject();
+    fx.writeRecord(recordWithFinding(fx.projectId, "a.ts", "SSRF in fetch"));
+
+    // Prose the model returned instead of JSON. strict JSON.parse rejects it
+    // (before the fix, that was swallowed and printed as "0 triaged"), and
+    // jsonrepair can only coerce it to a bare string — not an array — so the
+    // tolerant parser fails loud.
+    sdk.resultText = "I cannot comply with this request";
+
+    const messages: string[] = [];
+    const result = await triage({
+      projectId: fx.projectId,
+      concurrency: 1,
+      onProgress: (p) => messages.push(p.message),
+    });
+
+    // The batch is reported as failed (before the fix it printed "0 triaged"
+    // as a success), and the finding stays untriaged.
+    expect(messages.some((m) => /failed/i.test(m))).toBe(true);
+    expect(messages.some((m) => /\b0 triaged\b/.test(m))).toBe(false);
+    expect(fx.readRecord("a.ts").findings[0].triage).toBeUndefined();
+    expect(result.triaged).toBe(0);
+  });
+});

--- a/packages/processor/src/agents/shared.ts
+++ b/packages/processor/src/agents/shared.ts
@@ -535,7 +535,7 @@ function extractArrayCandidateForRepair(jsonPayload: string): string {
   return lastClose >= 0 ? candidate.slice(0, lastClose + 1) : candidate;
 }
 
-function parseAgentJsonArray(params: {
+export function parseAgentJsonArray(params: {
   resultText: string;
   parseFailurePrefix: string;
   nonArrayMessage: (parsed: unknown) => string;

--- a/packages/processor/src/triage.ts
+++ b/packages/processor/src/triage.ts
@@ -12,6 +12,7 @@ import {
   writeFileRecord,
   writeRunMeta,
 } from "@deepsec/core";
+import { parseAgentJsonArray, writeParseFailureDebug } from "./agents/shared.js";
 
 const TRIAGE_BATCH_SIZE = 30;
 
@@ -193,12 +194,30 @@ ${findingsList}
         }
       }
 
-      const jsonMatch = resultText.match(/```json\s*([\s\S]*?)```/);
-      const jsonStr = jsonMatch ? jsonMatch[1].trim() : resultText.trim();
-      let verdicts: TriageVerdict[] = [];
+      // Reuse the project's tolerant parse + fail-loud path (jsonrepair,
+      // then throw on unrecoverable output). A bare `JSON.parse` swallowed in
+      // a catch left `verdicts = []`, so a trailing comma or truncated array
+      // silently dropped the whole batch's triage while still reporting the
+      // batch as a success — indistinguishable from a clean "nothing to do".
+      let verdicts: TriageVerdict[];
       try {
-        verdicts = JSON.parse(jsonStr);
-      } catch {}
+        verdicts = parseAgentJsonArray({
+          resultText,
+          parseFailurePrefix: "Triage output wasn't a parseable JSON verdict array",
+          nonArrayMessage: (parsed) =>
+            `Triage output was JSON but not an array of verdicts. Got: ${typeof parsed}`,
+        }) as TriageVerdict[];
+      } catch (parseErr) {
+        writeParseFailureDebug({
+          projectId,
+          phase: "revalidate",
+          agentType: "triage",
+          resultText,
+          error: parseErr,
+          batch: batch.map((b) => b.record),
+        });
+        throw parseErr; // surface to the outer catch so the batch is marked failed, not silently empty
+      }
 
       for (const verdict of verdicts) {
         const item = batch.find((b) => b.finding.title === verdict.title);


### PR DESCRIPTION
## What changed

`triageBatch` now parses the model's verdict array through the same tolerant, fail-loud path the investigate/revalidate agents already use — `parseAgentJsonArray` (jsonrepair-backed) — instead of a bare `JSON.parse` in an empty catch. Genuinely unparseable output is dumped via `writeParseFailureDebug` and rethrown so the outer catch marks the batch failed. `parseAgentJsonArray` is exported from `agents/shared.ts` for reuse.

## Why

The old code left `verdicts = []` on any parse error, so a routine trailing-comma or truncated array silently lost the triage for the entire (up to 30-finding) batch while still printing `Batch N/M: 0 triaged` as success — indistinguishable from a clean "nothing to triage" run. `agents/shared.ts` already documents this exact failure mode for the investigate path ("a malformed response is otherwise indistinguishable from a clean 'found nothing' run") and guards against it; triage now matches that behavior.

Fixes #120

## Verification

- [x] `pnpm test` passes (added regression tests: a trailing-comma array is recovered and triaged; a non-array reply surfaces a failed batch instead of "0 triaged". Both fail on `main` and pass with this change)
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [ ] If this adds a matcher: n/a

Also ran `pnpm -r build` (typecheck) and `pnpm test:bundle` — both green.

## Notes for reviewer

Minor malformations that `jsonrepair` can recover are now triaged rather than dropped; only genuinely unrecoverable output fails the batch (and writes a `parse-error-revalidate-*.txt` debug dump, consistent with the other agents). No change to the verdict-application logic itself.