### PR TITLE
Add OpenCode SDK agent harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ If you feel like the `deepsec` should look at more parts of the code, give it [t
 
 ## AI provider
 
-When running locally, `deepsec` falls back to your existing `claude` /
-`codex` subscription if you've logged in on this machine. Subscriptions
-(Claude Pro/Max, ChatGPT Plus) are useful for evaluating deepsec but
-generally don't have enough headroom for full repo scans.
+When running locally, `deepsec` can reuse existing Claude, Codex, Pi, or
+OpenCode provider authentication. Subscriptions (Claude Pro/Max, ChatGPT
+Plus) are useful for evaluating deepsec but generally don't have enough
+headroom for full repo scans.
 
-For real scans, use Vercel AI Gateway. One key covers both Claude and
-Codex, and the gateway's default quotas are sized for highly concurrent
-research.
+For real scans, use Vercel AI Gateway. One key covers Claude, Codex,
+OpenCode, and Pi, and the gateway's default quotas are sized for highly
+concurrent research.
 
 ```
 AI_GATEWAY_API_KEY=vck_...

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,12 +68,13 @@ built-ins by reusing the same slug.
 - **Outputs:** FileRecord `findings[]` populated, `status: "analyzed"`,
   `analysisHistory[]` appended.
 
-Three agent backends are supported:
+Four agent backends are supported:
 
 | `--agent` | SDK | Default model |
 |---|---|---|
 | `codex` (default) | `@openai/codex-sdk` | `gpt-5.5` |
 | `claude` | `@anthropic-ai/claude-agent-sdk` | `claude-opus-4-8` |
+| `opencode` | `@opencode-ai/sdk/v2` | `anthropic/claude-opus-4-8` |
 | `pi` | `@earendil-works/pi-coding-agent` | `zai/glm-5.2` |
 
 Same prompt, same JSON output schema. You can mix backends within a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ see [`samples/webapp/deepsec.config.ts`](../samples/webapp/deepsec.config.ts).
 | `projects` | `ProjectDeclaration[]` | The codebases deepsec knows about. |
 | `plugins` | `DeepsecPlugin[]` | Loaded in order; later plugins override single-slot capabilities. |
 | `matchers` | `{ only?: string[]; exclude?: string[] }` | Filter the matcher set used by `scan`. |
-| `defaultAgent` | `string` | Default `--agent` value (`codex`, `claude`, or `pi`). See [models.md](models.md). |
+| `defaultAgent` | `string` | Default `--agent` value (`codex`, `claude`, `opencode`, or `pi`). See [models.md](models.md). |
 | `dataDir` | `string` | Override the `data/` directory. Defaults to `./data`. |
 
 ## ProjectDeclaration
@@ -107,18 +107,19 @@ backend you're using.
 
 | Var | Used by | Purpose |
 |---|---|---|
-| `AI_GATEWAY_API_KEY` | all AI commands | Shortcut. Expands at CLI startup into `ANTHROPIC_AUTH_TOKEN` / `OPENAI_API_KEY` / `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` for Claude/Codex, and is read directly by Pi's `vercel-ai-gateway` provider. Falls back to `VERCEL_OIDC_TOKEN` (from `vercel env pull`) when unset. |
-| `ANTHROPIC_AUTH_TOKEN` | `process`, `revalidate`, `triage` (Claude backend) | API token for the Claude Agent SDK. AI Gateway-issued or Anthropic-issued. Set this if you don't use `AI_GATEWAY_API_KEY`. |
+| `AI_GATEWAY_API_KEY` | all AI commands | Shortcut. Expands at CLI startup into `ANTHROPIC_AUTH_TOKEN` / `OPENAI_API_KEY` / `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` for Claude/Codex/OpenCode, and is read directly by Pi's `vercel-ai-gateway` provider. Falls back to `VERCEL_OIDC_TOKEN` (from `vercel env pull`) when unset. |
+| `ANTHROPIC_AUTH_TOKEN` | `process`, `revalidate`, `triage` (Claude or OpenCode Anthropic backend) | API token for the Claude Agent SDK or OpenCode Anthropic provider. AI Gateway-issued or Anthropic-issued. Set this if you don't use `AI_GATEWAY_API_KEY`. |
 | `ANTHROPIC_BASE_URL` | same | Default (when `AI_GATEWAY_API_KEY` is set): `https://ai-gateway.vercel.sh`. Set to `https://api.anthropic.com` for direct Anthropic. |
 
 ### Optional
 
 | Var | Used by | Purpose |
 |---|---|---|
-| `OPENAI_API_KEY` | `--agent codex`, `--agent pi --model openai/...` | Codex SDK token or Pi OpenAI-provider token. Unset is fine if `AI_GATEWAY_API_KEY` is set. |
-| `OPENAI_BASE_URL` | `--agent codex` | Default (when `AI_GATEWAY_API_KEY` is set): `https://ai-gateway.vercel.sh/v1`. |
+| `OPENAI_API_KEY` | `--agent codex`, `--agent opencode --model openai/...`, `--agent pi --model openai/...` | Codex SDK, OpenCode, or Pi OpenAI-provider token. Unset is fine if `AI_GATEWAY_API_KEY` is set. |
+| `OPENAI_BASE_URL` | `--agent codex`, `--agent opencode --model openai/...` | Default (when `AI_GATEWAY_API_KEY` is set): `https://ai-gateway.vercel.sh/v1`. |
 | `PI_CODING_AGENT_DIR` | `--agent pi` | Optional Pi config/auth directory. Defaults to `~/.pi/agent`; local non-sandbox runs can reuse `auth.json` there. |
-| `DEEPSEC_AGENT_DEBUG` | both backends | Set to `1` to enable verbose agent logging. |
+| `XDG_DATA_HOME` | `--agent opencode` | Optional OpenCode data root. Local preflight looks for provider auth at `$XDG_DATA_HOME/opencode/auth.json` (default `~/.local/share/opencode/auth.json`). |
+| `DEEPSEC_AGENT_DEBUG` | AI backends | Set to `1` to enable verbose agent logging. |
 | `DEEPSEC_DATA_ROOT` | core | Override the data directory location. Equivalent to `dataDir` in config. |
 
 ### Plugin-specific

--- a/docs/data-layout.md
+++ b/docs/data-layout.md
@@ -135,7 +135,7 @@ deleted.
 | `investigatedAt` | `string` (ISO) | Timestamp. |
 | `durationMs` | `number` | Wall-clock total. |
 | `durationApiMs` | `number?` | API time only (excludes process orchestration). |
-| `agentType` | `string` | `claude-agent-sdk` or `codex`. |
+| `agentType` | `string` | Producing backend: `claude-agent-sdk`, `codex`, `opencode`, `pi`, or a plugin agent type. |
 | `model` | `string` | Model identifier. |
 | `modelConfig` | `Record<string, unknown>` | Provider-specific settings echoed back. |
 | `agentSessionId` | `string?` | The agent's session/thread id, for reproducing or replaying. |

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,22 +1,23 @@
 ---
 title: "Models"
-description: "Choose Codex, Claude, or Pi for process and revalidate runs, and compare models under the same workload."
+description: "Choose Codex, Claude, OpenCode, or Pi for process and revalidate runs, and compare models under the same workload."
 ---
 
 deepsec talks to LLMs through interchangeable agent backends:
 
-| Backend                     | Default model         | Used by                      |
-|-----------------------------|-----------------------|------------------------------|
-| `codex` (default)           | `gpt-5.5`             | `process`, `revalidate`      |
-| `claude`                    | `claude-opus-4-8`     | `process`, `revalidate`      |
-| `pi`                        | `zai/glm-5.2`        | `process`, `revalidate` |
-| `claude` (triage)           | `claude-sonnet-4-6`   | `triage` (Claude-only)       |
+| Backend                     | Default model                   | Used by                 |
+|-----------------------------|---------------------------------|-------------------------|
+| `codex` (default)           | `gpt-5.5`                       | `process`, `revalidate` |
+| `claude`                    | `claude-opus-4-8`               | `process`, `revalidate` |
+| `opencode`                  | `anthropic/claude-opus-4-8`     | `process`, `revalidate` |
+| `pi`                        | `zai/glm-5.2`                   | `process`, `revalidate` |
+| `claude` (triage)           | `claude-sonnet-4-6`             | `triage` (Claude-only)  |
 
 The built-in backends work with [Vercel AI Gateway](https://vercel.com/ai-gateway).
 One `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN` covers Codex, Claude,
-and Pi. Pi also accepts provider/model identifiers directly through its
-model registry, which makes it useful for comparing gateway/provider
-behavior under the same deepsec workload.
+OpenCode, and Pi. OpenCode and Pi also accept provider/model identifiers,
+which makes them useful for comparing harness and provider behavior under
+the same deepsec workload.
 
 ## CLI selection
 
@@ -32,6 +33,10 @@ pnpm deepsec process --project-id my-app --agent codex
 
 # Codex backend, specific model:
 pnpm deepsec process --project-id my-app --agent codex --model gpt-5.4
+
+# OpenCode SDK harness (provider/model is required):
+pnpm deepsec process --project-id my-app --agent opencode
+pnpm deepsec process --project-id my-app --agent opencode --model openai/gpt-5.5
 
 # Pi backend through Vercel AI Gateway, default model:
 pnpm deepsec process --project-id my-app --agent pi
@@ -63,11 +68,12 @@ over large repos.
 
 The flag maps onto each backend's native dial:
 
-| Backend  | Setting                                     |
-|----------|---------------------------------------------|
-| `codex`  | model reasoning effort (`minimal`–`xhigh`)  |
-| `pi`     | thinking level (`minimal`–`xhigh`)          |
-| `claude` | adaptive-thinking effort (`minimal` → `low`, `xhigh` → `max`) |
+| Backend    | Setting                                                       |
+|------------|---------------------------------------------------------------|
+| `codex`    | model reasoning effort (`minimal`–`xhigh`)                    |
+| `opencode` | provider variant (Anthropic maps to `high` / `max`)           |
+| `pi`       | thinking level (`minimal`–`xhigh`)                            |
+| `claude`   | adaptive-thinking effort (`minimal` → `low`, `xhigh` → `max`) |
 
 It applies to the main investigation/revalidation runs only.
 Special-purpose follow-up calls (the refusal report, JSON repair) keep
@@ -132,6 +138,29 @@ Repeat `--ai-header name=value` for provider-specific headers. There is
 no Martian-specific first-class integration; these flags are the generic
 provider override path.
 
+### OpenCode SDK harness
+
+OpenCode uses `@opencode-ai/sdk/v2` plus the `opencode-ai` runtime. Each
+batch starts a local OpenCode server, creates a session rooted at the target
+project, and requests JSON Schema output. The deepsec agent allows only
+`read`, `glob`, `grep`, and `list`; shell, edits, network tools, subagents,
+external directories, LSP, skills, and MCP-triggered permissions are denied.
+The session and server are closed on success, error, or abort.
+
+Models use OpenCode's required `provider/model` form:
+
+```bash
+pnpm deepsec process --project-id my-app \
+  --agent opencode \
+  --model anthropic/claude-opus-4-8
+```
+
+For a local run without environment credentials, authenticate a provider in
+OpenCode first: run `opencode`, then use `/connect`. Sandbox runs cannot reuse
+that local credential store; use AI Gateway or an explicit provider token.
+Generic `--ai-provider`, `--ai-base-url`, `--ai-api-key-env`, and
+`--ai-header` overrides work for OpenCode as they do for Pi.
+
 ### `claude-sonnet-4-6` for `triage`
 
 Triage buckets findings into P0/P1/P2/skip without re-reading the code
@@ -177,6 +206,7 @@ rest of deepsec stays unchanged:
 ```bash
 pnpm deepsec process --project-id my-app --model anthropic-mythos-1
 pnpm deepsec process --project-id my-app --agent codex --model gpt-6
+pnpm deepsec process --project-id my-app --agent opencode --model anthropic/claude-mythos-1
 pnpm deepsec process --project-id my-app --agent pi --model vercel-ai-gateway/openai/gpt-6
 ```
 

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -7,7 +7,7 @@ deepsec uses two Vercel products. Most people only need the first.
 
 | Product | When you need it |
 |---|---|
-| **[AI Gateway](https://vercel.com/docs/ai-gateway)** | Always — for `process` and `revalidate`. One token covers Claude, Codex, and Pi; the gateway adds provider failover, observability, and zero data retention on top. |
+| **[AI Gateway](https://vercel.com/docs/ai-gateway)** | Always — for `process` and `revalidate`. One token covers Claude, Codex, OpenCode, and Pi; the gateway adds provider failover, observability, and zero data retention on top. |
 | **[Vercel Sandbox](https://vercel.com/docs/vercel-sandbox)** | Only for `deepsec sandbox process` (distributed scans across microVMs). Skip it if you're running locally. |
 
 Both have a free tier suitable for evaluation. Real scans on production codebases will exceed the free tier — see [Costs and credits](#costs-and-credits) below.
@@ -65,7 +65,7 @@ If the second command fails with `Missing AI credentials` or a `401`, see [Troub
 
 ### How it works
 
-deepsec expands whichever credential it finds (the API key first, the OIDC token as fallback) at startup into the four vars the Claude/Codex SDKs read (`ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`, `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`). Pi reads `AI_GATEWAY_API_KEY` directly through its built-in `vercel-ai-gateway` provider. A single credential covers Codex (`--agent codex`, the default), Claude (`--agent claude`), and Pi (`--agent pi`).
+deepsec expands whichever credential it finds (the API key first, the OIDC token as fallback) at startup into the four vars the Claude/Codex/OpenCode harnesses read (`ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`, `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`). Pi reads `AI_GATEWAY_API_KEY` directly through its built-in `vercel-ai-gateway` provider. A single credential covers Codex (`--agent codex`, the default), Claude (`--agent claude`), OpenCode (`--agent opencode`), and Pi (`--agent pi`).
 
 Any of those four vars you set explicitly takes precedence over the expansion — useful for mixing direct Anthropic with gateway-routed OpenAI, etc.
 
@@ -108,6 +108,10 @@ codex login     # for --agent codex
 
 Subscriptions are useful for **evaluating** deepsec but generally do not have enough headroom for full repo scans. The Claude weekly / 5-hour and ChatGPT Plus quotas trip well before a real codebase is finished. Switch to the gateway (or a direct provider key) once you're past evaluation.
 
+OpenCode can likewise reuse its local provider store: run `opencode`, use
+`/connect`, then select `--agent opencode`. This local store is not copied into
+Vercel Sandbox workers.
+
 ---
 
 ## BYOK and direct providers
@@ -130,9 +134,9 @@ OPENAI_API_KEY=sk-…
 
 Mix freely — gateway for Claude, direct for OpenAI, etc. The explicit values always win over the `AI_GATEWAY_API_KEY` expansion.
 
-### Pi provider overrides
+### Pi and OpenCode provider overrides
 
-Pi can also point an existing provider at another gateway without a
+Pi and OpenCode can point an existing provider at another gateway without a
 plugin. This is the intended path for Martian or any OpenAI-compatible
 gateway:
 
@@ -150,6 +154,18 @@ Use `--ai-header name=value` for any extra provider headers; repeat it
 as needed. In sandbox mode, deepsec passes only a placeholder env var
 into the worker and injects the real token at egress for the
 `--ai-base-url` host.
+
+For OpenCode, use a `provider/model` model identifier:
+
+```bash
+MARTIAN_API_KEY=...
+pnpm deepsec process --project-id my-app \
+  --agent opencode \
+  --model openai/gpt-5.5 \
+  --ai-provider openai \
+  --ai-base-url https://api.withmartian.com/v1 \
+  --ai-api-key-env MARTIAN_API_KEY
+```
 
 ---
 
@@ -211,7 +227,7 @@ If the sandbox can't authenticate, the spawn fails with the SDK's error. Re-run 
 
 | Symptom | What it means | Fix |
 |---|---|---|
-| `Missing AI credentials for --agent claude` / `codex` / `pi` | No credential present on this machine. | Set `AI_GATEWAY_API_KEY=vck_…` in `.env.local`; for Claude/Codex local evaluation you can also run `claude login` / `codex login`, and for Pi you can use local Pi auth. |
+| `Missing AI credentials for --agent claude` / `codex` / `opencode` / `pi` | No credential present on this machine. | Set `AI_GATEWAY_API_KEY=vck_…` in `.env.local`; locally you can also use Claude/Codex/Pi auth, or run OpenCode and use `/connect`. |
 | `401 Unauthorized` from `process` / `revalidate` | Credential present but rejected. | OIDC: re-run `vercel env pull` (token may have expired — 12 h). API key: regenerate in the dashboard. Confirm `.env.local` is in the cwd deepsec runs from. |
 | `✘ Stopped: Vercel AI Gateway credits exhausted` | Gateway balance is $0. | [Top up](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%3Fmodal%3Dtop-up), then re-run the same command — it resumes from where it stopped. |
 | `✘ Stopped: Anthropic API credits exhausted` | Direct Anthropic account out of credits. | Top up at [Anthropic Console](https://console.anthropic.com/), or switch to the gateway. |

--- a/e2e/bundle.test.ts
+++ b/e2e/bundle.test.ts
@@ -46,6 +46,10 @@ describe("bundle e2e", () => {
     expect(stdout).toContain("deepsec");
     expect(stdout).toContain("scan");
     expect(stdout).toContain("process");
+
+    const processHelp = runBundle(["process", "--help"]);
+    expect(processHelp.status).toBe(0);
+    expect(processHelp.stdout).toContain("opencode");
   });
 
   it("config.d.ts is self-contained (no internal @deepsec/* re-exports)", () => {

--- a/e2e/pipeline-sandbox.test.ts
+++ b/e2e/pipeline-sandbox.test.ts
@@ -64,6 +64,7 @@ const HAS_SANDBOX_KEY =
     Boolean(process.env.VERCEL_PROJECT_ID));
 
 const SHOULD_RUN = LIVE && HAS_SANDBOX_KEY;
+const SANDBOX_TIMEOUT_MS = 30 * 60_000;
 
 /**
  * Stub agent definition shared with pipeline.test.ts. Inlined here
@@ -325,6 +326,8 @@ describe.skipIf(!SHOULD_RUN)("pipeline e2e — live sandbox", () => {
             "1",
             "--vcpus",
             "2",
+            "--timeout",
+            String(SANDBOX_TIMEOUT_MS),
             "--limit",
             "2",
             "--concurrency",
@@ -364,6 +367,8 @@ describe.skipIf(!SHOULD_RUN)("pipeline e2e — live sandbox", () => {
             "1",
             "--vcpus",
             "2",
+            "--timeout",
+            String(SANDBOX_TIMEOUT_MS),
             "--limit",
             "2",
             "--concurrency",

--- a/knip.json
+++ b/knip.json
@@ -29,6 +29,8 @@
     "@anthropic-ai/claude-agent-sdk",
     "@earendil-works/pi-coding-agent",
     "@openai/codex",
-    "@openai/codex-sdk"
+    "@openai/codex-sdk",
+    "@opencode-ai/sdk",
+    "opencode-ai"
   ]
 }

--- a/knip.json
+++ b/knip.json
@@ -31,6 +31,7 @@
     "@openai/codex",
     "@openai/codex-sdk",
     "@opencode-ai/sdk",
-    "opencode-ai"
+    "opencode-ai",
+    "undici"
   ]
 }

--- a/packages/deepsec/build.mjs
+++ b/packages/deepsec/build.mjs
@@ -15,6 +15,7 @@ const external = [
   "@earendil-works/pi-coding-agent",
   "@openai/codex",
   "@openai/codex-sdk",
+  "@opencode-ai/sdk",
   "@vercel/sandbox",
   "jiti",
 ];

--- a/packages/deepsec/build.mjs
+++ b/packages/deepsec/build.mjs
@@ -18,6 +18,7 @@ const external = [
   "@opencode-ai/sdk",
   "@vercel/sandbox",
   "jiti",
+  "undici",
 ];
 
 const common = {

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -36,10 +36,12 @@
     "@earendil-works/pi-coding-agent": "0.79.10",
     "@openai/codex": "^0.144.0",
     "@openai/codex-sdk": "^0.144.0",
+    "@opencode-ai/sdk": "^1.18.3",
     "@vercel/oidc": "^3.4.0",
     "@vercel/sandbox": "^1.9.0",
     "jiti": "^2.4.0",
     "minimatch": "^10.0.0",
+    "opencode-ai": "^1.18.3",
     "tar": "^7.5.20"
   },
   "devDependencies": {

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -42,7 +42,8 @@
     "jiti": "^2.4.0",
     "minimatch": "^10.0.0",
     "opencode-ai": "^1.18.3",
-    "tar": "^7.5.20"
+    "tar": "^7.5.20",
+    "undici": "^8.5.0"
   },
   "devDependencies": {
     "@deepsec/core": "workspace:*",

--- a/packages/deepsec/src/__tests__/agent-defaults.test.ts
+++ b/packages/deepsec/src/__tests__/agent-defaults.test.ts
@@ -5,6 +5,7 @@ describe("defaultModelForAgent", () => {
   it("returns the backend-specific default models", () => {
     expect(defaultModelForAgent("codex")).toBe("gpt-5.5");
     expect(defaultModelForAgent("pi")).toBe("zai/glm-5.2");
+    expect(defaultModelForAgent("opencode")).toBe("anthropic/claude-opus-4-8");
     expect(defaultModelForAgent("claude-agent-sdk")).toBe("claude-opus-4-8");
   });
 });

--- a/packages/deepsec/src/__tests__/credential-brokering.test.ts
+++ b/packages/deepsec/src/__tests__/credential-brokering.test.ts
@@ -4,6 +4,7 @@ import { buildSandboxEnv, resolveBrokeredCredentials } from "../sandbox/setup.js
 const TOUCHED_KEYS = [
   "AI_GATEWAY_API_KEY",
   "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_API_KEY",
   "ANTHROPIC_BASE_URL",
   "OPENAI_API_KEY",
   "OPENAI_BASE_URL",
@@ -36,6 +37,12 @@ describe("credential brokering", () => {
       expect(c.openaiToken).toBeUndefined();
     });
 
+    it("captures ANTHROPIC_API_KEY for the OpenCode sandbox path", () => {
+      process.env.ANTHROPIC_API_KEY = "sk-ant-real";
+      const c = resolveBrokeredCredentials("opencode");
+      expect(c.anthropicToken).toBe("sk-ant-real");
+    });
+
     it("falls back to ANTHROPIC token for OpenAI on the codex path", () => {
       process.env.ANTHROPIC_AUTH_TOKEN = "vck_real";
       const c = resolveBrokeredCredentials("codex");
@@ -64,6 +71,14 @@ describe("credential brokering", () => {
     it("captures a custom API key env for the pi path", () => {
       process.env.MARTIAN_API_KEY = "martian-real";
       const c = resolveBrokeredCredentials("pi", { aiApiKeyEnv: "MARTIAN_API_KEY" });
+      expect(c.customToken).toEqual({ envName: "MARTIAN_API_KEY", token: "martian-real" });
+    });
+
+    it("captures a custom API key env for the OpenCode path", () => {
+      process.env.MARTIAN_API_KEY = "martian-real";
+      const c = resolveBrokeredCredentials("opencode", {
+        aiApiKeyEnv: "MARTIAN_API_KEY",
+      });
       expect(c.customToken).toEqual({ envName: "MARTIAN_API_KEY", token: "martian-real" });
     });
   });
@@ -144,6 +159,39 @@ describe("credential brokering", () => {
       for (const v of Object.values(env)) {
         expect(v).not.toContain("martian-real-secret");
       }
+    });
+
+    it("routes OpenCode Anthropic traffic through the local proxy", () => {
+      process.env.ANTHROPIC_AUTH_TOKEN = "vck_real_opencode_secret";
+      process.env.ANTHROPIC_BASE_URL = "https://ai-gateway.vercel.sh";
+      const credentials = resolveBrokeredCredentials("opencode");
+      const env = buildSandboxEnv("opencode", credentials, {
+        model: "anthropic/claude-opus-4-8",
+      });
+
+      expect(env.DEEPSEC_OPENCODE_PROVIDER).toBe("anthropic");
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBeDefined();
+      expect(env.ANTHROPIC_AUTH_TOKEN).not.toBe("vck_real_opencode_secret");
+      expect(env.ANTHROPIC_UPSTREAM_BASE_URL).toBe("https://ai-gateway.vercel.sh");
+      expect(env.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    });
+
+    it("routes a custom OpenCode provider without exposing its key", () => {
+      process.env.MARTIAN_API_KEY = "martian-real-secret";
+      const credentials = resolveBrokeredCredentials("opencode", {
+        aiApiKeyEnv: "MARTIAN_API_KEY",
+      });
+      const env = buildSandboxEnv("opencode", credentials, {
+        aiApiKeyEnv: "MARTIAN_API_KEY",
+        aiBaseUrl: "https://api.withmartian.com/v1",
+        aiProvider: "martian",
+        model: "openai/security-model",
+      });
+
+      expect(env.DEEPSEC_OPENCODE_PROVIDER).toBe("martian");
+      expect(env.DEEPSEC_OPENCODE_AI_BASE_URL).toBe("https://api.withmartian.com/v1");
+      expect(env.MARTIAN_API_KEY).toBeDefined();
+      expect(env.MARTIAN_API_KEY).not.toBe("martian-real-secret");
     });
   });
 });

--- a/packages/deepsec/src/__tests__/network-policy.test.ts
+++ b/packages/deepsec/src/__tests__/network-policy.test.ts
@@ -62,6 +62,12 @@ describe("buildWorkerNetworkPolicy", () => {
 
     const piPolicy = buildWorkerNetworkPolicy({}, "pi");
     expect(allowedHosts(piPolicy)).toEqual(["ai-gateway.vercel.sh"]);
+
+    const openCodePolicy = buildWorkerNetworkPolicy(
+      { DEEPSEC_OPENCODE_PROVIDER: "anthropic" },
+      "opencode",
+    );
+    expect(allowedHosts(openCodePolicy)).toEqual(["api.anthropic.com"]);
   });
 
   it("falls back when the URL is unparseable", () => {
@@ -120,6 +126,45 @@ describe("buildWorkerNetworkPolicy", () => {
       const policy = buildWorkerNetworkPolicy(
         { DEEPSEC_PI_AI_BASE_URL: "https://api.withmartian.com/v1" },
         "pi",
+        { customToken: { envName: "MARTIAN_API_KEY", token: "martian-real" } },
+      );
+      expect(allowedHosts(policy)).toEqual(["api.withmartian.com"]);
+      expect(bearerFor(policy, "api.withmartian.com")).toBe("Bearer martian-real");
+    });
+
+    it("uses the Anthropic route and token for the default OpenCode model", () => {
+      const policy = buildWorkerNetworkPolicy(
+        {
+          DEEPSEC_OPENCODE_PROVIDER: "anthropic",
+          ANTHROPIC_UPSTREAM_BASE_URL: "https://ai-gateway.vercel.sh",
+        },
+        "opencode",
+        { anthropicToken: "vck_opencode" },
+      );
+      expect(allowedHosts(policy)).toEqual(["ai-gateway.vercel.sh"]);
+      expect(bearerFor(policy, "ai-gateway.vercel.sh")).toBe("Bearer vck_opencode");
+    });
+
+    it("uses the OpenAI route and token for an OpenCode OpenAI model", () => {
+      const policy = buildWorkerNetworkPolicy(
+        {
+          DEEPSEC_OPENCODE_PROVIDER: "openai",
+          OPENAI_BASE_URL: "https://api.openai.com/v1",
+        },
+        "opencode",
+        { openaiToken: "sk-opencode" },
+      );
+      expect(allowedHosts(policy)).toEqual(["api.openai.com"]);
+      expect(bearerFor(policy, "api.openai.com")).toBe("Bearer sk-opencode");
+    });
+
+    it("uses a custom OpenCode provider host and brokered token", () => {
+      const policy = buildWorkerNetworkPolicy(
+        {
+          DEEPSEC_OPENCODE_PROVIDER: "martian",
+          DEEPSEC_OPENCODE_AI_BASE_URL: "https://api.withmartian.com/v1",
+        },
+        "opencode",
         { customToken: { envName: "MARTIAN_API_KEY", token: "martian-real" } },
       );
       expect(allowedHosts(policy)).toEqual(["api.withmartian.com"]);

--- a/packages/deepsec/src/__tests__/opencode-sandbox.test.ts
+++ b/packages/deepsec/src/__tests__/opencode-sandbox.test.ts
@@ -1,0 +1,47 @@
+import type { Sandbox } from "@vercel/sandbox";
+import { describe, expect, it, vi } from "vitest";
+import { DEEPSEC_DIR, ensureOpenCodeBinary } from "../sandbox/setup.js";
+
+function commandResult(exitCode: number, stdout = "", stderr = "") {
+  return {
+    exitCode,
+    stdout: async () => stdout,
+    stderr: async () => stderr,
+  };
+}
+
+describe("ensureOpenCodeBinary", () => {
+  it.each([
+    ["dev", `${DEEPSEC_DIR}/packages/deepsec/node_modules/opencode-ai/bin/opencode.exe`],
+    ["installed", `${DEEPSEC_DIR}/node_modules/deepsec/node_modules/opencode-ai/bin/opencode.exe`],
+  ] as const)("links the %s package binary onto PATH", async (mode, source) => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce(commandResult(0))
+      .mockResolvedValueOnce(commandResult(0, "1.18.3\n"));
+    const onLog = vi.fn();
+
+    await ensureOpenCodeBinary({ runCommand } as unknown as Sandbox, mode, onLog);
+
+    expect(runCommand).toHaveBeenNthCalledWith(1, {
+      cmd: "ln",
+      args: ["-sfn", source, "/usr/local/bin/opencode"],
+      sudo: true,
+    });
+    expect(runCommand).toHaveBeenNthCalledWith(2, {
+      cmd: "opencode",
+      args: ["--version"],
+      cwd: DEEPSEC_DIR,
+    });
+    expect(onLog).toHaveBeenCalledWith("  1.18.3");
+  });
+
+  it("reports a failed system link before checking the binary", async () => {
+    const runCommand = vi.fn().mockResolvedValue(commandResult(1, "", "permission denied"));
+
+    await expect(
+      ensureOpenCodeBinary({ runCommand } as unknown as Sandbox, "dev", vi.fn()),
+    ).rejects.toThrow("OpenCode native binary link failed (exit 1): permission denied");
+    expect(runCommand).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -39,6 +39,7 @@ describe("assertAgentCredential", () => {
       CLAUDE_HOME: process.env.CLAUDE_HOME,
       CODEX_HOME: process.env.CODEX_HOME,
       PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+      XDG_DATA_HOME: process.env.XDG_DATA_HOME,
       PATH: process.env.PATH,
     };
     delete process.env.ANTHROPIC_AUTH_TOKEN;
@@ -56,7 +57,9 @@ describe("assertAgentCredential", () => {
     process.env.CLAUDE_HOME = emptyClaudeHome;
     process.env.CODEX_HOME = emptyCodexHome;
     process.env.PI_CODING_AGENT_DIR = join(emptyCodexHome, "pi-agent");
+    process.env.XDG_DATA_HOME = join(emptyCodexHome, "xdg-data");
     mkdirSync(process.env.PI_CODING_AGENT_DIR, { recursive: true });
+    mkdirSync(process.env.XDG_DATA_HOME, { recursive: true });
     process.env.PATH = emptyPathDir;
   });
   afterEach(() => {
@@ -151,6 +154,33 @@ describe("assertAgentCredential", () => {
     const piHome = process.env.PI_CODING_AGENT_DIR!;
     writeFileSync(join(piHome, "auth.json"), "{}");
     expect(() => assertAgentCredential("pi", { inSandbox: true })).toThrow(/AI_GATEWAY_API_KEY/);
+  });
+
+  it("passes for opencode when AI Gateway credentials are set", () => {
+    process.env.AI_GATEWAY_API_KEY = "vck_gateway";
+    expect(() => assertAgentCredential("opencode")).not.toThrow();
+  });
+
+  it("passes for opencode when local provider auth exists", () => {
+    const authDir = join(process.env.XDG_DATA_HOME!, "opencode");
+    mkdirSync(authDir, { recursive: true });
+    writeFileSync(join(authDir, "auth.json"), "{}");
+    expect(() => assertAgentCredential("opencode")).not.toThrow();
+  });
+
+  it("ignores local OpenCode auth in sandbox mode", () => {
+    const authDir = join(process.env.XDG_DATA_HOME!, "opencode");
+    mkdirSync(authDir, { recursive: true });
+    writeFileSync(join(authDir, "auth.json"), "{}");
+    expect(() => assertAgentCredential("opencode")).not.toThrow();
+    expect(() => assertAgentCredential("opencode", { inSandbox: true })).toThrow(
+      /AI_GATEWAY_API_KEY/,
+    );
+  });
+
+  it("shows OpenCode connection instructions when credentials are missing", () => {
+    expect(() => assertAgentCredential("opencode")).toThrow(/--agent opencode/);
+    expect(() => assertAgentCredential("opencode")).toThrow(/\/connect/);
   });
 });
 

--- a/packages/deepsec/src/__tests__/resolve-agent-type.test.ts
+++ b/packages/deepsec/src/__tests__/resolve-agent-type.test.ts
@@ -20,6 +20,10 @@ describe("resolveAgentType", () => {
     expect(resolveAgentType("pi")).toBe("pi");
   });
 
+  it("accepts opencode as a built-in agent type", () => {
+    expect(resolveAgentType("opencode")).toBe("opencode");
+  });
+
   it("aliases claude from defaultAgent config", () => {
     setLoadedConfig(defineConfig({ projects: [], defaultAgent: "claude" }));
     expect(resolveAgentType(undefined)).toBe("claude-agent-sdk");

--- a/packages/deepsec/src/agent-config.ts
+++ b/packages/deepsec/src/agent-config.ts
@@ -43,7 +43,7 @@ export function buildAgentConfig(opts: AgentRuntimeOpts): Record<string, unknown
   const effectiveProvider = opts.aiProvider ?? providerFromModel(opts.model);
   if (hasProviderOverride && !effectiveProvider) {
     throw new Error(
-      `Pi provider override flags require --ai-provider or a provider/model --model value.`,
+      `Pi/OpenCode provider override flags require --ai-provider or a provider/model --model value.`,
     );
   }
   const config: Record<string, unknown> = {
@@ -56,8 +56,8 @@ export function buildAgentConfig(opts: AgentRuntimeOpts): Record<string, unknown
         `--thinking-level must be one of ${THINKING_LEVELS.join(", ")}, got "${opts.thinkingLevel}"`,
       );
     }
-    // Same dial, different name per harness: pi and claude read
-    // thinkingLevel, codex reads reasoningEffort.
+    // Same dial, different name per harness: Pi, OpenCode, and Claude read
+    // thinkingLevel; Codex reads reasoningEffort.
     config.thinkingLevel = opts.thinkingLevel;
     config.reasoningEffort = opts.thinkingLevel;
   }

--- a/packages/deepsec/src/agent-defaults.ts
+++ b/packages/deepsec/src/agent-defaults.ts
@@ -8,6 +8,8 @@ export function defaultModelForAgent(agentType: string): string {
       return "gpt-5.5";
     case "pi":
       return "zai/glm-5.2";
+    case "opencode":
+      return "anthropic/claude-opus-4-8";
     default:
       return "claude-opus-4-8";
   }

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -136,24 +136,27 @@ program
   .option("--run-id <id>", "Resume a specific processing run")
   .option(
     "--agent <type>",
-    "Agent plugin type: codex, claude, or pi (default: defaultAgent in deepsec.config.ts, else codex)",
+    "Agent plugin type: codex, claude, opencode, or pi (default: defaultAgent in deepsec.config.ts, else codex)",
   )
   .option(
     "--model <model>",
-    "Model to use (default: claude-opus-4-8 for claude, gpt-5.5 for codex, zai/glm-5.2 for pi)",
+    "Model to use (default: claude-opus-4-8 for claude, gpt-5.5 for codex, anthropic/claude-opus-4-8 for opencode, zai/glm-5.2 for pi)",
   )
   .option(
     "--ai-provider <provider>",
-    "Pi: provider to override for --ai-base-url / --ai-api-key-env (e.g. openai)",
+    "Pi/OpenCode: provider to override for --ai-base-url / --ai-api-key-env (e.g. openai)",
   )
   .option(
     "--ai-base-url <url>",
-    "Pi: provider base URL override (e.g. a Martian/OpenAI-compatible gateway)",
+    "Pi/OpenCode: provider base URL override (e.g. a Martian/OpenAI-compatible gateway)",
   )
-  .option("--ai-api-key-env <name>", "Pi: environment variable that holds the provider API key")
+  .option(
+    "--ai-api-key-env <name>",
+    "Pi/OpenCode: environment variable that holds the provider API key",
+  )
   .option(
     "--ai-header <name=value>",
-    "Pi: extra provider request header; repeatable",
+    "Pi/OpenCode: extra provider request header; repeatable",
     collectRepeatable,
     [],
   )
@@ -215,24 +218,27 @@ program
   .option("--run-id <id>", "Resume a specific revalidation run")
   .option(
     "--agent <type>",
-    "Agent plugin type: codex, claude, or pi (default: defaultAgent in deepsec.config.ts, else codex)",
+    "Agent plugin type: codex, claude, opencode, or pi (default: defaultAgent in deepsec.config.ts, else codex)",
   )
   .option(
     "--model <model>",
-    "Model to use (default: claude-opus-4-8 for claude, gpt-5.5 for codex, zai/glm-5.2 for pi)",
+    "Model to use (default: claude-opus-4-8 for claude, gpt-5.5 for codex, anthropic/claude-opus-4-8 for opencode, zai/glm-5.2 for pi)",
   )
   .option(
     "--ai-provider <provider>",
-    "Pi: provider to override for --ai-base-url / --ai-api-key-env (e.g. openai)",
+    "Pi/OpenCode: provider to override for --ai-base-url / --ai-api-key-env (e.g. openai)",
   )
   .option(
     "--ai-base-url <url>",
-    "Pi: provider base URL override (e.g. a Martian/OpenAI-compatible gateway)",
+    "Pi/OpenCode: provider base URL override (e.g. a Martian/OpenAI-compatible gateway)",
   )
-  .option("--ai-api-key-env <name>", "Pi: environment variable that holds the provider API key")
+  .option(
+    "--ai-api-key-env <name>",
+    "Pi/OpenCode: environment variable that holds the provider API key",
+  )
   .option(
     "--ai-header <name=value>",
-    "Pi: extra provider request header; repeatable",
+    "Pi/OpenCode: extra provider request header; repeatable",
     collectRepeatable,
     [],
   )
@@ -327,7 +333,7 @@ program
   .option("--require-owner", "Drop findings that have no ownership data (no assignee, no teams)")
   .option(
     "--only-agent <type>",
-    "Only export findings produced by this agent backend (e.g. codex, claude, pi)",
+    "Only export findings produced by this agent backend (e.g. codex, claude, opencode, pi)",
   )
   .option(
     "--only-marker <n>",

--- a/packages/deepsec/src/commands/sandbox-all.ts
+++ b/packages/deepsec/src/commands/sandbox-all.ts
@@ -206,6 +206,7 @@ export async function sandboxAllCommand(
       agentType,
       aiApiKeyEnv: extractFlag(passthrough, "--ai-api-key-env"),
       aiBaseUrl: extractFlag(passthrough, "--ai-base-url"),
+      aiProvider: extractFlag(passthrough, "--ai-provider"),
       model: extractFlag(passthrough, "--model") ?? defaultModelForAgent(agentType),
       snapshotId: undefined,
       saveSnapshot: false,

--- a/packages/deepsec/src/commands/sandbox-process.ts
+++ b/packages/deepsec/src/commands/sandbox-process.ts
@@ -76,6 +76,7 @@ function buildConfig(
     agentType,
     aiApiKeyEnv: extractFlag(args, "--ai-api-key-env"),
     aiBaseUrl: extractFlag(args, "--ai-base-url"),
+    aiProvider: extractFlag(args, "--ai-provider"),
     model: extractFlag(args, "--model") ?? defaultModelForAgent(agentType),
     snapshotId: opts.snapshotId,
     saveSnapshot: opts.saveSnapshot ?? false,

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -85,6 +85,10 @@ function isPi(agentType: string | undefined): boolean {
   return agentType === "pi";
 }
 
+function isOpenCode(agentType: string | undefined): boolean {
+  return agentType === "opencode";
+}
+
 /**
  * Walk `$PATH` looking for a binary. Used as a positive signal that an
  * agent CLI (`claude`, `codex`) is set up on this host — if it's
@@ -143,11 +147,21 @@ function hasLocalPiAgent(): boolean {
   return existsSync(join(piHome, "auth.json"));
 }
 
+/**
+ * OpenCode stores provider credentials in its XDG data directory. The CLI
+ * binary is a deepsec runtime dependency, so merely finding `opencode` on
+ * PATH is not evidence that the user connected a provider.
+ */
+function hasLocalOpenCodeAuth(): boolean {
+  const dataHome = process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+  return existsSync(join(dataHome, "opencode", "auth.json"));
+}
+
 // Built-in backends we know how to credential-check. Agents registered
 // via plugins (deepsec.config.ts → plugins: [{ agents: [...] }]) handle
 // their own credential resolution, so we skip the check for anything
 // other than these.
-const KNOWN_BACKENDS = new Set<string>(["claude-agent-sdk", "codex", "pi"]);
+const KNOWN_BACKENDS = new Set<string>(["claude-agent-sdk", "codex", "opencode", "pi"]);
 
 /**
  * Verify the orchestrator has an AI credential the chosen agent can use.
@@ -199,6 +213,21 @@ export function assertAgentCredential(
       `Missing AI credentials for --agent pi.\n` +
         `\n` +
         `  Add to .env.local:    AI_GATEWAY_API_KEY=vck_…${customHint}\n` +
+        `  Setup: ${SETUP_DOC_URL}`,
+    );
+  }
+
+  if (isOpenCode(agentType)) {
+    if (gateway || custom || anthropic || anthropicApi || openai) return;
+    if (!options.inSandbox && hasLocalOpenCodeAuth()) return;
+    const customHint = options.aiApiKeyEnv
+      ? `, or set ${options.aiApiKeyEnv}=… for the selected --ai-api-key-env`
+      : "";
+    throw new Error(
+      `Missing AI credentials for --agent opencode.\n` +
+        `\n` +
+        `  Add to .env.local:    AI_GATEWAY_API_KEY=vck_…${customHint}\n` +
+        `  Or run opencode and use /connect to authenticate a provider (local runs only).\n` +
         `  Setup: ${SETUP_DOC_URL}`,
     );
   }

--- a/packages/deepsec/src/sandbox/orchestrator.ts
+++ b/packages/deepsec/src/sandbox/orchestrator.ts
@@ -354,6 +354,8 @@ async function bootstrapAndSpawn(
         agentType: config.agentType,
         aiApiKeyEnv: config.aiApiKeyEnv,
         aiBaseUrl: config.aiBaseUrl,
+        aiProvider: config.aiProvider,
+        model: config.model,
         vcpus: config.vcpus,
         timeout: config.timeout,
         mode: ctx.mode,

--- a/packages/deepsec/src/sandbox/setup.ts
+++ b/packages/deepsec/src/sandbox/setup.ts
@@ -72,6 +72,8 @@ interface BrokeredCredentials {
 interface BrokeredCredentialOptions {
   aiApiKeyEnv?: string;
   aiBaseUrl?: string;
+  aiProvider?: string;
+  model?: string;
 }
 
 /**
@@ -84,11 +86,12 @@ export function resolveBrokeredCredentials(
   agentType: string | undefined,
   options: BrokeredCredentialOptions = {},
 ): BrokeredCredentials {
-  const anthropicToken = process.env.ANTHROPIC_AUTH_TOKEN;
+  const anthropicToken = process.env.ANTHROPIC_AUTH_TOKEN ?? process.env.ANTHROPIC_API_KEY;
   const explicitOpenai = process.env.OPENAI_API_KEY;
+  const configurableAgent = agentType === "pi" || agentType === "opencode";
   const aiGatewayToken = agentType === "pi" ? process.env.AI_GATEWAY_API_KEY : undefined;
   const customToken =
-    agentType === "pi" && options.aiApiKeyEnv && process.env[options.aiApiKeyEnv]
+    configurableAgent && options.aiApiKeyEnv && process.env[options.aiApiKeyEnv]
       ? { envName: options.aiApiKeyEnv, token: process.env[options.aiApiKeyEnv]! }
       : undefined;
   // Only borrow ANTHROPIC for OPENAI on the codex path — and only when the
@@ -110,6 +113,14 @@ const PROXY_SCRIPT_BY_MODE: Record<DeepsecMode, string> = {
   installed: `${DEEPSEC_DIR}/node_modules/deepsec/dist/sandbox/request-proxy.mjs`,
 };
 const CODEX_HOME = "/vercel/sandbox/.codex";
+const OPENCODE_PROVIDER_ENV = "DEEPSEC_OPENCODE_PROVIDER";
+const OPENCODE_CUSTOM_BASE_URL_ENV = "DEEPSEC_OPENCODE_AI_BASE_URL";
+
+function providerFromModel(model: string | undefined): string | undefined {
+  if (!model) return undefined;
+  const slash = model.indexOf("/");
+  return slash > 0 ? model.slice(0, slash) : undefined;
+}
 
 export function buildSandboxEnv(
   agentType: string | undefined,
@@ -142,6 +153,16 @@ export function buildSandboxEnv(
       env[PI_CUSTOM_BASE_URL_ENV] = options.aiBaseUrl;
     }
   }
+  if (agentType === "opencode") {
+    const provider = options.aiProvider ?? providerFromModel(options.model) ?? "anthropic";
+    env[OPENCODE_PROVIDER_ENV] = provider;
+    if (credentials.customToken) {
+      env[credentials.customToken.envName] = BROKERED_TOKEN_PLACEHOLDER;
+    }
+    if (options.aiBaseUrl) {
+      env[OPENCODE_CUSTOM_BASE_URL_ENV] = options.aiBaseUrl;
+    }
+  }
 
   // Belt-and-suspenders alongside the worker egress firewall: the master
   // kill-switch covers DISABLE_TELEMETRY / DISABLE_ERROR_REPORTING /
@@ -166,12 +187,13 @@ export function buildSandboxEnv(
   // body mutation needed for Codex, so a proxy hop would just add latency
   // and a base-url-rewriting hazard (path doubling, etc.). spawnFromSnapshot
   // skips the proxy startup when agentType=codex for the same reason.
+  const openCodeProvider = env[OPENCODE_PROVIDER_ENV];
   if (agentType === "codex") {
     env["CODEX_HOME"] = CODEX_HOME;
     if (!env["OPENAI_BASE_URL"] && env["ANTHROPIC_BASE_URL"]) {
       env["OPENAI_BASE_URL"] = env["ANTHROPIC_BASE_URL"];
     }
-  } else {
+  } else if (agentType !== "opencode" || openCodeProvider === "anthropic") {
     const realBaseUrl = env["ANTHROPIC_BASE_URL"];
     if (realBaseUrl) {
       env["ANTHROPIC_UPSTREAM_BASE_URL"] = realBaseUrl;
@@ -221,15 +243,22 @@ export function buildWorkerNetworkPolicy(
 ): NetworkPolicy {
   const isCodex = agentType === "codex";
   const isPi = agentType === "pi";
+  const isOpenCode = agentType === "opencode";
+  const openCodeProvider = env[OPENCODE_PROVIDER_ENV] ?? "anthropic";
+  const openCodeCustomBaseUrl = env[OPENCODE_CUSTOM_BASE_URL_ENV];
 
   // Single AI host per backend. Prefer derived from the base URL the agent
   // will actually use; fall back to the provider's documented default when
   // the user hasn't configured one.
   const aiHost = isPi
     ? (hostFromUrl(env[PI_CUSTOM_BASE_URL_ENV]) ?? DEFAULT_AI_GATEWAY_HOST)
-    : isCodex
-      ? (hostFromUrl(env["OPENAI_BASE_URL"]) ?? DEFAULT_OPENAI_HOST)
-      : (hostFromUrl(env["ANTHROPIC_UPSTREAM_BASE_URL"]) ?? DEFAULT_ANTHROPIC_HOST);
+    : isOpenCode && openCodeCustomBaseUrl
+      ? (hostFromUrl(openCodeCustomBaseUrl) ?? DEFAULT_ANTHROPIC_HOST)
+      : isOpenCode && openCodeProvider === "openai"
+        ? (hostFromUrl(env["OPENAI_BASE_URL"]) ?? DEFAULT_OPENAI_HOST)
+        : isCodex
+          ? (hostFromUrl(env["OPENAI_BASE_URL"]) ?? DEFAULT_OPENAI_HOST)
+          : (hostFromUrl(env["ANTHROPIC_UPSTREAM_BASE_URL"]) ?? DEFAULT_ANTHROPIC_HOST);
 
   // The fallback flips at resolveBrokeredCredentials — by here, openaiToken
   // already carries the ANTHROPIC gateway token if the user only set that
@@ -238,9 +267,13 @@ export function buildWorkerNetworkPolicy(
     ? env[PI_CUSTOM_BASE_URL_ENV]
       ? credentials.customToken?.token
       : credentials.aiGatewayToken
-    : isCodex
-      ? credentials.openaiToken
-      : credentials.anthropicToken;
+    : isOpenCode && openCodeCustomBaseUrl
+      ? credentials.customToken?.token
+      : isOpenCode && openCodeProvider === "openai"
+        ? credentials.openaiToken
+        : isCodex
+          ? credentials.openaiToken
+          : credentials.anthropicToken;
 
   const allow: Record<string, NetworkPolicyRule[]> = {
     [aiHost]: injectToken
@@ -359,7 +392,7 @@ export async function createBootstrapSnapshot(opts: BootstrapOptions): Promise<s
     opts.onLog(`Running pnpm ${installArgs.join(" ")}...`);
     await runAndLog(sandbox, "pnpm", installArgs, DEEPSEC_DIR, opts.onLog);
 
-    // Ensure agent native binaries. Both backends ship vendored native binaries
+    // Ensure agent native binaries. The built-in backends ship vendored native binaries
     // through optional deps; pnpm's optional-dep filter on the host platform
     // doesn't always land the right binary on the sandbox. We install the
     // matching binary explicitly per agent.
@@ -367,6 +400,9 @@ export async function createBootstrapSnapshot(opts: BootstrapOptions): Promise<s
       opts.onLog("Ensuring Codex CLI native binary is installed...");
       await ensureCodexNativeBinary(sandbox, opts.onLog);
       await writeCodexConfig(sandbox, opts.onLog);
+    } else if (agentType === "opencode") {
+      opts.onLog("Ensuring OpenCode CLI native binary is installed...");
+      await ensureOpenCodeBinary(sandbox, opts.onLog);
     } else {
       opts.onLog("Ensuring Claude SDK native binaries are installed...");
       await ensureClaudeNativeBinaries(sandbox, opts.onLog);
@@ -395,6 +431,8 @@ interface SpawnOptions {
   agentType?: string;
   aiApiKeyEnv?: string;
   aiBaseUrl?: string;
+  aiProvider?: string;
+  model?: string;
   vcpus: number;
   timeout: number;
   /** Source repo vs. user's `.deepsec/` install — see DeepsecMode docstring */
@@ -419,6 +457,8 @@ export async function spawnFromSnapshot(opts: SpawnOptions): Promise<Sandbox> {
   const credentialOptions = {
     aiApiKeyEnv: opts.aiApiKeyEnv,
     aiBaseUrl: opts.aiBaseUrl,
+    aiProvider: opts.aiProvider,
+    model: opts.model,
   };
   const credentials = resolveBrokeredCredentials(opts.agentType, credentialOptions);
   const sandboxEnv = buildSandboxEnv(opts.agentType, credentials, credentialOptions);
@@ -461,7 +501,11 @@ export async function spawnFromSnapshot(opts: SpawnOptions): Promise<Sandbox> {
   // keeps a stub agent out of the proxy startup, which fails fast when
   // ANTHROPIC_UPSTREAM_BASE_URL isn't set — letting the live-sandbox e2e
   // run with no AI credentials.
-  if (opts.agentType === "claude-agent-sdk") {
+  const openCodeUsesAnthropic =
+    opts.agentType === "opencode" &&
+    (opts.aiProvider ?? providerFromModel(opts.model) ?? "anthropic") === "anthropic" &&
+    Boolean(sandboxEnv["ANTHROPIC_UPSTREAM_BASE_URL"]);
+  if (opts.agentType === "claude-agent-sdk" || openCodeUsesAnthropic) {
     await startRequestProxy(sandbox, opts.mode, opts.onLog);
   }
 
@@ -505,6 +549,22 @@ exit 1
   }
   if (check.exitCode !== 0) {
     throw new Error(`request-proxy failed to start (exit ${check.exitCode})`);
+  }
+}
+
+async function ensureOpenCodeBinary(sandbox: Sandbox, onLog: (msg: string) => void): Promise<void> {
+  const result = await sandbox.runCommand({
+    cmd: "pnpm",
+    args: ["exec", "opencode", "--version"],
+    cwd: DEEPSEC_DIR,
+  });
+  const stdout = (await result.stdout()).trim();
+  const stderr = (await result.stderr()).trim();
+  for (const line of `${stdout}\n${stderr}`.split("\n")) {
+    if (line.trim()) onLog(`  ${line}`);
+  }
+  if (result.exitCode !== 0) {
+    throw new Error(`OpenCode native binary check failed (exit ${result.exitCode})`);
   }
 }
 

--- a/packages/deepsec/src/sandbox/setup.ts
+++ b/packages/deepsec/src/sandbox/setup.ts
@@ -112,6 +112,10 @@ const PROXY_SCRIPT_BY_MODE: Record<DeepsecMode, string> = {
   dev: `${DEEPSEC_DIR}/packages/deepsec/src/sandbox/request-proxy.mjs`,
   installed: `${DEEPSEC_DIR}/node_modules/deepsec/dist/sandbox/request-proxy.mjs`,
 };
+const OPENCODE_BINARY_BY_MODE: Record<DeepsecMode, string> = {
+  dev: `${DEEPSEC_DIR}/packages/deepsec/node_modules/opencode-ai/bin/opencode.exe`,
+  installed: `${DEEPSEC_DIR}/node_modules/deepsec/node_modules/opencode-ai/bin/opencode.exe`,
+};
 const CODEX_HOME = "/vercel/sandbox/.codex";
 const OPENCODE_PROVIDER_ENV = "DEEPSEC_OPENCODE_PROVIDER";
 const OPENCODE_CUSTOM_BASE_URL_ENV = "DEEPSEC_OPENCODE_AI_BASE_URL";
@@ -402,7 +406,7 @@ export async function createBootstrapSnapshot(opts: BootstrapOptions): Promise<s
       await writeCodexConfig(sandbox, opts.onLog);
     } else if (agentType === "opencode") {
       opts.onLog("Ensuring OpenCode CLI native binary is installed...");
-      await ensureOpenCodeBinary(sandbox, opts.onLog);
+      await ensureOpenCodeBinary(sandbox, opts.mode, opts.onLog);
     } else {
       opts.onLog("Ensuring Claude SDK native binaries are installed...");
       await ensureClaudeNativeBinaries(sandbox, opts.onLog);
@@ -552,10 +556,27 @@ exit 1
   }
 }
 
-async function ensureOpenCodeBinary(sandbox: Sandbox, onLog: (msg: string) => void): Promise<void> {
+export async function ensureOpenCodeBinary(
+  sandbox: Sandbox,
+  mode: DeepsecMode,
+  onLog: (msg: string) => void,
+): Promise<void> {
+  const binaryPath = OPENCODE_BINARY_BY_MODE[mode];
+  const link = await sandbox.runCommand({
+    cmd: "ln",
+    args: ["-sfn", binaryPath, "/usr/local/bin/opencode"],
+    sudo: true,
+  });
+  if (link.exitCode !== 0) {
+    const stderr = (await link.stderr()).trim();
+    throw new Error(
+      `OpenCode native binary link failed (exit ${link.exitCode})${stderr ? `: ${stderr}` : ""}`,
+    );
+  }
+
   const result = await sandbox.runCommand({
-    cmd: "pnpm",
-    args: ["exec", "opencode", "--version"],
+    cmd: "opencode",
+    args: ["--version"],
     cwd: DEEPSEC_DIR,
   });
   const stdout = (await result.stdout()).trim();

--- a/packages/deepsec/src/sandbox/types.ts
+++ b/packages/deepsec/src/sandbox/types.ts
@@ -19,12 +19,14 @@ export interface SandboxConfig {
   concurrency: number;
   /** Batch size within each sandbox */
   batchSize: number;
-  /** Agent backend type — claude-agent-sdk, codex, or pi */
+  /** Agent backend type — claude-agent-sdk, codex, opencode, or pi */
   agentType?: string;
-  /** Pi provider API key env var for custom gateway/provider routing */
+  /** Pi/OpenCode provider API key env var for custom gateway/provider routing */
   aiApiKeyEnv?: string;
-  /** Pi provider base URL for custom gateway/provider routing */
+  /** Pi/OpenCode provider base URL for custom gateway/provider routing */
   aiBaseUrl?: string;
+  /** Pi/OpenCode provider override for custom gateway/provider routing */
+  aiProvider?: string;
   /** Model to use */
   model: string;
   /** Restore from existing snapshot */

--- a/packages/processor/package.json
+++ b/packages/processor/package.json
@@ -16,6 +16,7 @@
     "@openai/codex": "^0.144.0",
     "@openai/codex-sdk": "^0.144.0",
     "@opencode-ai/sdk": "^1.18.3",
-    "jsonrepair": "^3.14.0"
+    "jsonrepair": "^3.14.0",
+    "undici": "^8.5.0"
   }
 }

--- a/packages/processor/package.json
+++ b/packages/processor/package.json
@@ -15,6 +15,7 @@
     "@earendil-works/pi-coding-agent": "0.79.10",
     "@openai/codex": "^0.144.0",
     "@openai/codex-sdk": "^0.144.0",
+    "@opencode-ai/sdk": "^1.18.3",
     "jsonrepair": "^3.14.0"
   }
 }

--- a/packages/processor/src/__tests__/opencode-sdk.test.ts
+++ b/packages/processor/src/__tests__/opencode-sdk.test.ts
@@ -5,6 +5,7 @@ import {
   parseOpenCodeModel,
   resolveOpenCodeAssistantText,
   resolveOpenCodeVariant,
+  shouldUseOpenCodeTextFormat,
 } from "../agents/opencode-sdk.js";
 
 describe("OpenCodeAgentPlugin configuration", () => {
@@ -43,6 +44,28 @@ describe("OpenCodeAgentPlugin configuration", () => {
     expect(resolveOpenCodeVariant("google", "high")).toBe("high");
     expect(resolveOpenCodeVariant("custom")).toBeUndefined();
     expect(resolveOpenCodeVariant("custom", "medium")).toBe("medium");
+  });
+
+  it("uses text output when Anthropic thinking conflicts with forced structured output", () => {
+    expect(
+      shouldUseOpenCodeTextFormat("anthropic", "high", {
+        type: "json_schema",
+        schema: { type: "object" },
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseOpenCodeTextFormat("anthropic", undefined, {
+        type: "json_schema",
+        schema: { type: "object" },
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseOpenCodeTextFormat("openai", "high", {
+        type: "json_schema",
+        schema: { type: "object" },
+      }),
+    ).toBe(false);
+    expect(shouldUseOpenCodeTextFormat("anthropic", "high", { type: "text" })).toBe(false);
   });
 
   it("preserves nested network error details", () => {
@@ -129,9 +152,19 @@ describe("OpenCodeAgentPlugin configuration", () => {
     expect(main?.permission).toEqual(config.permission);
     expect(config.provider?.anthropic?.options).toMatchObject({
       apiKey: "{env:ANTHROPIC_AUTH_TOKEN}",
-      baseURL: "https://ai-gateway.example",
+      baseURL: "https://ai-gateway.example/v1",
     });
     expect(JSON.stringify(config)).not.toContain("do-not-inline-this-secret");
+  });
+
+  it("does not duplicate the Anthropic API version path", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1/";
+
+    const config = buildOpenCodeConfig({
+      model: "anthropic/claude-haiku-4-5",
+    });
+
+    expect(config.provider?.anthropic?.options?.baseURL).toBe("https://api.anthropic.com/v1");
   });
 
   it("supports a custom provider override without changing the model id", () => {

--- a/packages/processor/src/__tests__/opencode-sdk.test.ts
+++ b/packages/processor/src/__tests__/opencode-sdk.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildOpenCodeConfig,
+  formatOpenCodeError,
   parseOpenCodeModel,
+  resolveOpenCodeAssistantText,
   resolveOpenCodeVariant,
 } from "../agents/opencode-sdk.js";
 
@@ -41,6 +43,54 @@ describe("OpenCodeAgentPlugin configuration", () => {
     expect(resolveOpenCodeVariant("google", "high")).toBe("high");
     expect(resolveOpenCodeVariant("custom")).toBeUndefined();
     expect(resolveOpenCodeVariant("custom", "medium")).toBe("medium");
+  });
+
+  it("preserves nested network error details", () => {
+    const cause = Object.assign(new Error("Headers Timeout Error"), {
+      code: "UND_ERR_HEADERS_TIMEOUT",
+    });
+    const error = new TypeError("fetch failed", { cause });
+
+    expect(formatOpenCodeError(error)).toBe(
+      "fetch failed: Headers Timeout Error (UND_ERR_HEADERS_TIMEOUT)",
+    );
+  });
+
+  it("uses plain text when a provider skips OpenCode's StructuredOutput tool", () => {
+    expect(
+      resolveOpenCodeAssistantText(
+        {
+          error: {
+            name: "StructuredOutputError",
+            data: {
+              message: "Model did not produce structured output",
+              retries: 0,
+            },
+          },
+        },
+        '[{"filePath":"src/a.ts","findings":[]}]',
+      ),
+    ).toEqual({
+      resultText: '[{"filePath":"src/a.ts","findings":[]}]',
+      recoveredStructuredText: true,
+    });
+  });
+
+  it("keeps a structured-output failure when the provider returned no text", () => {
+    expect(() =>
+      resolveOpenCodeAssistantText(
+        {
+          error: {
+            name: "StructuredOutputError",
+            data: {
+              message: "Model did not produce structured output",
+              retries: 0,
+            },
+          },
+        },
+        "",
+      ),
+    ).toThrow(/StructuredOutputError: Model did not produce structured output/);
   });
 
   it("enforces read-only tools, capped steps, and structured provider routing", () => {

--- a/packages/processor/src/__tests__/opencode-sdk.test.ts
+++ b/packages/processor/src/__tests__/opencode-sdk.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildOpenCodeConfig,
+  parseOpenCodeModel,
+  resolveOpenCodeVariant,
+} from "../agents/opencode-sdk.js";
+
+describe("OpenCodeAgentPlugin configuration", () => {
+  const savedEnv = {
+    ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+  };
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("parses provider/model while preserving slashes in the model id", () => {
+    expect(parseOpenCodeModel("openai/acme/gpt-sec")).toEqual({
+      providerID: "openai",
+      modelID: "acme/gpt-sec",
+    });
+  });
+
+  it("rejects a bare model name with an actionable example", () => {
+    expect(() => parseOpenCodeModel("claude-opus")).toThrow(/provider\/model/);
+    expect(() => parseOpenCodeModel("claude-opus")).toThrow(/anthropic\/claude-opus-4-8/);
+  });
+
+  it("maps the shared thinking dial to provider variants", () => {
+    expect(resolveOpenCodeVariant("anthropic", "xhigh")).toBe("max");
+    expect(resolveOpenCodeVariant("anthropic", "medium")).toBe("high");
+    expect(resolveOpenCodeVariant("openai", "low")).toBe("low");
+    expect(resolveOpenCodeVariant("google", "minimal")).toBe("low");
+    expect(resolveOpenCodeVariant("google", "high")).toBe("high");
+    expect(resolveOpenCodeVariant("custom")).toBeUndefined();
+    expect(resolveOpenCodeVariant("custom", "medium")).toBe("medium");
+  });
+
+  it("enforces read-only tools, capped steps, and structured provider routing", () => {
+    process.env.ANTHROPIC_AUTH_TOKEN = "do-not-inline-this-secret";
+    process.env.ANTHROPIC_BASE_URL = "https://ai-gateway.example";
+
+    const config = buildOpenCodeConfig({
+      model: "anthropic/claude-opus-4-8",
+      maxTurns: 42,
+      thinkingLevel: "xhigh",
+    });
+    const main = config.agent?.deepsec;
+
+    expect(config.default_agent).toBe("deepsec");
+    expect(config.share).toBe("disabled");
+    expect(config.autoupdate).toBe(false);
+    expect(config.tools).toMatchObject({
+      read: true,
+      glob: true,
+      grep: true,
+      list: true,
+      bash: false,
+      edit: false,
+      task: false,
+      webfetch: false,
+    });
+    expect(config.permission).toMatchObject({
+      "*": "deny",
+      read: "allow",
+      bash: "deny",
+      edit: "deny",
+      external_directory: "deny",
+    });
+    expect(main?.steps).toBe(42);
+    expect(main?.variant).toBe("max");
+    expect(main?.permission).toEqual(config.permission);
+    expect(config.provider?.anthropic?.options).toMatchObject({
+      apiKey: "{env:ANTHROPIC_AUTH_TOKEN}",
+      baseURL: "https://ai-gateway.example",
+    });
+    expect(JSON.stringify(config)).not.toContain("do-not-inline-this-secret");
+  });
+
+  it("supports a custom provider override without changing the model id", () => {
+    process.env.MARTIAN_API_KEY = "secret";
+    const config = buildOpenCodeConfig({
+      model: "openai/org/model",
+      aiProvider: "martian",
+      aiBaseUrl: "https://martian.example/v1",
+      aiApiKeyEnv: "MARTIAN_API_KEY",
+      aiHeaders: { "x-team": "security" },
+    });
+
+    expect(config.model).toBe("martian/org/model");
+    expect(config.provider?.martian).toEqual({
+      options: {
+        apiKey: "{env:MARTIAN_API_KEY}",
+        baseURL: "https://martian.example/v1",
+      },
+      headers: { "x-team": "security" },
+    });
+  });
+});

--- a/packages/processor/src/__tests__/registry.test.ts
+++ b/packages/processor/src/__tests__/registry.test.ts
@@ -56,7 +56,8 @@ describe("createDefaultAgentRegistry", () => {
     const registry = createDefaultAgentRegistry();
     expect(registry.get("claude-agent-sdk")).toBeDefined();
     expect(registry.get("codex")).toBeDefined();
+    expect(registry.get("opencode")).toBeDefined();
     expect(registry.get("pi")).toBeDefined();
-    expect(registry.types().sort()).toEqual(["claude-agent-sdk", "codex", "pi"]);
+    expect(registry.types().sort()).toEqual(["claude-agent-sdk", "codex", "opencode", "pi"]);
   });
 });

--- a/packages/processor/src/agents/opencode-sdk.ts
+++ b/packages/processor/src/agents/opencode-sdk.ts
@@ -251,6 +251,16 @@ export function resolveOpenCodeVariant(
   return explicit ? level : undefined;
 }
 
+export function shouldUseOpenCodeTextFormat(
+  providerID: string,
+  variant: string | undefined,
+  format: OutputFormat,
+): boolean {
+  return (
+    providerID.toLowerCase() === "anthropic" && Boolean(variant) && format.type === "json_schema"
+  );
+}
+
 function providerCredentialEnv(providerID: string, cfg: OpenCodeAgentConfig): string | undefined {
   if (cfg.aiApiKeyEnv) return cfg.aiApiKeyEnv;
   if (providerID === "anthropic") {
@@ -259,6 +269,12 @@ function providerCredentialEnv(providerID: string, cfg: OpenCodeAgentConfig): st
   }
   if (providerID === "openai" && process.env.OPENAI_API_KEY) return "OPENAI_API_KEY";
   return undefined;
+}
+
+function anthropicBaseUrlForOpenCode(baseURL: string | undefined): string | undefined {
+  if (!baseURL) return undefined;
+  const normalized = baseURL.replace(/\/+$/, "");
+  return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
 }
 
 export function buildOpenCodeConfig(config: Record<string, unknown>): Config {
@@ -272,7 +288,7 @@ export function buildOpenCodeConfig(config: Record<string, unknown>): Config {
   const baseURL =
     cfg.aiBaseUrl ??
     (providerID === "anthropic"
-      ? process.env.ANTHROPIC_BASE_URL
+      ? anthropicBaseUrlForOpenCode(process.env.ANTHROPIC_BASE_URL)
       : providerID === "openai"
         ? process.env.OPENAI_BASE_URL
         : undefined);
@@ -580,6 +596,7 @@ async function runPrompt(params: {
   const requested = parseOpenCodeModel(cfg.model ?? DEFAULT_MODEL);
   const providerID = cfg.aiProvider ?? requested.providerID;
   const variant = resolveOpenCodeVariant(providerID, cfg.thinkingLevel);
+  const useTextFormat = shouldUseOpenCodeTextFormat(providerID, variant, params.format);
   const startTime = Date.now();
 
   const response = await params.context.client.session.prompt(
@@ -590,7 +607,7 @@ async function runPrompt(params: {
       agent: params.agent ?? MAIN_AGENT,
       ...(variant ? { variant } : {}),
       tools: params.tools ?? READ_ONLY_TOOLS,
-      format: params.format,
+      format: useTextFormat ? TEXT_FORMAT : params.format,
       parts: [{ type: "text", text: params.prompt }],
     },
     { throwOnError: true, signal: params.context.controller.signal },
@@ -602,6 +619,13 @@ async function runPrompt(params: {
   const toolUseCount = parts.filter((part) => part.type === "tool").length;
   const completed = info.time.completed ?? Date.now();
   const progress = progressFromParts(parts);
+  if (useTextFormat) {
+    progress.push({
+      type: "thinking",
+      message:
+        "Anthropic thinking is incompatible with forced StructuredOutput; validating the text response",
+    });
+  }
   if (resolved.recoveredStructuredText) {
     progress.push({
       type: "thinking",

--- a/packages/processor/src/agents/opencode-sdk.ts
+++ b/packages/processor/src/agents/opencode-sdk.ts
@@ -3,12 +3,14 @@ import type { RefusalReport } from "@deepsec/core";
 import {
   type AssistantMessage,
   type Config,
-  createOpencode,
+  createOpencodeClient,
+  createOpencodeServer,
   type OpencodeClient,
   type OutputFormat,
   type Part,
   type PermissionConfig,
 } from "@opencode-ai/sdk/v2";
+import { Agent as UndiciAgent, fetch as undiciFetch } from "undici";
 import {
   backoff,
   buildInvestigateJsonRepairPrompt,
@@ -66,6 +68,7 @@ interface OpenCodeModelRef {
 interface OpenCodeRunContext {
   client: OpencodeClient;
   server: { close(): void };
+  dispatcher: UndiciAgent;
   sessionID: string;
   directory: string;
   controller: AbortController;
@@ -78,6 +81,11 @@ interface OpenCodePromptResult {
   turnCount: number;
   toolUseCount: number;
   progress: AgentProgress[];
+}
+
+interface OpenCodeResolvedText {
+  resultText: string;
+  recoveredStructuredText: boolean;
 }
 
 const INVESTIGATE_FORMAT: OutputFormat = {
@@ -157,31 +165,7 @@ const REVALIDATE_FORMAT: OutputFormat = {
   },
 };
 
-const REFUSAL_FORMAT: OutputFormat = {
-  type: "json_schema",
-  retryCount: 1,
-  schema: {
-    type: "object",
-    additionalProperties: false,
-    required: ["refused", "skipped"],
-    properties: {
-      refused: { type: "boolean" },
-      reason: { type: ["string", "null"] },
-      skipped: {
-        type: "array",
-        items: {
-          type: "object",
-          additionalProperties: false,
-          required: ["reason"],
-          properties: {
-            filePath: { type: "string" },
-            reason: { type: "string" },
-          },
-        },
-      },
-    },
-  },
-};
+const TEXT_FORMAT: OutputFormat = { type: "text" };
 
 const READ_ONLY_PERMISSION: PermissionConfig = {
   "*": "deny",
@@ -369,6 +353,28 @@ async function findFreePort(): Promise<number> {
   });
 }
 
+function createOpenCodeFetch(dispatcher: UndiciAgent): typeof globalThis.fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    // The generated SDK constructs Node's built-in Request, while the
+    // separately versioned Undici package has its own branded Request class.
+    // Normalize to primitives so fetch and its dispatcher always come from
+    // the same Undici version.
+    const request = input instanceof Request ? input : new Request(input, init);
+    const body =
+      request.method === "GET" || request.method === "HEAD"
+        ? undefined
+        : new Uint8Array(await request.arrayBuffer());
+    return (await undiciFetch(request.url, {
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      body,
+      redirect: request.redirect,
+      signal: request.signal,
+      dispatcher,
+    })) as unknown as Response;
+  }) as typeof globalThis.fetch;
+}
+
 async function createRunContext(params: {
   projectRoot: string;
   config: Record<string, unknown>;
@@ -384,23 +390,33 @@ async function createRunContext(params: {
   }
   const detachParentAbort = () => params.signal?.removeEventListener("abort", onParentAbort);
 
-  let server: { close(): void } | undefined;
+  let server: { url: string; close(): void } | undefined;
+  const dispatcher = new UndiciAgent({
+    // session.prompt is synchronous: OpenCode does not send response headers
+    // until the entire agent loop finishes. Undici's 300-second defaults turn
+    // valid long-running batches into a misleading `fetch failed`.
+    headersTimeout: 0,
+    bodyTimeout: 0,
+  });
   try {
     const port = await findFreePort();
-    const started = await createOpencode({
+    server = await createOpencodeServer({
       hostname: "127.0.0.1",
       port,
       timeout: 15_000,
       signal: controller.signal,
       config: buildOpenCodeConfig(params.config),
     });
-    server = started.server;
+    const client = createOpencodeClient({
+      baseUrl: server.url,
+      fetch: createOpenCodeFetch(dispatcher),
+    });
 
     const cfg = readConfig(params.config);
     const requested = parseOpenCodeModel(cfg.model ?? DEFAULT_MODEL);
     const providerID = cfg.aiProvider ?? requested.providerID;
     const variant = resolveOpenCodeVariant(providerID, cfg.thinkingLevel);
-    const created = await started.client.session.create(
+    const created = await client.session.create(
       {
         directory: params.projectRoot,
         title: params.title,
@@ -415,8 +431,9 @@ async function createRunContext(params: {
     );
 
     return {
-      client: started.client,
-      server: started.server,
+      client,
+      server,
+      dispatcher,
       sessionID: created.data.id,
       directory: params.projectRoot,
       controller,
@@ -424,6 +441,7 @@ async function createRunContext(params: {
     };
   } catch (err) {
     server?.close();
+    await dispatcher.close().catch(() => undefined);
     detachParentAbort();
     throw err;
   }
@@ -443,6 +461,7 @@ async function disposeRunContext(context: OpenCodeRunContext | undefined): Promi
     }
   }
   context.server.close();
+  await context.dispatcher.close();
 }
 
 function formatAssistantError(error: NonNullable<AssistantMessage["error"]>): string {
@@ -451,6 +470,58 @@ function formatAssistantError(error: NonNullable<AssistantMessage["error"]>): st
       ? String(error.data.message)
       : JSON.stringify(error.data);
   return `${error.name}: ${message}`;
+}
+
+function assistantError(error: NonNullable<AssistantMessage["error"]>): Error {
+  const result = new Error(formatAssistantError(error));
+  result.name = error.name;
+  return result;
+}
+
+function isStructuredOutputError(error: unknown): boolean {
+  return error instanceof Error && error.name === "StructuredOutputError";
+}
+
+export function formatOpenCodeError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+
+  const messages = [error.message];
+  let cause: unknown = error.cause;
+  const seen = new Set<unknown>([error]);
+  while (cause instanceof Error && !seen.has(cause)) {
+    seen.add(cause);
+    const code =
+      "code" in cause && typeof cause.code === "string" && cause.code ? ` (${cause.code})` : "";
+    const message = `${cause.message}${code}`;
+    if (!messages.includes(message)) messages.push(message);
+    cause = cause.cause;
+  }
+  return messages.join(": ");
+}
+
+export function resolveOpenCodeAssistantText(
+  info: Pick<AssistantMessage, "structured" | "error">,
+  partText: string,
+): OpenCodeResolvedText {
+  if (info.structured !== undefined) {
+    return {
+      resultText: JSON.stringify(info.structured),
+      recoveredStructuredText: false,
+    };
+  }
+  if (!info.error) {
+    return {
+      resultText: partText,
+      recoveredStructuredText: false,
+    };
+  }
+  if (info.error.name === "StructuredOutputError" && partText) {
+    return {
+      resultText: partText,
+      recoveredStructuredText: true,
+    };
+  }
+  throw assistantError(info.error);
 }
 
 function textFromParts(parts: Part[]): string {
@@ -526,19 +597,24 @@ async function runPrompt(params: {
   );
 
   const { info, parts } = response.data;
-  if (info.error) throw new Error(formatAssistantError(info.error));
-
-  const resultText =
-    info.structured !== undefined ? JSON.stringify(info.structured) : textFromParts(parts);
+  const resolved = resolveOpenCodeAssistantText(info, textFromParts(parts));
   const turnCount = Math.max(1, parts.filter((part) => part.type === "step-finish").length);
   const toolUseCount = parts.filter((part) => part.type === "tool").length;
   const completed = info.time.completed ?? Date.now();
+  const progress = progressFromParts(parts);
+  if (resolved.recoveredStructuredText) {
+    progress.push({
+      type: "thinking",
+      message:
+        "OpenCode returned text instead of calling StructuredOutput; validating the text response",
+    });
+  }
 
   return {
-    resultText,
+    resultText: resolved.resultText,
     turnCount,
     toolUseCount,
-    progress: progressFromParts(parts),
+    progress,
     meta: {
       durationApiMs: Math.max(0, completed - info.time.created),
       numTurns: turnCount,
@@ -558,7 +634,6 @@ async function runPrompt(params: {
 async function runToollessFollowUp(params: {
   context: OpenCodeRunContext | undefined;
   prompt: string;
-  format: OutputFormat;
   config: Record<string, unknown>;
 }): Promise<string | undefined> {
   if (!params.context) return undefined;
@@ -566,7 +641,7 @@ async function runToollessFollowUp(params: {
     const result = await runPrompt({
       context: params.context,
       prompt: params.prompt,
-      format: params.format,
+      format: TEXT_FORMAT,
       config: params.config,
       tools: NO_TOOLS,
       agent: JSON_AGENT,
@@ -584,7 +659,6 @@ async function runRefusalFollowUp(params: {
   const raw = await runToollessFollowUp({
     ...params,
     prompt: REFUSAL_FOLLOWUP_PROMPT,
-    format: REFUSAL_FORMAT,
   });
   return raw === undefined ? undefined : parseRefusalReport(raw);
 }
@@ -603,9 +677,11 @@ export class OpenCodeAgentPlugin implements AgentPlugin {
     let sdkMeta: Partial<BatchMeta> = {};
     let turnCount = 0;
     let toolUseCount = 0;
+    let attempts = 0;
 
     try {
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        attempts = attempt;
         if (attempt > 1) {
           yield {
             type: "thinking",
@@ -645,8 +721,23 @@ export class OpenCodeAgentPlugin implements AgentPlugin {
           toolUseCount = run.toolUseCount;
           for (const progress of run.progress) yield progress;
         } catch (err) {
-          lastError = err instanceof Error ? err.message : String(err);
-          yield { type: "error", message: `OpenCode SDK error: ${lastError.slice(0, 300)}` };
+          if (isStructuredOutputError(err)) {
+            yield {
+              type: "thinking",
+              message:
+                "OpenCode did not call StructuredOutput; requesting a tool-free JSON finalization",
+            };
+            const recovered = await runToollessFollowUp({
+              context,
+              prompt: buildInvestigateJsonRepairPrompt(batch),
+              config,
+            });
+            if (recovered) resultText = recovered;
+          }
+          if (!resultText) {
+            lastError = formatOpenCodeError(err);
+            yield { type: "error", message: `OpenCode SDK error: ${lastError.slice(0, 300)}` };
+          }
         }
 
         if (resultText) break;
@@ -658,7 +749,7 @@ export class OpenCodeAgentPlugin implements AgentPlugin {
 
       if (!resultText) {
         throw new Error(
-          `OpenCode produced no investigation result after ${MAX_ATTEMPTS} attempt(s). ` +
+          `OpenCode produced no investigation result after ${attempts} attempt(s). ` +
             `Last error: ${lastError || "(none captured)"}.`,
         );
       }
@@ -674,7 +765,6 @@ export class OpenCodeAgentPlugin implements AgentPlugin {
         const repairText = await runToollessFollowUp({
           context,
           prompt: buildInvestigateJsonRepairPrompt(batch),
-          format: INVESTIGATE_FORMAT,
           config,
         });
         if (repairText === undefined) {
@@ -753,9 +843,11 @@ export class OpenCodeAgentPlugin implements AgentPlugin {
     let sdkMeta: Partial<BatchMeta> = {};
     let turnCount = 0;
     let toolUseCount = 0;
+    let attempts = 0;
 
     try {
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        attempts = attempt;
         if (attempt > 1) {
           yield {
             type: "thinking",
@@ -795,8 +887,23 @@ export class OpenCodeAgentPlugin implements AgentPlugin {
           toolUseCount = run.toolUseCount;
           for (const progress of run.progress) yield progress;
         } catch (err) {
-          lastError = err instanceof Error ? err.message : String(err);
-          yield { type: "error", message: `OpenCode SDK error: ${lastError.slice(0, 300)}` };
+          if (isStructuredOutputError(err)) {
+            yield {
+              type: "thinking",
+              message:
+                "OpenCode did not call StructuredOutput; requesting a tool-free JSON finalization",
+            };
+            const recovered = await runToollessFollowUp({
+              context,
+              prompt: buildRevalidateJsonRepairPrompt(),
+              config,
+            });
+            if (recovered) resultText = recovered;
+          }
+          if (!resultText) {
+            lastError = formatOpenCodeError(err);
+            yield { type: "error", message: `OpenCode SDK error: ${lastError.slice(0, 300)}` };
+          }
         }
 
         if (resultText) break;
@@ -808,7 +915,7 @@ export class OpenCodeAgentPlugin implements AgentPlugin {
 
       if (!resultText) {
         throw new Error(
-          `OpenCode produced no revalidation result after ${MAX_ATTEMPTS} attempt(s). ` +
+          `OpenCode produced no revalidation result after ${attempts} attempt(s). ` +
             `Last error: ${lastError || "(none captured)"}.`,
         );
       }
@@ -824,7 +931,6 @@ export class OpenCodeAgentPlugin implements AgentPlugin {
         const repairText = await runToollessFollowUp({
           context,
           prompt: buildRevalidateJsonRepairPrompt(),
-          format: REVALIDATE_FORMAT,
           config,
         });
         if (repairText === undefined) {

--- a/packages/processor/src/agents/opencode-sdk.ts
+++ b/packages/processor/src/agents/opencode-sdk.ts
@@ -1,0 +1,882 @@
+import net from "node:net";
+import type { RefusalReport } from "@deepsec/core";
+import {
+  type AssistantMessage,
+  type Config,
+  createOpencode,
+  type OpencodeClient,
+  type OutputFormat,
+  type Part,
+  type PermissionConfig,
+} from "@opencode-ai/sdk/v2";
+import {
+  backoff,
+  buildInvestigateJsonRepairPrompt,
+  buildInvestigatePrompt,
+  buildRevalidateJsonRepairPrompt,
+  buildRevalidatePrompt,
+  classifyQuotaError,
+  formatJsonRepairFailureDebugText,
+  isTransientError,
+  jsonRepairFailureError,
+  MAX_ATTEMPTS,
+  parseInvestigateResults,
+  parseRefusalReport,
+  parseRevalidateVerdicts,
+  QuotaExhaustedError,
+  REFUSAL_FOLLOWUP_PROMPT,
+  writeParseFailureDebug,
+} from "./shared.js";
+import type {
+  AgentPlugin,
+  AgentProgress,
+  BatchMeta,
+  InvestigateOutput,
+  InvestigateParams,
+  InvestigateResult,
+  RevalidateOutput,
+  RevalidateParams,
+  RevalidateVerdict,
+} from "./types.js";
+
+const DEFAULT_MODEL = "anthropic/claude-opus-4-8";
+const DEFAULT_THINKING_LEVEL = "xhigh";
+const DEFAULT_MAX_TURNS = 150;
+const MAIN_AGENT = "deepsec";
+const JSON_AGENT = "deepsec-json";
+
+const DEEPSEC_SYSTEM_NOTE =
+  "You are running inside the OpenCode harness for deepsec. Perform static source inspection only. Do not run the target application, execute shell commands, send network requests, modify files, or attempt exploitation. Return only the requested JSON value.";
+
+interface OpenCodeAgentConfig {
+  model?: string;
+  maxTurns?: number;
+  thinkingLevel?: string;
+  aiProvider?: string;
+  aiBaseUrl?: string;
+  aiApiKeyEnv?: string;
+  aiHeaders?: Record<string, string>;
+}
+
+interface OpenCodeModelRef {
+  providerID: string;
+  modelID: string;
+}
+
+interface OpenCodeRunContext {
+  client: OpencodeClient;
+  server: { close(): void };
+  sessionID: string;
+  directory: string;
+  controller: AbortController;
+  detachParentAbort: () => void;
+}
+
+interface OpenCodePromptResult {
+  resultText: string;
+  meta: Partial<BatchMeta>;
+  turnCount: number;
+  toolUseCount: number;
+  progress: AgentProgress[];
+}
+
+const INVESTIGATE_FORMAT: OutputFormat = {
+  type: "json_schema",
+  retryCount: 2,
+  schema: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: ["filePath", "findings"],
+      properties: {
+        filePath: { type: "string" },
+        findings: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "severity",
+              "vulnSlug",
+              "title",
+              "description",
+              "lineNumbers",
+              "recommendation",
+              "confidence",
+            ],
+            properties: {
+              severity: {
+                type: "string",
+                enum: ["CRITICAL", "HIGH", "MEDIUM", "HIGH_BUG", "BUG"],
+              },
+              vulnSlug: { type: "string" },
+              title: { type: "string" },
+              description: { type: "string" },
+              lineNumbers: {
+                type: "array",
+                items: { type: "integer" },
+              },
+              recommendation: { type: "string" },
+              confidence: {
+                type: "string",
+                enum: ["high", "medium", "low"],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const REVALIDATE_FORMAT: OutputFormat = {
+  type: "json_schema",
+  retryCount: 2,
+  schema: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: ["filePath", "title", "verdict", "reasoning"],
+      properties: {
+        filePath: { type: "string" },
+        title: { type: "string" },
+        verdict: {
+          type: "string",
+          enum: ["true-positive", "false-positive", "fixed", "uncertain", "duplicate"],
+        },
+        reasoning: { type: "string" },
+        adjustedSeverity: {
+          type: "string",
+          enum: ["CRITICAL", "HIGH", "MEDIUM", "HIGH_BUG", "BUG"],
+        },
+        duplicateOf: { type: "string" },
+      },
+    },
+  },
+};
+
+const REFUSAL_FORMAT: OutputFormat = {
+  type: "json_schema",
+  retryCount: 1,
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["refused", "skipped"],
+    properties: {
+      refused: { type: "boolean" },
+      reason: { type: ["string", "null"] },
+      skipped: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["reason"],
+          properties: {
+            filePath: { type: "string" },
+            reason: { type: "string" },
+          },
+        },
+      },
+    },
+  },
+};
+
+const READ_ONLY_PERMISSION: PermissionConfig = {
+  "*": "deny",
+  read: "allow",
+  glob: "allow",
+  grep: "allow",
+  list: "allow",
+  external_directory: "deny",
+  bash: "deny",
+  edit: "deny",
+  task: "deny",
+  todowrite: "deny",
+  question: "deny",
+  webfetch: "deny",
+  websearch: "deny",
+  lsp: "deny",
+  skill: "deny",
+  doom_loop: "allow",
+};
+
+const READ_ONLY_TOOLS: Record<string, boolean> = {
+  read: true,
+  glob: true,
+  grep: true,
+  list: true,
+  bash: false,
+  edit: false,
+  write: false,
+  patch: false,
+  task: false,
+  todowrite: false,
+  question: false,
+  webfetch: false,
+  websearch: false,
+  lsp: false,
+  skill: false,
+};
+
+const NO_TOOLS = Object.fromEntries(Object.keys(READ_ONLY_TOOLS).map((name) => [name, false]));
+
+function readConfig(config: Record<string, unknown>): OpenCodeAgentConfig {
+  return {
+    model: typeof config.model === "string" ? config.model : undefined,
+    maxTurns: typeof config.maxTurns === "number" ? config.maxTurns : undefined,
+    thinkingLevel: typeof config.thinkingLevel === "string" ? config.thinkingLevel : undefined,
+    aiProvider: typeof config.aiProvider === "string" ? config.aiProvider : undefined,
+    aiBaseUrl: typeof config.aiBaseUrl === "string" ? config.aiBaseUrl : undefined,
+    aiApiKeyEnv: typeof config.aiApiKeyEnv === "string" ? config.aiApiKeyEnv : undefined,
+    aiHeaders:
+      config.aiHeaders && typeof config.aiHeaders === "object" && !Array.isArray(config.aiHeaders)
+        ? (config.aiHeaders as Record<string, string>)
+        : undefined,
+  };
+}
+
+export function parseOpenCodeModel(model: string): OpenCodeModelRef {
+  const slash = model.indexOf("/");
+  if (slash <= 0 || slash === model.length - 1) {
+    throw new Error(
+      `OpenCode model must use provider/model format, got "${model}". ` +
+        `For example: ${DEFAULT_MODEL}.`,
+    );
+  }
+  return {
+    providerID: model.slice(0, slash),
+    modelID: model.slice(slash + 1),
+  };
+}
+
+export function resolveOpenCodeVariant(
+  providerID: string,
+  thinkingLevel?: string,
+): string | undefined {
+  const explicit = thinkingLevel !== undefined;
+  const level = thinkingLevel ?? DEFAULT_THINKING_LEVEL;
+  const provider = providerID.toLowerCase();
+
+  if (provider === "anthropic") return level === "xhigh" ? "max" : "high";
+  if (provider === "openai") return level;
+  if (provider === "google") {
+    return level === "minimal" || level === "low" ? "low" : "high";
+  }
+  return explicit ? level : undefined;
+}
+
+function providerCredentialEnv(providerID: string, cfg: OpenCodeAgentConfig): string | undefined {
+  if (cfg.aiApiKeyEnv) return cfg.aiApiKeyEnv;
+  if (providerID === "anthropic") {
+    if (process.env.ANTHROPIC_AUTH_TOKEN) return "ANTHROPIC_AUTH_TOKEN";
+    if (process.env.ANTHROPIC_API_KEY) return "ANTHROPIC_API_KEY";
+  }
+  if (providerID === "openai" && process.env.OPENAI_API_KEY) return "OPENAI_API_KEY";
+  return undefined;
+}
+
+export function buildOpenCodeConfig(config: Record<string, unknown>): Config {
+  const cfg = readConfig(config);
+  const requested = parseOpenCodeModel(cfg.model ?? DEFAULT_MODEL);
+  const providerID = cfg.aiProvider ?? requested.providerID;
+  const model = `${providerID}/${requested.modelID}`;
+  const variant = resolveOpenCodeVariant(providerID, cfg.thinkingLevel);
+  const maxTurns = cfg.maxTurns ?? DEFAULT_MAX_TURNS;
+  const credentialEnv = providerCredentialEnv(providerID, cfg);
+  const baseURL =
+    cfg.aiBaseUrl ??
+    (providerID === "anthropic"
+      ? process.env.ANTHROPIC_BASE_URL
+      : providerID === "openai"
+        ? process.env.OPENAI_BASE_URL
+        : undefined);
+
+  const providerOptions: Record<string, unknown> = {};
+  if (credentialEnv) providerOptions.apiKey = `{env:${credentialEnv}}`;
+  if (baseURL) providerOptions.baseURL = baseURL;
+
+  const provider =
+    Object.keys(providerOptions).length > 0 || cfg.aiHeaders
+      ? {
+          [providerID]: {
+            ...(Object.keys(providerOptions).length > 0 ? { options: providerOptions } : {}),
+            ...(cfg.aiHeaders ? { headers: cfg.aiHeaders } : {}),
+          },
+        }
+      : undefined;
+
+  return {
+    logLevel: "WARN",
+    autoupdate: false,
+    share: "disabled",
+    snapshot: false,
+    formatter: false,
+    lsp: false,
+    plugin: [],
+    instructions: [],
+    mcp: {},
+    model,
+    default_agent: MAIN_AGENT,
+    permission: READ_ONLY_PERMISSION,
+    tools: READ_ONLY_TOOLS,
+    ...(provider ? { provider } : {}),
+    agent: {
+      [MAIN_AGENT]: {
+        description: "Read-only static security analysis for deepsec",
+        mode: "primary",
+        model,
+        ...(variant ? { variant } : {}),
+        steps: maxTurns,
+        prompt: DEEPSEC_SYSTEM_NOTE,
+        tools: READ_ONLY_TOOLS,
+        permission: READ_ONLY_PERMISSION,
+      },
+      [JSON_AGENT]: {
+        description: "Tool-free JSON formatting follow-up for deepsec",
+        mode: "primary",
+        hidden: true,
+        model,
+        ...(variant ? { variant } : {}),
+        steps: 1,
+        prompt: "Return only the JSON value requested by the user. Do not use tools.",
+        tools: NO_TOOLS,
+        permission: "deny",
+      },
+    },
+  };
+}
+
+async function findFreePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("OpenCode could not allocate a local server port"));
+        return;
+      }
+      const port = address.port;
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve(port);
+      });
+    });
+  });
+}
+
+async function createRunContext(params: {
+  projectRoot: string;
+  config: Record<string, unknown>;
+  signal?: AbortSignal;
+  title: string;
+}): Promise<OpenCodeRunContext> {
+  const controller = new AbortController();
+  const onParentAbort = () =>
+    controller.abort(params.signal?.reason ?? new Error("OpenCode run aborted"));
+  if (params.signal) {
+    if (params.signal.aborted) onParentAbort();
+    else params.signal.addEventListener("abort", onParentAbort, { once: true });
+  }
+  const detachParentAbort = () => params.signal?.removeEventListener("abort", onParentAbort);
+
+  let server: { close(): void } | undefined;
+  try {
+    const port = await findFreePort();
+    const started = await createOpencode({
+      hostname: "127.0.0.1",
+      port,
+      timeout: 15_000,
+      signal: controller.signal,
+      config: buildOpenCodeConfig(params.config),
+    });
+    server = started.server;
+
+    const cfg = readConfig(params.config);
+    const requested = parseOpenCodeModel(cfg.model ?? DEFAULT_MODEL);
+    const providerID = cfg.aiProvider ?? requested.providerID;
+    const variant = resolveOpenCodeVariant(providerID, cfg.thinkingLevel);
+    const created = await started.client.session.create(
+      {
+        directory: params.projectRoot,
+        title: params.title,
+        agent: MAIN_AGENT,
+        model: {
+          providerID,
+          id: requested.modelID,
+          ...(variant ? { variant } : {}),
+        },
+      },
+      { throwOnError: true, signal: controller.signal },
+    );
+
+    return {
+      client: started.client,
+      server: started.server,
+      sessionID: created.data.id,
+      directory: params.projectRoot,
+      controller,
+      detachParentAbort,
+    };
+  } catch (err) {
+    server?.close();
+    detachParentAbort();
+    throw err;
+  }
+}
+
+async function disposeRunContext(context: OpenCodeRunContext | undefined): Promise<void> {
+  if (!context) return;
+  context.detachParentAbort();
+  if (!context.controller.signal.aborted) {
+    try {
+      await context.client.session.delete(
+        { sessionID: context.sessionID, directory: context.directory },
+        { throwOnError: true },
+      );
+    } catch {
+      // Best effort: server shutdown is the authoritative cleanup.
+    }
+  }
+  context.server.close();
+}
+
+function formatAssistantError(error: NonNullable<AssistantMessage["error"]>): string {
+  const message =
+    error.data && typeof error.data === "object" && "message" in error.data
+      ? String(error.data.message)
+      : JSON.stringify(error.data);
+  return `${error.name}: ${message}`;
+}
+
+function textFromParts(parts: Part[]): string {
+  const text: string[] = [];
+  for (const part of parts) {
+    if (part.type === "text" && !part.ignored) text.push(part.text);
+  }
+  return text.join("\n").trim();
+}
+
+function shortToolTarget(part: Extract<Part, { type: "tool" }>): string | undefined {
+  const input = part.state.input;
+  for (const key of ["path", "filePath", "file_path", "pattern", "query"]) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.split("/").slice(-3).join("/");
+    }
+  }
+  return undefined;
+}
+
+function progressFromParts(parts: Part[]): AgentProgress[] {
+  const progress: AgentProgress[] = [];
+  for (const part of parts) {
+    if (part.type === "tool") {
+      const target = shortToolTarget(part);
+      progress.push({
+        type: part.state.status === "error" ? "error" : "tool_use",
+        message:
+          part.state.status === "error"
+            ? `OpenCode ${part.tool} error${target ? `: ${target}` : ""}: ${part.state.error.slice(0, 300)}`
+            : `${part.tool}${target ? `: ${target}` : ""}`,
+        candidateFile: target,
+      });
+    } else if (part.type === "retry") {
+      progress.push({
+        type: "thinking",
+        message: `OpenCode provider retry ${part.attempt}: ${part.error.data.message.slice(0, 200)}`,
+      });
+    } else if (part.type === "compaction") {
+      progress.push({ type: "thinking", message: "OpenCode compacted conversation context" });
+    }
+  }
+  return progress;
+}
+
+async function runPrompt(params: {
+  context: OpenCodeRunContext;
+  prompt: string;
+  format: OutputFormat;
+  config: Record<string, unknown>;
+  tools?: Record<string, boolean>;
+  agent?: string;
+}): Promise<OpenCodePromptResult> {
+  const cfg = readConfig(params.config);
+  const requested = parseOpenCodeModel(cfg.model ?? DEFAULT_MODEL);
+  const providerID = cfg.aiProvider ?? requested.providerID;
+  const variant = resolveOpenCodeVariant(providerID, cfg.thinkingLevel);
+  const startTime = Date.now();
+
+  const response = await params.context.client.session.prompt(
+    {
+      sessionID: params.context.sessionID,
+      directory: params.context.directory,
+      model: { providerID, modelID: requested.modelID },
+      agent: params.agent ?? MAIN_AGENT,
+      ...(variant ? { variant } : {}),
+      tools: params.tools ?? READ_ONLY_TOOLS,
+      format: params.format,
+      parts: [{ type: "text", text: params.prompt }],
+    },
+    { throwOnError: true, signal: params.context.controller.signal },
+  );
+
+  const { info, parts } = response.data;
+  if (info.error) throw new Error(formatAssistantError(info.error));
+
+  const resultText =
+    info.structured !== undefined ? JSON.stringify(info.structured) : textFromParts(parts);
+  const turnCount = Math.max(1, parts.filter((part) => part.type === "step-finish").length);
+  const toolUseCount = parts.filter((part) => part.type === "tool").length;
+  const completed = info.time.completed ?? Date.now();
+
+  return {
+    resultText,
+    turnCount,
+    toolUseCount,
+    progress: progressFromParts(parts),
+    meta: {
+      durationApiMs: Math.max(0, completed - info.time.created),
+      numTurns: turnCount,
+      costUsd: info.cost,
+      agentSessionId: info.sessionID,
+      usage: {
+        inputTokens: info.tokens.input,
+        outputTokens: info.tokens.output,
+        cacheReadInputTokens: info.tokens.cache.read,
+        cacheCreationInputTokens: info.tokens.cache.write,
+      },
+      durationMs: Date.now() - startTime,
+    },
+  };
+}
+
+async function runToollessFollowUp(params: {
+  context: OpenCodeRunContext | undefined;
+  prompt: string;
+  format: OutputFormat;
+  config: Record<string, unknown>;
+}): Promise<string | undefined> {
+  if (!params.context) return undefined;
+  try {
+    const result = await runPrompt({
+      context: params.context,
+      prompt: params.prompt,
+      format: params.format,
+      config: params.config,
+      tools: NO_TOOLS,
+      agent: JSON_AGENT,
+    });
+    return result.resultText;
+  } catch {
+    return undefined;
+  }
+}
+
+async function runRefusalFollowUp(params: {
+  context: OpenCodeRunContext | undefined;
+  config: Record<string, unknown>;
+}): Promise<RefusalReport | undefined> {
+  const raw = await runToollessFollowUp({
+    ...params,
+    prompt: REFUSAL_FOLLOWUP_PROMPT,
+    format: REFUSAL_FORMAT,
+  });
+  return raw === undefined ? undefined : parseRefusalReport(raw);
+}
+
+export class OpenCodeAgentPlugin implements AgentPlugin {
+  type = "opencode";
+
+  async *investigate(params: InvestigateParams): AsyncGenerator<AgentProgress, InvestigateOutput> {
+    const { batch, projectRoot, promptTemplate, projectInfo, config, signal, projectId } = params;
+    const prompt = buildInvestigatePrompt({ promptTemplate, projectInfo, batch });
+    const model = readConfig(config).model ?? DEFAULT_MODEL;
+    const startTime = Date.now();
+    let context: OpenCodeRunContext | undefined;
+    let resultText = "";
+    let lastError = "";
+    let sdkMeta: Partial<BatchMeta> = {};
+    let turnCount = 0;
+    let toolUseCount = 0;
+
+    try {
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        if (attempt > 1) {
+          yield {
+            type: "thinking",
+            message: `Retrying OpenCode batch after transient error (attempt ${attempt}/${MAX_ATTEMPTS}): ${lastError.slice(0, 200)}`,
+          };
+          await disposeRunContext(context);
+          context = undefined;
+          resultText = "";
+          lastError = "";
+          sdkMeta = {};
+          turnCount = 0;
+          toolUseCount = 0;
+        }
+
+        try {
+          context = await createRunContext({
+            projectRoot,
+            config,
+            signal,
+            title: `deepsec investigate (${batch.length} files)`,
+          });
+          if (attempt === 1) {
+            yield {
+              type: "started",
+              message: `Investigating ${batch.length} file(s) with OpenCode (${model})`,
+            };
+          }
+          const run = await runPrompt({
+            context,
+            prompt,
+            format: INVESTIGATE_FORMAT,
+            config,
+          });
+          resultText = run.resultText;
+          sdkMeta = run.meta;
+          turnCount = run.turnCount;
+          toolUseCount = run.toolUseCount;
+          for (const progress of run.progress) yield progress;
+        } catch (err) {
+          lastError = err instanceof Error ? err.message : String(err);
+          yield { type: "error", message: `OpenCode SDK error: ${lastError.slice(0, 300)}` };
+        }
+
+        if (resultText) break;
+        const quotaSource = classifyQuotaError(lastError);
+        if (quotaSource) throw new QuotaExhaustedError(quotaSource, lastError);
+        if (attempt >= MAX_ATTEMPTS || !isTransientError(lastError)) break;
+        await backoff(attempt);
+      }
+
+      if (!resultText) {
+        throw new Error(
+          `OpenCode produced no investigation result after ${MAX_ATTEMPTS} attempt(s). ` +
+            `Last error: ${lastError || "(none captured)"}.`,
+        );
+      }
+
+      let results: InvestigateResult[];
+      try {
+        results = parseInvestigateResults(resultText, batch);
+      } catch (err) {
+        yield {
+          type: "thinking",
+          message: "OpenCode returned non-JSON investigation output; requesting JSON-only repair",
+        };
+        const repairText = await runToollessFollowUp({
+          context,
+          prompt: buildInvestigateJsonRepairPrompt(batch),
+          format: INVESTIGATE_FORMAT,
+          config,
+        });
+        if (repairText === undefined) {
+          writeParseFailureDebug({
+            projectId,
+            phase: "investigate",
+            agentType: this.type,
+            resultText,
+            error: err,
+            batch,
+          });
+          throw err;
+        }
+        try {
+          results = parseInvestigateResults(repairText, batch);
+          resultText = repairText;
+          yield { type: "thinking", message: "OpenCode JSON repair succeeded" };
+        } catch (repairErr) {
+          const combinedError = jsonRepairFailureError(err, repairErr);
+          writeParseFailureDebug({
+            projectId,
+            phase: "investigate",
+            agentType: this.type,
+            resultText: formatJsonRepairFailureDebugText(resultText, repairText),
+            error: combinedError,
+            batch,
+          });
+          throw combinedError;
+        }
+      }
+
+      const refusal = await runRefusalFollowUp({ context, config });
+      if (refusal?.refused) {
+        yield {
+          type: "thinking",
+          message: `Refusal detected: ${refusal.reason ?? "see raw"}`,
+        };
+      }
+
+      const durationMs = Date.now() - startTime;
+      const costStr = sdkMeta.costUsd != null ? ` $${sdkMeta.costUsd.toFixed(3)}` : "";
+      const tokensStr = sdkMeta.usage
+        ? ` ${sdkMeta.usage.inputTokens + sdkMeta.usage.outputTokens} tokens`
+        : "";
+      yield {
+        type: "complete",
+        message: `Investigation complete (${(durationMs / 1000).toFixed(1)}s, ${turnCount} turns, ${toolUseCount} tool calls${costStr}${tokensStr}${refusal?.refused ? " refusal" : ""})`,
+      };
+
+      return {
+        results,
+        meta: {
+          durationMs,
+          ...sdkMeta,
+          refusal,
+        },
+      };
+    } finally {
+      await disposeRunContext(context);
+    }
+  }
+
+  async *revalidate(params: RevalidateParams): AsyncGenerator<AgentProgress, RevalidateOutput> {
+    const { batch, projectRoot, projectInfo, config, force = false, signal, projectId } = params;
+    const { prompt, totalFindings } = buildRevalidatePrompt({
+      batch,
+      projectRoot,
+      projectInfo,
+      force,
+    });
+    const model = readConfig(config).model ?? DEFAULT_MODEL;
+    const startTime = Date.now();
+    let context: OpenCodeRunContext | undefined;
+    let resultText = "";
+    let lastError = "";
+    let sdkMeta: Partial<BatchMeta> = {};
+    let turnCount = 0;
+    let toolUseCount = 0;
+
+    try {
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        if (attempt > 1) {
+          yield {
+            type: "thinking",
+            message: `Retrying OpenCode revalidation after transient error (attempt ${attempt}/${MAX_ATTEMPTS}): ${lastError.slice(0, 200)}`,
+          };
+          await disposeRunContext(context);
+          context = undefined;
+          resultText = "";
+          lastError = "";
+          sdkMeta = {};
+          turnCount = 0;
+          toolUseCount = 0;
+        }
+
+        try {
+          context = await createRunContext({
+            projectRoot,
+            config,
+            signal,
+            title: `deepsec revalidate (${totalFindings} findings)`,
+          });
+          if (attempt === 1) {
+            yield {
+              type: "started",
+              message: `Revalidating ${totalFindings} finding(s) across ${batch.length} file(s) with OpenCode (${model})`,
+            };
+          }
+          const run = await runPrompt({
+            context,
+            prompt,
+            format: REVALIDATE_FORMAT,
+            config,
+          });
+          resultText = run.resultText;
+          sdkMeta = run.meta;
+          turnCount = run.turnCount;
+          toolUseCount = run.toolUseCount;
+          for (const progress of run.progress) yield progress;
+        } catch (err) {
+          lastError = err instanceof Error ? err.message : String(err);
+          yield { type: "error", message: `OpenCode SDK error: ${lastError.slice(0, 300)}` };
+        }
+
+        if (resultText) break;
+        const quotaSource = classifyQuotaError(lastError);
+        if (quotaSource) throw new QuotaExhaustedError(quotaSource, lastError);
+        if (attempt >= MAX_ATTEMPTS || !isTransientError(lastError)) break;
+        await backoff(attempt);
+      }
+
+      if (!resultText) {
+        throw new Error(
+          `OpenCode produced no revalidation result after ${MAX_ATTEMPTS} attempt(s). ` +
+            `Last error: ${lastError || "(none captured)"}.`,
+        );
+      }
+
+      let verdicts: RevalidateVerdict[];
+      try {
+        verdicts = parseRevalidateVerdicts(resultText);
+      } catch (err) {
+        yield {
+          type: "thinking",
+          message: "OpenCode returned non-JSON revalidation output; requesting JSON-only repair",
+        };
+        const repairText = await runToollessFollowUp({
+          context,
+          prompt: buildRevalidateJsonRepairPrompt(),
+          format: REVALIDATE_FORMAT,
+          config,
+        });
+        if (repairText === undefined) {
+          writeParseFailureDebug({
+            projectId,
+            phase: "revalidate",
+            agentType: this.type,
+            resultText,
+            error: err,
+            batch,
+          });
+          throw err;
+        }
+        try {
+          verdicts = parseRevalidateVerdicts(repairText);
+          resultText = repairText;
+          yield { type: "thinking", message: "OpenCode JSON repair succeeded" };
+        } catch (repairErr) {
+          const combinedError = jsonRepairFailureError(err, repairErr);
+          writeParseFailureDebug({
+            projectId,
+            phase: "revalidate",
+            agentType: this.type,
+            resultText: formatJsonRepairFailureDebugText(resultText, repairText),
+            error: combinedError,
+            batch,
+          });
+          throw combinedError;
+        }
+      }
+
+      const refusal = await runRefusalFollowUp({ context, config });
+      if (refusal?.refused) {
+        yield {
+          type: "thinking",
+          message: `Refusal detected during revalidation: ${refusal.reason ?? "see raw"}`,
+        };
+      }
+
+      const durationMs = Date.now() - startTime;
+      const costStr = sdkMeta.costUsd != null ? ` $${sdkMeta.costUsd.toFixed(3)}` : "";
+      yield {
+        type: "complete",
+        message: `Revalidation complete (${(durationMs / 1000).toFixed(1)}s, ${turnCount} turns, ${toolUseCount} tool calls${costStr}, ${verdicts.length} verdicts${refusal?.refused ? " refusal" : ""})`,
+      };
+
+      return {
+        verdicts,
+        meta: { durationMs, ...sdkMeta, refusal },
+      };
+    } finally {
+      await disposeRunContext(context);
+    }
+  }
+}

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -21,6 +21,7 @@ import {
 import { noiseScore, readTechJson } from "@deepsec/scanner";
 import { ClaudeAgentSdkPlugin } from "./agents/claude-agent-sdk.js";
 import { CodexAgentSdkPlugin } from "./agents/codex-sdk.js";
+import { OpenCodeAgentPlugin } from "./agents/opencode-sdk.js";
 import { PiAgentPlugin } from "./agents/pi-sdk.js";
 import { AgentRegistry } from "./agents/registry.js";
 import { QuotaExhaustedError, type QuotaSource } from "./agents/shared.js";
@@ -37,6 +38,7 @@ import { languagesForBatch } from "./prompt/file-language.js";
 
 export { ClaudeAgentSdkPlugin } from "./agents/claude-agent-sdk.js";
 export { CodexAgentSdkPlugin } from "./agents/codex-sdk.js";
+export { OpenCodeAgentPlugin } from "./agents/opencode-sdk.js";
 export { PiAgentPlugin } from "./agents/pi-sdk.js";
 export { AgentRegistry } from "./agents/registry.js";
 export {
@@ -63,6 +65,7 @@ export function createDefaultAgentRegistry(): AgentRegistry {
   const registry = new AgentRegistry();
   registry.register(new ClaudeAgentSdkPlugin());
   registry.register(new CodexAgentSdkPlugin());
+  registry.register(new OpenCodeAgentPlugin());
   registry.register(new PiAgentPlugin());
   // Plugins can contribute additional backends via `agents: []` in their
   // DeepsecPlugin export. The shape is validated by AgentRegistry at use.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       tar:
         specifier: ^7.5.20
         version: 7.5.20
+      undici:
+        specifier: ^8.5.0
+        version: 8.5.0
     devDependencies:
       '@deepsec/core':
         specifier: workspace:*
@@ -127,6 +130,9 @@ importers:
       jsonrepair:
         specifier: ^3.14.0
         version: 3.14.0
+      undici:
+        specifier: ^8.5.0
+        version: 8.5.0
 
   packages/scanner:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@openai/codex-sdk':
         specifier: ^0.144.0
         version: 0.144.0
+      '@opencode-ai/sdk':
+        specifier: ^1.18.3
+        version: 1.18.3
       '@vercel/oidc':
         specifier: ^3.4.0
         version: 3.4.0
@@ -69,6 +72,9 @@ importers:
       minimatch:
         specifier: ^10.0.0
         version: 10.2.5
+      opencode-ai:
+        specifier: ^1.18.3
+        version: 1.18.3
       tar:
         specifier: ^7.5.20
         version: 7.5.20
@@ -115,6 +121,9 @@ importers:
       '@openai/codex-sdk':
         specifier: ^0.144.0
         version: 0.144.0
+      '@opencode-ai/sdk':
+        specifier: ^1.18.3
+        version: 1.18.3
       jsonrepair:
         specifier: ^3.14.0
         version: 3.14.0
@@ -2430,6 +2439,12 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@opencode-ai/sdk@1.18.3:
+    resolution: {integrity: sha512-Mevo4e6kQwbvto9E+42KSIVMhp+JBu+SwQhC5AomAvrV6Xkio3U249T+xDILDCXhl5Z/Hi/DlAuVLzpGnuh0gg==}
+    dependencies:
+      cross-spawn: 7.0.6
+    dev: false
 
   /@opentelemetry/api@1.9.0:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -10650,6 +10665,123 @@ packages:
     dependencies:
       zod: 4.4.3
     dev: false
+
+  /opencode-ai@1.18.3:
+    resolution: {integrity: sha512-HnItl/+uhSpj7JV9x6ITiE0XFq4b/PKF5OM03TIyiFoFiLw3MQoJOAXZFTEzC7IOgAIYcysRQBBmCmlXILkxww==}
+    cpu: [arm64, x64]
+    os: [darwin, linux, win32]
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      opencode-darwin-arm64: 1.18.3
+      opencode-darwin-x64: 1.18.3
+      opencode-darwin-x64-baseline: 1.18.3
+      opencode-linux-arm64: 1.18.3
+      opencode-linux-arm64-musl: 1.18.3
+      opencode-linux-x64: 1.18.3
+      opencode-linux-x64-baseline: 1.18.3
+      opencode-linux-x64-baseline-musl: 1.18.3
+      opencode-linux-x64-musl: 1.18.3
+      opencode-windows-arm64: 1.18.3
+      opencode-windows-x64: 1.18.3
+      opencode-windows-x64-baseline: 1.18.3
+    dev: false
+
+  /opencode-darwin-arm64@1.18.3:
+    resolution: {integrity: sha512-BkfJf4E502OVwpDXgaVz8eqTDOy2B9xXPefYebT+xv8TXYvEo1wtby4eu4MoN51o4o1qpzcvCCXDqUDXu1pBGQ==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-darwin-x64-baseline@1.18.3:
+    resolution: {integrity: sha512-8qQ9Ig7Zp7LEKaKGRL+OIlDb/uTLYkeAq6SGsN0fLHR2rHZRHyb61KrpkS5TgUlGwSWPtb5uCeVtTA9rGbEAKw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-darwin-x64@1.18.3:
+    resolution: {integrity: sha512-ujy61O3WUEHjPqk+qXMBl97zR9q3crOzHbm2VLmXLHUWbqB5ZtN1HToODbuI1SBMKVR8GyZwPygRQVMfON4DHg==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-linux-arm64-musl@1.18.3:
+    resolution: {integrity: sha512-s1vNP8dpIH3vFs8aoMzgHViBNVz6xtR7n24gGg0WOw4uSZVM+sRUmZKc3Hj56XjHQSsVBg5AkwR2Xm0nFSfIUQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-linux-arm64@1.18.3:
+    resolution: {integrity: sha512-K+1SPkfrYFUufPUYpbSurlB2ogpjv5in2usA1FwOM7HCOpNxR3ap7K+X4uQXnOV8AtsON+Vr9W5uYXQJA1yKlA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-linux-x64-baseline-musl@1.18.3:
+    resolution: {integrity: sha512-F2nNPqYPdTCydLvNH1rvSXdlX3pfmOmOOfsFl+pqi3W0iE3Alyxmv28AjrIGUw4/6EfWhMKYcyxKjNIKLFyaZQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-linux-x64-baseline@1.18.3:
+    resolution: {integrity: sha512-DDfspGSQ123yhsFhAlbpF+tsvje5kHOS2/PYUpWJroTlvgtqRLGmET51Anrxd5BrAFrqB6PXYA2kGh5QStPU/g==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-linux-x64-musl@1.18.3:
+    resolution: {integrity: sha512-SSp2zSpAM4dntcPZw8ISl3CmXYrWPftLc8u0HuAIeNWJOo6G4xAHPoXhNnXI3tQYqqGcppArf/3EMPnF9WnyFw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-linux-x64@1.18.3:
+    resolution: {integrity: sha512-p+19dSTf3pWL3+Rh/Ym94DvS9mNxNG94HJnR5oMCDhQvgimdT5tSdoK4ETtk4XOoCKz3OcTQDPHTdYKcJg32KQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-windows-arm64@1.18.3:
+    resolution: {integrity: sha512-qkz9/r6kUhhgLycQv71MoSQ2m5UI2QnZZx8SeZgyYD7oB8pDH6DIGbDWcs6BJ02ND1Y5hmgYWlP+rOrMkGlMJw==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-windows-x64-baseline@1.18.3:
+    resolution: {integrity: sha512-+tyoxwSfY7msfZNY1IoA0ZWRL9XfdqY+ash6U3ldfE+GfF2WNAdhewmmYiUsC4lHjkdSmLt2brdWgoebQK9HAg==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /opencode-windows-x64@1.18.3:
+    resolution: {integrity: sha512-V/Q4VkyZ7TkotLbpTCX/s5wP8MoFj5UnRqBHFJ8WGptb/+oYw36kamUUt1P1wN8iRjmw+8vwYhuYdAe+3xbgpQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}


### PR DESCRIPTION
## What changed

Adds an OpenCode SDK agent harness and exposes it through the DeepSec CLI, including read-only tool controls, structured-output fallback handling, provider/model routing, and long-running request support. Extends Vercel Sandbox setup, credential brokering, packaging, tests, and documentation so the OpenCode agent works locally and in sandboxed runs.

## Why

DeepSec could run Codex, Claude, and Pi agents, but did not have an OpenCode SDK integration. This adds OpenCode as a first-class agent while preserving the existing agent contract and sandbox security model.

## Verification

- [x] `pnpm test` passes (2,200 passed, 1 expected live-sandbox skip)
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [x] `pnpm -r build` passes
- [x] `pnpm test:bundle` passes (23 tests)
- [x] Local OpenCode Go smoke test against this repository
- [x] Local packed-package smoke test against a separate real repository
- [x] Vercel Sandbox smoke test with Anthropic through AI Gateway/OIDC
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane (not applicable; no matcher added)

## Notes for reviewer

- OpenCode models use `provider/model` IDs; `opencode-go/grok-4.5` was the primary live smoke-test target.
- Zen and additional direct-provider API permutations are supported through the generic OpenCode provider routing but were intentionally not included in the live validation matrix for this PR.
- OpenCode may return valid JSON as text instead of invoking `StructuredOutput`; the harness validates that response as a compatibility fallback.
- `pnpm lint` exits successfully with one Biome warning for the escaped shell variable in the OpenCode Sandbox binary-resolution script.
