### PR TITLE
revalidate: stable finding IDs, permissive verdict reconciliation, targeted repair

### DIFF
--- a/packages/core/src/__tests__/finding-id.test.ts
+++ b/packages/core/src/__tests__/finding-id.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { computeFindingId, ensureFindingIds } from "../finding-id.js";
+import type { FileRecord, Finding } from "../types.js";
+
+function finding(title: string, overrides: Partial<Finding> = {}): Finding {
+  return {
+    severity: "HIGH",
+    vulnSlug: "auth-bypass",
+    title,
+    description: "d",
+    lineNumbers: [1],
+    recommendation: "r",
+    confidence: "high",
+    ...overrides,
+  };
+}
+
+function record(findings: Finding[]): FileRecord {
+  return {
+    filePath: "src/app.ts",
+    projectId: "proj",
+    candidates: [],
+    lastScannedAt: "",
+    lastScannedRunId: "",
+    fileHash: "",
+    findings,
+    analysisHistory: [],
+    status: "analyzed",
+  };
+}
+
+describe("computeFindingId", () => {
+  it("is deterministic and shaped finding_<16 hex>", () => {
+    const a = computeFindingId("proj", "src/app.ts", "SQL injection");
+    expect(a).toMatch(/^finding_[0-9a-f]{16}$/);
+    expect(computeFindingId("proj", "src/app.ts", "SQL injection")).toBe(a);
+  });
+
+  it("normalizes path separators and leading ./ so the same finding hashes equal", () => {
+    const base = computeFindingId("proj", "src/app.ts", "t");
+    expect(computeFindingId("proj", "./src/app.ts", "t")).toBe(base);
+    expect(computeFindingId("proj", "src\\app.ts", "t")).toBe(base);
+  });
+
+  it("varies with projectId, filePath, and title only", () => {
+    const base = computeFindingId("proj", "src/app.ts", "t");
+    expect(computeFindingId("other", "src/app.ts", "t")).not.toBe(base);
+    expect(computeFindingId("proj", "src/other.ts", "t")).not.toBe(base);
+    expect(computeFindingId("proj", "src/app.ts", "u")).not.toBe(base);
+  });
+});
+
+describe("ensureFindingIds", () => {
+  it("backfills missing IDs and reports change", () => {
+    const rec = record([finding("a"), finding("b")]);
+    expect(ensureFindingIds(rec)).toBe(true);
+    expect(rec.findings[0].findingId).toMatch(/^finding_/);
+    expect(rec.findings[1].findingId).toMatch(/^finding_/);
+    expect(rec.findings[0].findingId).not.toBe(rec.findings[1].findingId);
+  });
+
+  it("is a no-op when IDs are already present", () => {
+    const rec = record([finding("a")]);
+    ensureFindingIds(rec);
+    const id = rec.findings[0].findingId;
+    expect(ensureFindingIds(rec)).toBe(false);
+    expect(rec.findings[0].findingId).toBe(id);
+  });
+
+  it("is stable across repeated loads (same derivation every time)", () => {
+    const rec1 = record([finding("a"), finding("a")]);
+    const rec2 = record([finding("a"), finding("a")]);
+    ensureFindingIds(rec1);
+    ensureFindingIds(rec2);
+    expect(rec1.findings.map((f) => f.findingId)).toEqual(rec2.findings.map((f) => f.findingId));
+  });
+
+  it("disambiguates same-file title collisions with unique IDs", () => {
+    const rec = record([finding("dup title"), finding("dup title", { vulnSlug: "xss" })]);
+    ensureFindingIds(rec);
+    const [a, b] = rec.findings.map((f) => f.findingId);
+    expect(a).not.toBe(b);
+  });
+
+  it("never derives from mutable fields (severity/revalidation changes keep the ID)", () => {
+    const rec = record([finding("a")]);
+    ensureFindingIds(rec);
+    const id = rec.findings[0].findingId;
+    rec.findings[0].severity = "LOW";
+    rec.findings[0].findingId = undefined;
+    ensureFindingIds(rec);
+    expect(rec.findings[0].findingId).toBe(id);
+  });
+});

--- a/packages/core/src/finding-id.ts
+++ b/packages/core/src/finding-id.ts
@@ -1,0 +1,56 @@
+import crypto from "node:crypto";
+import type { FileRecord } from "./types.js";
+
+/**
+ * Deterministic, stable identifier for a finding. Derived ONLY from
+ * immutable identifying data (projectId, normalized filePath, original
+ * title) — never from severity, description, line numbers, or
+ * revalidation state — so the same finding gets the same ID on every
+ * load, across scans and revalidation runs, on any machine.
+ *
+ * The ID is what the revalidation agent echoes back to identify a
+ * finding, so it stays short: `finding_` + first 16 hex chars of the
+ * sha256 (64 bits — collision within a single project's finding count
+ * is negligible, and same-file collisions are handled explicitly in
+ * `ensureFindingIds`).
+ */
+export function computeFindingId(projectId: string, filePath: string, title: string): string {
+  const normPath = filePath.replaceAll("\\", "/").replace(/^\.\//, "");
+  const h = crypto.createHash("sha256").update(`${projectId}\0${normPath}\0${title}`).digest("hex");
+  return `finding_${h.slice(0, 16)}`;
+}
+
+/**
+ * Lazily backfill `findingId` on every finding of a record that predates
+ * the field. Mutates in place; returns true when anything was assigned.
+ *
+ * Deterministic across loads: IDs are derived from immutable fields, and
+ * two same-file findings with the *identical* title (rare, but the
+ * investigate-merge dedup only suppresses same slug+title, so distinct
+ * slugs can collide on title) are disambiguated by a stable ordinal that
+ * follows array order — findings are append-only, so the ordinal never
+ * changes for an existing finding.
+ *
+ * Callers on the read path (readFileRecord / loadAllFileRecords) backfill
+ * in memory only; the IDs persist the next time the record is written,
+ * and re-deriving on every load yields the same values until then.
+ */
+export function ensureFindingIds(record: FileRecord): boolean {
+  let changed = false;
+  const used = new Set<string>();
+  for (const f of record.findings) {
+    if (f.findingId) used.add(f.findingId);
+  }
+  for (const f of record.findings) {
+    if (f.findingId) continue;
+    let id = computeFindingId(record.projectId, record.filePath, f.title);
+    // Same-file title collision: salt with a stable ordinal until unique.
+    for (let n = 2; used.has(id); n++) {
+      id = computeFindingId(record.projectId, record.filePath, `${f.title}\0${n}`);
+    }
+    used.add(id);
+    f.findingId = id;
+    changed = true;
+  }
+  return changed;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./config.js";
+export * from "./finding-id.js";
 export * from "./paths.js";
 export * from "./plugin.js";
 export * from "./run.js";

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { ensureFindingIds } from "./finding-id.js";
 import {
   dataDir,
   fileRecordPath,
@@ -276,7 +277,12 @@ export function readFileRecord(projectId: string, filePath: string): FileRecord 
   if (!fs.existsSync(p)) return null;
   try {
     const raw = JSON.parse(fs.readFileSync(p, "utf-8"));
-    return fileRecordSchema.parse(raw);
+    const record = fileRecordSchema.parse(raw);
+    // Lazy backfill: records written before findingId existed get
+    // deterministic IDs assigned in memory on every load (same inputs →
+    // same IDs), and the IDs persist on the next write.
+    ensureFindingIds(record);
+    return record;
   } catch {
     return null;
   }
@@ -390,7 +396,9 @@ export function loadAllFileRecords(projectId: string): FileRecord[] {
       } else if (entry.name.endsWith(".json")) {
         try {
           const raw = JSON.parse(fs.readFileSync(full, "utf-8"));
-          records.push(fileRecordSchema.parse(raw));
+          const record = fileRecordSchema.parse(raw);
+          ensureFindingIds(record); // see readFileRecord
+          records.push(record);
         } catch {
           // skip malformed
         }

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -35,6 +35,9 @@ export const revalidationSchema = z.object({
 });
 
 export const findingSchema = z.object({
+  // Stable deterministic identity (`finding_<sha256 prefix>`). Optional
+  // for records written before the field existed; backfilled on load.
+  findingId: z.string().optional(),
   severity: z.enum(["CRITICAL", "HIGH", "MEDIUM", "HIGH_BUG", "BUG", "LOW"]),
   vulnSlug: z.string(),
   title: z.string(),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -183,9 +183,10 @@ export interface Revalidation {
   reasoning: string;
   adjustedSeverity?: Severity;
   /**
-   * Set iff `verdict === "duplicate"`. Holds the `title` of the primary
-   * finding in the same file. The primary's verdict is the canonical
-   * one for the underlying issue.
+   * Set iff `verdict === "duplicate"`. Holds the identity of the primary
+   * finding — the `findingId` when known (new writes), or the primary's
+   * `title` for records written before finding IDs existed. The
+   * primary's verdict is the canonical one for the underlying issue.
    */
   duplicateOf?: string;
   revalidatedAt: string;
@@ -205,6 +206,19 @@ export interface Triage {
 }
 
 export interface Finding {
+  /**
+   * Stable, deterministic identifier: `finding_` + sha256 prefix of
+   * (projectId, normalized filePath, original title). Assigned at append
+   * time for new findings and lazily backfilled on load for records
+   * written before the field existed (see `ensureFindingIds`). This is
+   * the primary identity used by the revalidation response contract —
+   * titles are human-readable context only.
+   *
+   * Optional in the schema for backward compatibility, but always
+   * present in memory after a record passes through
+   * readFileRecord/loadAllFileRecords.
+   */
+  findingId?: string;
   severity: Severity;
   vulnSlug: string;
   title: string;

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/src/__tests__/merge-records.test.ts
+++ b/packages/deepsec/src/__tests__/merge-records.test.ts
@@ -66,17 +66,45 @@ describe("mergeFileRecord", () => {
     expect(merged.status).toBe("analyzed");
   });
 
-  it("dedupes analysisHistory when both sides serialize the same runId", () => {
+  it("dedupes an identical entry seen on both sides, regardless of key order", () => {
     const sameEntry = entry("run-x", "codex", "2026-05-06T15:59:48.000Z");
+    // Same entry, keys in a different order — simulates the host path
+    // (raw JSON.parse) vs the incoming path (zod parse) serializing the
+    // same entry differently.
+    const reordered = Object.fromEntries(
+      Object.entries(sameEntry).reverse(),
+    ) as unknown as AnalysisEntry;
     const host = record({ analysisHistory: [sameEntry] });
-    const incoming = record({
-      analysisHistory: [{ ...sameEntry, findingCount: 5 }],
-    });
+    const incoming = record({ analysisHistory: [reordered] });
 
     const merged = mergeFileRecord(host, incoming);
 
     expect(merged.analysisHistory).toHaveLength(1);
-    expect(merged.analysisHistory[0].findingCount).toBe(5); // incoming wins
+  });
+
+  it("keeps multiple same-runId entries (revalidate split retries) with their own accounting", () => {
+    // One revalidate run appends several entries per file under the same
+    // runId: the initial invocation plus per-file / per-finding split
+    // retries, each carrying its own cost/token share. Keying the merge
+    // by runId alone collapsed these and silently dropped the accounting.
+    const initial = {
+      ...entry("reval-run", "claude-agent-sdk", "2026-05-06T15:54:37.000Z"),
+      phase: "revalidate" as const,
+      costUsd: 0.4,
+    };
+    const retry = {
+      ...entry("reval-run", "claude-agent-sdk", "2026-05-06T15:58:02.000Z"),
+      phase: "revalidate" as const,
+      costUsd: 0.1,
+    };
+    const host = record({ analysisHistory: [initial] });
+    const incoming = record({ analysisHistory: [initial, retry] });
+
+    const merged = mergeFileRecord(host, incoming);
+
+    expect(merged.analysisHistory).toHaveLength(2);
+    const totalCost = merged.analysisHistory.reduce((s, e) => s + (e.costUsd ?? 0), 0);
+    expect(totalCost).toBeCloseTo(0.5, 6);
   });
 
   it("unions findings by vulnSlug+title signature", () => {

--- a/packages/deepsec/src/__tests__/tarball.test.ts
+++ b/packages/deepsec/src/__tests__/tarball.test.ts
@@ -110,6 +110,33 @@ describe("extractTarballLocally — strict allowlist", () => {
     ).toBe(true);
   });
 
+  it("accepts revalidation invocation artifacts under revalidation/<runId>/*.json", async () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-tar-reval-"));
+    fs.mkdirSync(path.join(src, "revalidation", "20260101000000-abcdef0123456789"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(src, "revalidation", "20260101000000-abcdef0123456789", "invocation-000.json"),
+      JSON.stringify({ rawResponses: [] }),
+    );
+    const stats = await makeTarball(src, []);
+    fs.rmSync(src, { recursive: true, force: true });
+
+    const count = await extractTarballLocally(stats.tarPath, destDir);
+    fs.unlinkSync(stats.tarPath);
+    expect(count).toBe(1);
+    expect(
+      fs.existsSync(
+        path.join(
+          destDir,
+          "revalidation",
+          "20260101000000-abcdef0123456789",
+          "invocation-000.json",
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("refuses a tarball with a disallowed extension and writes nothing", async () => {
     const src = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-tar-bad-"));
     fs.mkdirSync(path.join(src, "files"));

--- a/packages/deepsec/src/commands/revalidate.ts
+++ b/packages/deepsec/src/commands/revalidate.ts
@@ -32,6 +32,10 @@ function logProgress(progress: {
           console.log(`  ${GREEN}${ap.message}${RESET}`);
         } else if (ap.type === "error") {
           console.log(`  ${RED}${ap.message}${RESET}`);
+        } else if (ap.type === "thinking") {
+          // Reconciliation / id-repair / split-retry status lives on
+          // "thinking" progress events — surface it dimly.
+          console.log(`  ${DIM}${ap.message}${RESET}`);
         }
         break;
       }
@@ -123,6 +127,9 @@ export async function revalidateCommand(opts: {
   console.log(
     `  ${GREEN}TP: ${result.truePositives}${RESET}  ${RED}FP: ${result.falsePositives}${RESET}  ${CYAN}Fixed: ${result.fixed}${RESET}  ${YELLOW}Uncertain: ${result.uncertain}${RESET}${dupeStr}`,
   );
+  console.log(
+    `  ${DIM}Persisted ${result.revalidated}/${result.requested} requested verdicts${RESET}`,
+  );
   if (result.quotaExhausted) {
     console.log(
       renderQuotaMessage({
@@ -131,6 +138,22 @@ export async function revalidateCommand(opts: {
         command: "revalidate",
         projectId,
       }),
+    );
+    process.exit(1);
+  }
+  if (result.unresolved.length > 0) {
+    console.log();
+    console.log(
+      `${RED}${result.unresolved.length} finding(s) did not receive a verdict after repair and split retries:${RESET}`,
+    );
+    for (const u of result.unresolved.slice(0, 20)) {
+      console.log(`  ${RED}-${RESET} ${u.filePath} ${DIM}${u.findingId}${RESET} "${u.title}"`);
+    }
+    if (result.unresolved.length > 20) {
+      console.log(`  ${DIM}… and ${result.unresolved.length - 20} more${RESET}`);
+    }
+    console.log(
+      `  ${DIM}Raw responses + reconciliation diagnostics: data/${projectId}/revalidation/${result.runId}/${RESET}`,
     );
     process.exit(1);
   }

--- a/packages/deepsec/src/sandbox/download.ts
+++ b/packages/deepsec/src/sandbox/download.ts
@@ -42,6 +42,12 @@ const ALLOWED_ENTRY_PATTERNS: RegExp[] = [
   // `-`), but the allowlist character class matches the same broad shape
   // as the files/ pattern so future debug filenames don't get rejected.
   /^\.?\/?debug\/[^/\\\0]+\.txt$/,
+  // Revalidation invocation artifacts: raw model responses +
+  // reconciliation diagnostics per agent call, one directory per run
+  // (`revalidation/<runId>/invocation-NNN.json`). Written by the
+  // processor's revalidate(); needed on the host to diagnose/rescore
+  // verdict mismatches from sandbox runs.
+  /^\.?\/?revalidation\/[^/\\\0]+\/[^/\\\0]+\.json$/,
 ];
 
 // Belt-and-suspenders caps on a sandbox-supplied tarball. The numbers err
@@ -255,7 +261,7 @@ export async function extractTarballLocally(
         return;
       }
       if (!ALLOWED_ENTRY_PATTERNS.some((re) => re.test(norm))) {
-        violations.push(`"${entry.path}" is outside files/, runs/, reports/`);
+        violations.push(`"${entry.path}" is outside files/, runs/, reports/, revalidation/`);
         return;
       }
       const sz = (entry as unknown as { size?: number }).size ?? 0;
@@ -283,7 +289,7 @@ export async function extractTarballLocally(
     const preview = violations.slice(0, 5).join("\n  ");
     const more = violations.length > 5 ? `\n  …and ${violations.length - 5} more` : "";
     throw new Error(
-      `Refusing sandbox results tarball: ${violations.length} disallowed entr${violations.length === 1 ? "y" : "ies"}:\n  ${preview}${more}\nAllowed: regular ${[...ALLOWED_EXTENSIONS].sort().join("/")} files under files/, runs/, or reports/; ≤${MAX_ENTRIES} entries, ≤${(MAX_UNCOMPRESSED_BYTES / 1024 / 1024).toFixed(0)}MB total.`,
+      `Refusing sandbox results tarball: ${violations.length} disallowed entr${violations.length === 1 ? "y" : "ies"}:\n  ${preview}${more}\nAllowed: regular ${[...ALLOWED_EXTENSIONS].sort().join("/")} files under files/, runs/, reports/, debug/, or revalidation/; ≤${MAX_ENTRIES} entries, ≤${(MAX_UNCOMPRESSED_BYTES / 1024 / 1024).toFixed(0)}MB total.`,
     );
   }
 

--- a/packages/deepsec/src/sandbox/merge-records.ts
+++ b/packages/deepsec/src/sandbox/merge-records.ts
@@ -64,9 +64,13 @@ export function snapshotFileRecords(
  * from per-file `analysisHistory` despite being recorded in `runs/*.json`.
  *
  * Merge strategy:
- *   - `analysisHistory`: union by `runId` (each run is globally unique).
- *     For the same runId on both sides, prefer `incoming` since the
- *     tarball is the more recent serialization.
+ *   - `analysisHistory`: union by canonical entry value. Entries are
+ *     append-only and never mutated after write, so value equality means
+ *     "the same entry seen from both sides". Keying by `runId` alone is
+ *     NOT enough: one revalidate run appends multiple entries per file
+ *     under the same runId (initial invocation + per-file / per-finding
+ *     split retries), each carrying its own cost/token/duration share —
+ *     collapsing them would silently drop that accounting.
  *   - `findings`: union by `(vulnSlug, normalized title)` signature, the
  *     same key `process()` uses to dedupe re-runs. For matching findings,
  *     merge field-by-field so a `revalidation` / `triage` set on either
@@ -83,14 +87,18 @@ export function snapshotFileRecords(
  *     scan run that has its own non-racing lifecycle.
  */
 export function mergeFileRecord(host: FileRecord, incoming: FileRecord): FileRecord {
-  const historyByRunId = new Map<string, AnalysisEntry>();
-  for (const entry of host.analysisHistory ?? []) {
-    historyByRunId.set(entry.runId, entry);
+  // Key by canonical (key-order-independent) serialization, not runId:
+  // split retries append several same-runId entries that must all
+  // survive, while the identical entry arriving via both the host
+  // snapshot and the tarball must land exactly once. Canonicalization
+  // matters because the two sides can serialize the same entry with
+  // different key order (raw JSON.parse on the host path vs zod parse on
+  // the incoming path).
+  const historyByValue = new Map<string, AnalysisEntry>();
+  for (const entry of [...(host.analysisHistory ?? []), ...(incoming.analysisHistory ?? [])]) {
+    historyByValue.set(canonicalJson(entry), entry);
   }
-  for (const entry of incoming.analysisHistory ?? []) {
-    historyByRunId.set(entry.runId, entry);
-  }
-  const mergedHistory = Array.from(historyByRunId.values()).sort(
+  const mergedHistory = Array.from(historyByValue.values()).sort(
     (a, b) => new Date(a.investigatedAt).getTime() - new Date(b.investigatedAt).getTime(),
   );
 
@@ -115,6 +123,25 @@ export function mergeFileRecord(host: FileRecord, incoming: FileRecord): FileRec
     analysisHistory: mergedHistory,
     status,
   };
+}
+
+/**
+ * Deterministic JSON serialization: object keys sorted at every level,
+ * `undefined` values omitted (like JSON.stringify). Two structurally
+ * equal entries produce the same string regardless of how they were
+ * parsed/constructed.
+ */
+function canonicalJson(v: unknown): string {
+  if (Array.isArray(v)) return `[${v.map(canonicalJson).join(",")}]`;
+  if (v !== null && typeof v === "object") {
+    const rec = v as Record<string, unknown>;
+    const parts = Object.keys(rec)
+      .sort()
+      .filter((k) => rec[k] !== undefined)
+      .map((k) => `${JSON.stringify(k)}:${canonicalJson(rec[k])}`);
+    return `{${parts.join(",")}}`;
+  }
+  return JSON.stringify(v) ?? "null";
 }
 
 function findingSignature(f: Finding): string {

--- a/packages/deepsec/src/sandbox/setup.ts
+++ b/packages/deepsec/src/sandbox/setup.ts
@@ -793,32 +793,32 @@ for CANDIDATE in \\
     if [ -f "$DIR/package.json" ]; then
       VER=$(node -p "require('$DIR/package.json').version" 2>/dev/null || true)
       # Skip platform-suffixed packages (e.g. 0.144.0-darwin-arm64).
-      case "\$VER" in
+      case "$VER" in
         *-linux-*|*-darwin-*|*-win32-*) continue ;;
       esac
-      if [ -n "\$VER" ]; then
-        SDK_VER="\$VER"
+      if [ -n "$VER" ]; then
+        SDK_VER="$VER"
         # Absolute path — the alias step below runs after cd'ing elsewhere.
-        CODEX_PKG_DIR="\$(cd "\$DIR" && pwd)"
+        CODEX_PKG_DIR="$(cd "$DIR" && pwd)"
         break 2
       fi
     fi
   done
 done
-if [ -z "\$SDK_VER" ]; then
+if [ -z "$SDK_VER" ]; then
   echo "Could not detect Codex CLI version"
   exit 1
 fi
-echo "Detected Codex CLI version: \$SDK_VER"
+echo "Detected Codex CLI version: $SDK_VER"
 
 # Map sandbox arch to platform package + vendor triple
 UNAME_M=$(uname -m)
-case "\$UNAME_M" in
+case "$UNAME_M" in
   x86_64) ARCH=x64; TRIPLE=x86_64-unknown-linux-musl ;;
   aarch64|arm64) ARCH=arm64; TRIPLE=aarch64-unknown-linux-musl ;;
-  *) echo "Unsupported arch: \$UNAME_M"; exit 1 ;;
+  *) echo "Unsupported arch: $UNAME_M"; exit 1 ;;
 esac
-echo "  Sandbox arch: \$UNAME_M (linux-\${ARCH}, \$TRIPLE)"
+echo "  Sandbox arch: $UNAME_M (linux-\${ARCH}, $TRIPLE)"
 
 # The platform package's actual published version is "<sdk_ver>-linux-<arch>".
 # pnpm aliases it as @openai/codex-linux-<arch> → @openai/codex@<ver>-linux-<arch>.
@@ -863,13 +863,13 @@ ALIAS_TARGETS=(
   "${DEEPSEC_DIR}/node_modules/.pnpm/@openai+codex@\${SDK_VER}/node_modules/\${PLATFORM_ALIAS}"
   "${DEEPSEC_DIR}/node_modules/\${PLATFORM_ALIAS}"
 )
-if [ -n "\$CODEX_PKG_DIR" ]; then
+if [ -n "$CODEX_PKG_DIR" ]; then
   ALIAS_TARGETS+=("\${CODEX_PKG_DIR}/node_modules/\${PLATFORM_ALIAS}")
 fi
 for ALIAS in "\${ALIAS_TARGETS[@]}"; do
-  mkdir -p "\$(dirname "\$ALIAS")"
-  ln -sfn "\${STORE_DEST}" "\$ALIAS"
-  echo "    → alias \$ALIAS"
+  mkdir -p "$(dirname "$ALIAS")"
+  ln -sfn "\${STORE_DEST}" "$ALIAS"
+  echo "    → alias $ALIAS"
 done
 rm -rf /tmp/codex-native-fetch
 `;

--- a/packages/processor/src/__tests__/process-revalidate.test.ts
+++ b/packages/processor/src/__tests__/process-revalidate.test.ts
@@ -1075,7 +1075,9 @@ describe("revalidate() duplicate verdict", () => {
     const dupe = rec.findings.find((f) => f.title === "dupe of primary");
     expect(primary?.revalidation?.verdict).toBe("true-positive");
     expect(dupe?.revalidation?.verdict).toBe("duplicate");
-    expect(dupe?.revalidation?.duplicateOf).toBe("primary issue");
+    // duplicateOf is persisted as the primary's stable findingId now.
+    expect(primary?.findingId).toBeTruthy();
+    expect(dupe?.revalidation?.duplicateOf).toBe(primary?.findingId);
     expect(result.truePositives).toBe(1);
     expect(result.duplicates).toBe(1);
     expect(result.duplicatesRejected).toBe(0);
@@ -1125,8 +1127,9 @@ describe("revalidate() duplicate verdict", () => {
 
     const after = fx.readRecord("app.ts");
     const dupe = after.findings.find((f) => f.title === "new dupe");
+    const primary = after.findings.find((f) => f.title === "primary issue");
     expect(dupe?.revalidation?.verdict).toBe("duplicate");
-    expect(dupe?.revalidation?.duplicateOf).toBe("primary issue");
+    expect(dupe?.revalidation?.duplicateOf).toBe(primary?.findingId);
     expect(result.duplicates).toBe(1);
     expect(result.duplicatesRejected).toBe(0);
   });
@@ -1316,5 +1319,408 @@ describe("revalidate() duplicate verdict", () => {
     expect(result.duplicates).toBe(2);
     expect(result.duplicatesRejected).toBe(0);
     expect(result.falsePositives).toBe(1);
+  });
+});
+
+describe("revalidate() reconciliation, repair, and adaptive splitting", () => {
+  let prevDataRoot: string | undefined;
+
+  beforeEach(() => {
+    prevDataRoot = process.env.DEEPSEC_DATA_ROOT;
+  });
+
+  afterEach(() => {
+    if (prevDataRoot === undefined) delete process.env.DEEPSEC_DATA_ROOT;
+    else process.env.DEEPSEC_DATA_ROOT = prevDataRoot;
+    setLoadedConfig(defineConfig({ projects: [] }));
+  });
+
+  function fileWithFindings(fx: Fixture, relPath: string, titles: string[]): FileRecord {
+    const rec = pendingRecord(fx.projectId, relPath);
+    rec.status = "analyzed";
+    rec.findings = titles.map((title) => ({
+      severity: "HIGH" as const,
+      vulnSlug: "auth-bypass",
+      title,
+      description: `desc for ${title}`,
+      lineNumbers: [1],
+      recommendation: "x",
+      confidence: "high" as const,
+    }));
+    rec.analysisHistory = [];
+    fx.writeRecord(rec);
+    return rec;
+  }
+
+  it("applies verdicts sent with findingId only (no filePath/title)", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    fileWithFindings(fx, "app.ts", ["finding one", "finding two"]);
+
+    const stub = new StubAgent({
+      async *revalidateImpl(params) {
+        return {
+          verdicts: params.batch.flatMap((rec) =>
+            rec.findings.map((f) => ({
+              findingId: f.findingId,
+              verdict: "false-positive" as const,
+              reasoning: "id-based",
+            })),
+          ),
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({ projectId: fx.projectId, agentType: "stub", concurrency: 1 });
+
+    expect(result.requested).toBe(2);
+    expect(result.revalidated).toBe(2);
+    expect(result.unresolved).toHaveLength(0);
+    const after = fx.readRecord("app.ts");
+    expect(after.findings.every((f) => f.revalidation?.verdict === "false-positive")).toBe(true);
+  });
+
+  it("regression: six verdicts with correct paths but altered titles all apply in one call", async () => {
+    // The observed 2.2.4 failure: batches reported success, file paths
+    // matched, yet zero findings got a revalidation because every title
+    // was reworded/mangled. All six must now apply without re-running
+    // the investigation (exactly one agent call).
+    const fx = setupProject({ files: ["srv/a.ts", "srv/b.ts"] });
+    fileWithFindings(fx, "srv/a.ts", [
+      "Missing auth on /admin endpoint",
+      "SQL injection in search query",
+      "Path traversal in file download",
+    ]);
+    fileWithFindings(fx, "srv/b.ts", [
+      "CSV domain permission bypass",
+      "Open redirect via next param",
+      "XSS in error page rendering",
+    ]);
+
+    const mangle = (t: string) => `  \`${t.toUpperCase()}\`.  `;
+    const stub = new StubAgent({
+      async *revalidateImpl(params) {
+        return {
+          verdicts: params.batch.flatMap((rec) =>
+            rec.findings.map((f) => ({
+              filePath: `./${rec.filePath}`,
+              title: mangle(f.title),
+              verdict: "true-positive" as const,
+              reasoning: "still there",
+            })),
+          ),
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+      batchSize: 5,
+    });
+
+    expect(stub.calls.revalidateCalls).toHaveLength(1);
+    expect(result.requested).toBe(6);
+    expect(result.revalidated).toBe(6);
+    expect(result.unresolved).toHaveLength(0);
+    for (const p of ["srv/a.ts", "srv/b.ts"]) {
+      const rec = fx.readRecord(p);
+      expect(rec.findings.every((f) => f.revalidation?.verdict === "true-positive")).toBe(true);
+    }
+  });
+
+  it("persists partial results, then recovers the rest via per-file and per-finding retries", async () => {
+    const fx = setupProject({ files: ["ok.ts", "bad.ts"] });
+    fileWithFindings(fx, "ok.ts", ["good one"]);
+    fileWithFindings(fx, "bad.ts", ["tricky one", "tricky two"]);
+
+    const stub = new StubAgent({
+      async *revalidateImpl(params) {
+        const wanted = params.onlyFindingIds ? new Set(params.onlyFindingIds) : undefined;
+        const targets = params.batch.flatMap((rec) =>
+          rec.findings
+            .filter((f) => (wanted ? wanted.has(f.findingId!) : !f.revalidation))
+            .map((f) => ({ rec, f })),
+        );
+        // Full batch: return good verdicts only for ok.ts, garbage for bad.ts.
+        // Per-file retry of bad.ts (2 findings): still garbage.
+        // Per-finding retry (single finding): correct verdict.
+        const isFullBatch = params.batch.length > 1;
+        const isSingleFinding = targets.length === 1 && params.onlyFindingIds?.length === 1;
+        return {
+          verdicts: targets.map(({ rec, f }) => {
+            const good = rec.filePath === "ok.ts" || isSingleFinding;
+            return good
+              ? { findingId: f.findingId, verdict: "true-positive" as const, reasoning: "ok" }
+              : {
+                  findingId: `item_${Math.abs(isFullBatch ? 1 : 2)}garbled`,
+                  title: "unrecognizable rewrite",
+                  verdict: "true-positive" as const,
+                  reasoning: "mangled",
+                };
+          }),
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+      batchSize: 5,
+    });
+
+    // initial (both files) + per-file retry (bad.ts) + 2 per-finding retries
+    expect(stub.calls.revalidateCalls).toHaveLength(4);
+    expect(stub.calls.revalidateCalls[1].onlyFindingIds).toHaveLength(2);
+    expect(stub.calls.revalidateCalls[2].onlyFindingIds).toHaveLength(1);
+    expect(stub.calls.revalidateCalls[3].onlyFindingIds).toHaveLength(1);
+    expect(result.requested).toBe(3);
+    expect(result.revalidated).toBe(3);
+    expect(result.unresolved).toHaveLength(0);
+    expect(fx.readRecord("ok.ts").findings[0].revalidation?.verdict).toBe("true-positive");
+    expect(fx.readRecord("bad.ts").findings.every((f) => f.revalidation)).toBe(true);
+  });
+
+  it("surfaces unresolved findings and writes reconciliation artifacts when recovery fails", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    fileWithFindings(fx, "app.ts", ["never matched"]);
+
+    // Two bogus verdicts so not even the unique-remainder rule can
+    // recover — with a single expected finding, one lone verdict would
+    // (deliberately) match 1:1.
+    const stub = new StubAgent({
+      async *revalidateImpl() {
+        return {
+          verdicts: [
+            { findingId: "item_bogus", verdict: "true-positive" as const, reasoning: "x" },
+            { findingId: "item_bogus2", verdict: "false-positive" as const, reasoning: "y" },
+          ],
+          meta: { durationMs: 1 },
+          rawResponses: [{ kind: "initial" as const, rawText: "raw model text" }],
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({ projectId: fx.projectId, agentType: "stub", concurrency: 1 });
+
+    expect(result.revalidated).toBe(0);
+    expect(result.unresolved).toHaveLength(1);
+    expect(result.unresolved[0].filePath).toBe("app.ts");
+    expect(result.unresolved[0].findingId).toMatch(/^finding_/);
+    expect(fx.readRecord("app.ts").findings[0].revalidation).toBeUndefined();
+
+    // Artifacts landed in the run's revalidation dir with raw output +
+    // reconciliation diagnostics.
+    const artDir = path.join(fx.dataRoot, fx.projectId, "revalidation", result.runId);
+    const artifacts = fs.readdirSync(artDir);
+    expect(artifacts.length).toBeGreaterThanOrEqual(1);
+    const first = JSON.parse(fs.readFileSync(path.join(artDir, artifacts[0]), "utf-8"));
+    expect(first.rawResponses[0].rawText).toBe("raw model text");
+    expect(first.reconciliation.unknownVerdicts).toHaveLength(2);
+    expect(first.unresolvedFindingIds).toHaveLength(1);
+  });
+
+  it("applies verdicts echoed with short aliases, including duplicateOf", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    fileWithFindings(fx, "app.ts", ["first thing", "second thing", "third thing"]);
+
+    // The agent echoes the per-invocation aliases (F1..F3) instead of
+    // full findingIds — including an alias duplicateOf reference.
+    const stub = new StubAgent({
+      async *revalidateImpl() {
+        return {
+          verdicts: [
+            { findingId: "F1", verdict: "true-positive" as const, reasoning: "p" },
+            { findingId: "#2", verdict: "false-positive" as const, reasoning: "fp" },
+            {
+              findingId: "f3",
+              verdict: "duplicate" as const,
+              duplicateOf: "F1",
+              reasoning: "same as first",
+            },
+          ],
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({ projectId: fx.projectId, agentType: "stub", concurrency: 1 });
+
+    expect(result.revalidated).toBe(3);
+    expect(result.duplicates).toBe(1);
+    expect(result.unresolved).toHaveLength(0);
+    expect(stub.calls.revalidateCalls).toHaveLength(1);
+    const after = fx.readRecord("app.ts");
+    const first = after.findings.find((f) => f.title === "first thing");
+    const second = after.findings.find((f) => f.title === "second thing");
+    const third = after.findings.find((f) => f.title === "third thing");
+    expect(first?.revalidation?.verdict).toBe("true-positive");
+    expect(second?.revalidation?.verdict).toBe("false-positive");
+    expect(third?.revalidation?.verdict).toBe("duplicate");
+    // Persisted as the primary's stable findingId, not the alias.
+    expect(third?.revalidation?.duplicateOf).toBe(first?.findingId);
+  });
+
+  it("accepts duplicateOf references by findingId", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    fileWithFindings(fx, "app.ts", ["the primary", "the dupe"]);
+
+    const stub = new StubAgent({
+      async *revalidateImpl(params) {
+        const [primary, dupe] = params.batch[0].findings;
+        return {
+          verdicts: [
+            { findingId: primary.findingId, verdict: "true-positive" as const, reasoning: "p" },
+            {
+              findingId: dupe.findingId,
+              verdict: "duplicate" as const,
+              duplicateOf: primary.findingId,
+              reasoning: "same",
+            },
+          ],
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({ projectId: fx.projectId, agentType: "stub", concurrency: 1 });
+
+    expect(result.duplicates).toBe(1);
+    expect(result.unresolved).toHaveLength(0);
+    const after = fx.readRecord("app.ts");
+    const primary = after.findings.find((f) => f.title === "the primary");
+    const dupe = after.findings.find((f) => f.title === "the dupe");
+    expect(dupe?.revalidation?.duplicateOf).toBe(primary?.findingId);
+  });
+
+  it("is idempotent across a restart: a second run re-requests nothing and appends no history", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    fileWithFindings(fx, "app.ts", ["a", "b"]);
+
+    const stub = new StubAgent({
+      async *revalidateImpl(params) {
+        return {
+          verdicts: params.batch.flatMap((rec) =>
+            rec.findings
+              .filter((f) => !f.revalidation)
+              .map((f) => ({
+                findingId: f.findingId,
+                verdict: "true-positive" as const,
+                reasoning: "x",
+              })),
+          ),
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const first = await revalidate({ projectId: fx.projectId, agentType: "stub", concurrency: 1 });
+    expect(first.revalidated).toBe(2);
+    const afterFirst = fx.readRecord("app.ts");
+    const firstRevalidatedAt = afterFirst.findings.map((f) => f.revalidation?.revalidatedAt);
+    const historyLen = afterFirst.analysisHistory.length;
+
+    const second = await revalidate({ projectId: fx.projectId, agentType: "stub", concurrency: 1 });
+    expect(second.requested).toBe(0);
+    expect(second.revalidated).toBe(0);
+    expect(second.unresolved).toHaveLength(0);
+    expect(stub.calls.revalidateCalls).toHaveLength(1); // second run never invoked the agent
+    const afterSecond = fx.readRecord("app.ts");
+    expect(afterSecond.analysisHistory.length).toBe(historyLen);
+    expect(afterSecond.findings.map((f) => f.revalidation?.revalidatedAt)).toEqual(
+      firstRevalidatedAt,
+    );
+  });
+
+  it("never overwrites a manual accepted-risk verdict, even with --force", async () => {
+    const fx = setupProject({ files: ["app.ts"] });
+    const rec = fileWithFindings(fx, "app.ts", ["accepted thing"]);
+    rec.findings[0].revalidation = {
+      verdict: "accepted-risk",
+      reasoning: "team decision",
+      revalidatedAt: new Date().toISOString(),
+      runId: "manual",
+      model: "human",
+    };
+    fx.writeRecord(rec);
+
+    const stub = new StubAgent({
+      async *revalidateImpl(params) {
+        return {
+          verdicts: params.batch.flatMap((r) =>
+            r.findings.map((f) => ({
+              findingId: f.findingId,
+              verdict: "false-positive" as const,
+              reasoning: "agent disagrees",
+            })),
+          ),
+          meta: { durationMs: 1 },
+        };
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    const result = await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+      force: true,
+    });
+
+    expect(result.unresolved).toHaveLength(0);
+    const after = fx.readRecord("app.ts");
+    expect(after.findings[0].revalidation?.verdict).toBe("accepted-risk");
+    expect(after.findings[0].revalidation?.reasoning).toBe("team decision");
   });
 });

--- a/packages/processor/src/__tests__/reconcile.test.ts
+++ b/packages/processor/src/__tests__/reconcile.test.ts
@@ -1,0 +1,436 @@
+import type { FileRecord, Finding } from "@deepsec/core";
+import { describe, expect, it } from "vitest";
+import { runRevalidateIdRepairLoop } from "../agents/shared.js";
+import type { RevalidateVerdict } from "../agents/types.js";
+import {
+  type ExpectedFinding,
+  normalizePath,
+  normalizeTitle,
+  reconcileVerdicts,
+  resolveDuplicateRef,
+} from "../reconcile.js";
+
+function exp(findingId: string, filePath: string, title: string): ExpectedFinding {
+  return { findingId, filePath, title };
+}
+
+function verdict(v: Partial<RevalidateVerdict>): RevalidateVerdict {
+  return { verdict: "true-positive", reasoning: "r", ...v };
+}
+
+describe("normalizeTitle / normalizePath", () => {
+  it("collapses whitespace, strips markdown quoting, casefolds, trims punctuation", () => {
+    expect(normalizeTitle("  `SQL   Injection` in *login*!  ")).toBe("sql injection in login");
+    expect(normalizeTitle("SQL Injection")).toBe(normalizeTitle("sql injection")); // case
+    expect(normalizeTitle("“Smart quotes”")).toBe("smart quotes");
+  });
+
+  it("applies Unicode normalization (NFKC)", () => {
+    expect(normalizeTitle("ﬁle upload")).toBe("file upload");
+  });
+
+  it("normalizes path separators and leading ./", () => {
+    expect(normalizePath("./src/app.ts")).toBe("src/app.ts");
+    expect(normalizePath("src\\app.ts")).toBe("src/app.ts");
+  });
+});
+
+describe("reconcileVerdicts", () => {
+  const expected = [
+    exp("finding_aaa", "src/a.ts", "Missing auth on /admin"),
+    exp("finding_bbb", "src/a.ts", "SQL injection in search"),
+    exp("finding_ccc", "src/b.ts", "Open redirect"),
+  ];
+
+  it("matches by exact findingId regardless of title/path noise", () => {
+    const res = reconcileVerdicts(expected, [
+      verdict({ findingId: "finding_bbb", title: "completely rewritten title" }),
+    ]);
+    expect(res.matches).toHaveLength(1);
+    expect(res.matches[0].expected.findingId).toBe("finding_bbb");
+    expect(res.matches[0].diagnostic.matchedBy).toBe("finding-id");
+    expect(res.missing.map((e) => e.findingId)).toEqual(["finding_aaa", "finding_ccc"]);
+    expect(res.unknown).toHaveLength(0);
+  });
+
+  it("matches legacy exact (filePath, title) responses without findingId", () => {
+    const res = reconcileVerdicts(expected, [
+      verdict({ filePath: "src/a.ts", title: "Missing auth on /admin" }),
+    ]);
+    expect(res.matches[0].expected.findingId).toBe("finding_aaa");
+    expect(res.matches[0].diagnostic.matchedBy).toBe("exact-title");
+  });
+
+  it("matches whitespace/case/markdown-mangled titles within the exact file", () => {
+    const res = reconcileVerdicts(expected, [
+      verdict({ filePath: "./src\\a.ts", title: "  `missing  AUTH` on /admin.  " }),
+    ]);
+    expect(res.matches[0].expected.findingId).toBe("finding_aaa");
+    expect(res.matches[0].diagnostic.matchedBy).toBe("normalized-title");
+  });
+
+  it("prefers a valid findingId over an incorrect title", () => {
+    const res = reconcileVerdicts(expected, [
+      verdict({ findingId: "finding_ccc", filePath: "src/a.ts", title: "totally wrong" }),
+    ]);
+    expect(res.matches[0].expected.findingId).toBe("finding_ccc");
+    expect(res.matches[0].diagnostic.matchedBy).toBe("finding-id");
+  });
+
+  it("recovers a unique 1:1 remainder", () => {
+    const res = reconcileVerdicts(expected, [
+      verdict({ findingId: "finding_aaa" }),
+      verdict({ findingId: "finding_bbb" }),
+      verdict({ title: "some paraphrased redirect thing" }),
+    ]);
+    expect(res.matches).toHaveLength(3);
+    const remainder = res.matches.find((m) => m.expected.findingId === "finding_ccc");
+    expect(remainder?.diagnostic.matchedBy).toBe("unique-remainder");
+    expect(res.missing).toHaveLength(0);
+  });
+
+  it("does NOT unique-remainder-match when more than one finding remains", () => {
+    const res = reconcileVerdicts(expected, [verdict({ title: "who knows" })]);
+    expect(res.matches).toHaveLength(0);
+    expect(res.missing).toHaveLength(3);
+    expect(res.unknown).toHaveLength(1);
+  });
+
+  it("marks a verdict ambiguous when normalization matches multiple findings and never guesses", () => {
+    const ambExpected = [
+      exp("finding_x", "src/a.ts", "SQL Injection"),
+      exp("finding_y", "src/a.ts", "sql injection"),
+      exp("finding_z", "src/a.ts", "other thing"),
+    ];
+    const res = reconcileVerdicts(ambExpected, [
+      verdict({ filePath: "src/a.ts", title: "SQL INJECTION!" }),
+    ]);
+    expect(res.matches).toHaveLength(0);
+    expect(res.ambiguous).toHaveLength(1);
+    expect(res.missing).toHaveLength(3);
+  });
+
+  it("gives each finding at most one verdict (first match wins)", () => {
+    const res = reconcileVerdicts(expected, [
+      verdict({ findingId: "finding_aaa", verdict: "true-positive" }),
+      verdict({ findingId: "finding_aaa", verdict: "false-positive" }),
+    ]);
+    expect(res.matches).toHaveLength(1);
+    expect(res.matches[0].verdict.verdict).toBe("true-positive");
+  });
+});
+
+describe("resolveDuplicateRef", () => {
+  const mk = (filePath: string, findings: Array<Partial<Finding> & { title: string }>) =>
+    ({
+      filePath,
+      projectId: "p",
+      candidates: [],
+      lastScannedAt: "",
+      lastScannedRunId: "",
+      fileHash: "",
+      findings: findings.map((f) => ({
+        severity: "HIGH",
+        vulnSlug: "s",
+        description: "d",
+        lineNumbers: [1],
+        recommendation: "r",
+        confidence: "high",
+        ...f,
+      })),
+      analysisHistory: [],
+      status: "analyzed",
+    }) as FileRecord;
+
+  it("resolves by findingId, exact title, then normalized title", () => {
+    const file = mk("a.ts", [{ title: "Primary Thing", findingId: "finding_p" }]);
+    expect(resolveDuplicateRef({ ref: "finding_p", file })?.finding.title).toBe("Primary Thing");
+    expect(resolveDuplicateRef({ ref: "Primary Thing", file })?.finding.title).toBe(
+      "Primary Thing",
+    );
+    expect(resolveDuplicateRef({ ref: "`primary thing`", file })?.finding.title).toBe(
+      "Primary Thing",
+    );
+    expect(resolveDuplicateRef({ ref: "nope", file })).toBeUndefined();
+  });
+
+  it("returns undefined on ambiguous title references", () => {
+    const file = mk("a.ts", [
+      { title: "Same Title", findingId: "finding_1" },
+      { title: "same title", findingId: "finding_2" },
+    ]);
+    expect(resolveDuplicateRef({ ref: "SAME TITLE", file })).toBeUndefined();
+  });
+
+  it("only crosses files when crossFile is enabled", () => {
+    const a = mk("a.ts", [{ title: "dupe", findingId: "finding_d" }]);
+    const b = mk("b.ts", [{ title: "the primary", findingId: "finding_p" }]);
+    expect(resolveDuplicateRef({ ref: "finding_p", file: a, batch: [a, b] })).toBeUndefined();
+    expect(
+      resolveDuplicateRef({ ref: "finding_p", file: a, batch: [a, b], crossFile: true })?.finding
+        .findingId,
+    ).toBe("finding_p");
+  });
+});
+
+async function drain<T>(gen: AsyncGenerator<unknown, T>): Promise<T> {
+  let r = await gen.next();
+  while (!r.done) r = await gen.next();
+  return r.value;
+}
+
+describe("runRevalidateIdRepairLoop", () => {
+  const expected = [
+    exp("finding_aaa", "a.ts", "one"),
+    exp("finding_bbb", "a.ts", "two"),
+    exp("finding_ccc", "b.ts", "three"),
+  ];
+
+  it("skips repair entirely when everything reconciled", async () => {
+    let followUps = 0;
+    const out = await drain(
+      runRevalidateIdRepairLoop({
+        expected,
+        verdicts: expected.map((e) => verdict({ findingId: e.findingId })),
+        initialRawText: "[]",
+        followUp: async () => {
+          followUps++;
+          return "[]";
+        },
+        agentLabel: "test",
+      }),
+    );
+    expect(followUps).toBe(0);
+    expect(out.repairAttempts).toBe(0);
+    expect(out.verdicts).toHaveLength(3);
+  });
+
+  it("requests only the missing findings and merges the repair response", async () => {
+    const prompts: string[] = [];
+    const out = await drain(
+      runRevalidateIdRepairLoop({
+        expected,
+        verdicts: [
+          verdict({ findingId: "finding_aaa" }),
+          verdict({ findingId: "item_zzz", title: "mangled" }), // unknown identifier
+        ],
+        initialRawText: "raw-initial",
+        followUp: async (p) => {
+          prompts.push(p);
+          return JSON.stringify([
+            { findingId: "finding_bbb", verdict: "false-positive", reasoning: "fp" },
+            { findingId: "finding_ccc", verdict: "fixed", reasoning: "gone" },
+          ]);
+        },
+        agentLabel: "test",
+      }),
+    );
+    expect(out.repairAttempts).toBe(1);
+    expect(prompts).toHaveLength(1);
+    // Repair prompt lists exactly the missing IDs and the unmatched identifier.
+    expect(prompts[0]).toContain("finding_bbb");
+    expect(prompts[0]).toContain("finding_ccc");
+    expect(prompts[0]).not.toMatch(/- finding_aaa —/);
+    expect(prompts[0]).toContain("item_zzz");
+    // Merged verdicts now reconcile completely.
+    const rec = reconcileVerdicts(expected, out.verdicts);
+    expect(rec.missing).toHaveLength(0);
+    // Raw responses retained for artifact logging.
+    expect(out.rawResponses.map((r) => r.kind)).toEqual(["initial", "id-repair"]);
+    expect(out.rawResponses[0].rawText).toBe("raw-initial");
+  });
+
+  it("stops after two repair attempts", async () => {
+    let followUps = 0;
+    const out = await drain(
+      runRevalidateIdRepairLoop({
+        expected,
+        verdicts: [],
+        initialRawText: "[]",
+        followUp: async () => {
+          followUps++;
+          return JSON.stringify([
+            { findingId: "still_wrong", verdict: "uncertain", reasoning: "x" },
+          ]);
+        },
+        agentLabel: "test",
+      }),
+    );
+    expect(followUps).toBe(2);
+    expect(out.repairAttempts).toBe(2);
+  });
+
+  it("stops when the repair response is unparseable, keeping prior verdicts", async () => {
+    const out = await drain(
+      runRevalidateIdRepairLoop({
+        expected,
+        verdicts: [verdict({ findingId: "finding_aaa" })],
+        initialRawText: "[]",
+        followUp: async () => "not json at all",
+        agentLabel: "test",
+      }),
+    );
+    expect(out.repairAttempts).toBe(1);
+    expect(out.verdicts).toHaveLength(1);
+    expect(out.rawResponses.at(-1)?.kind).toBe("id-repair");
+  });
+
+  it("does nothing without a followUp channel", async () => {
+    const out = await drain(
+      runRevalidateIdRepairLoop({
+        expected,
+        verdicts: [],
+        initialRawText: "[]",
+        followUp: undefined,
+        agentLabel: "test",
+      }),
+    );
+    expect(out.repairAttempts).toBe(0);
+  });
+});
+
+describe("short aliases", () => {
+  const aliased = [
+    { ...exp("finding_aaa", "src/a.ts", "one"), alias: "F1" },
+    { ...exp("finding_bbb", "src/a.ts", "two"), alias: "F2" },
+    { ...exp("finding_ccc", "src/b.ts", "three"), alias: "F3" },
+  ];
+
+  it("normalizeAliasRef accepts F3 / f3 / #3 / bare 3 and rejects non-aliases", async () => {
+    const { normalizeAliasRef } = await import("../reconcile.js");
+    expect(normalizeAliasRef("F3")).toBe("3");
+    expect(normalizeAliasRef("f3")).toBe("3");
+    expect(normalizeAliasRef("#3")).toBe("3");
+    expect(normalizeAliasRef(" 3 ")).toBe("3");
+    expect(normalizeAliasRef("F03")).toBe("3");
+    expect(normalizeAliasRef("finding_abc123")).toBeUndefined();
+    expect(normalizeAliasRef("Fix the thing")).toBeUndefined();
+    expect(normalizeAliasRef("")).toBeUndefined();
+  });
+
+  it("expectedFindingsForBatch assigns F1..Fn in prompt order", async () => {
+    const { expectedFindingsForBatch } = await import("../reconcile.js");
+    const mkFile = (filePath: string, titles: string[]) =>
+      ({
+        filePath,
+        projectId: "p",
+        candidates: [],
+        lastScannedAt: "",
+        lastScannedRunId: "",
+        fileHash: "",
+        findings: titles.map((title) => ({
+          severity: "HIGH",
+          vulnSlug: "s",
+          title,
+          description: "d",
+          lineNumbers: [1],
+          recommendation: "r",
+          confidence: "high",
+        })),
+        analysisHistory: [],
+        status: "analyzed",
+      }) as FileRecord;
+    const out = expectedFindingsForBatch([mkFile("a.ts", ["x", "y"]), mkFile("b.ts", ["z"])]);
+    expect(out.map((e) => e.alias)).toEqual(["F1", "F2", "F3"]);
+  });
+
+  it("reconciles verdicts that echo the alias in any accepted form", () => {
+    const res = reconcileVerdicts(aliased, [
+      verdict({ findingId: "F1" }),
+      verdict({ findingId: "#2" }),
+      verdict({ findingId: "f3" }),
+    ]);
+    expect(res.matches.map((m) => m.expected.findingId).sort()).toEqual([
+      "finding_aaa",
+      "finding_bbb",
+      "finding_ccc",
+    ]);
+    expect(res.matches.every((m) => m.diagnostic.matchedBy === "finding-id")).toBe(true);
+    expect(res.missing).toHaveLength(0);
+  });
+
+  it("still accepts the full findingId when the model returns it instead of the alias", () => {
+    const res = reconcileVerdicts(aliased, [verdict({ findingId: "finding_bbb" })]);
+    expect(res.matches[0].expected.findingId).toBe("finding_bbb");
+  });
+
+  it("treats an out-of-range alias as unknown", () => {
+    const res = reconcileVerdicts(aliased, [
+      verdict({ findingId: "F9" }),
+      verdict({ findingId: "F8" }),
+    ]);
+    expect(res.matches).toHaveLength(0);
+    expect(res.unknown).toHaveLength(2);
+  });
+
+  it("buildAliasMap + resolveDuplicateRef translate alias references", async () => {
+    const { buildAliasMap } = await import("../reconcile.js");
+    const file = {
+      filePath: "src/a.ts",
+      projectId: "p",
+      candidates: [],
+      lastScannedAt: "",
+      lastScannedRunId: "",
+      fileHash: "",
+      findings: [
+        {
+          severity: "HIGH",
+          vulnSlug: "s",
+          title: "one",
+          description: "d",
+          lineNumbers: [1],
+          recommendation: "r",
+          confidence: "high",
+          findingId: "finding_aaa",
+        },
+      ],
+      analysisHistory: [],
+      status: "analyzed",
+    } as FileRecord;
+    const aliasMap = buildAliasMap(aliased);
+    expect(resolveDuplicateRef({ ref: "F1", file, aliasMap })?.finding.findingId).toBe(
+      "finding_aaa",
+    );
+    expect(resolveDuplicateRef({ ref: "F1", file })).toBeUndefined(); // no map, no guess
+  });
+});
+
+describe("buildRevalidatePrompt alias rendering", () => {
+  it("shows short aliases as the Finding ID and lists them in the checklist", async () => {
+    const { buildRevalidatePrompt } = await import("../agents/shared.js");
+    const file = {
+      filePath: "src/a.ts",
+      projectId: "p",
+      candidates: [],
+      lastScannedAt: "",
+      lastScannedRunId: "",
+      fileHash: "",
+      findings: ["alpha issue", "beta issue"].map((title) => ({
+        severity: "HIGH" as const,
+        vulnSlug: "s",
+        title,
+        description: "d",
+        lineNumbers: [1],
+        recommendation: "r",
+        confidence: "high" as const,
+      })),
+      analysisHistory: [],
+      status: "analyzed" as const,
+    } as FileRecord;
+
+    const { prompt, expected } = buildRevalidatePrompt({
+      batch: [file],
+      projectRoot: process.cwd(),
+      projectInfo: "",
+      force: false,
+    });
+
+    expect(expected.map((e) => e.alias)).toEqual(["F1", "F2"]);
+    expect(prompt).toContain("- **Finding ID:** F1");
+    expect(prompt).toContain("- **Finding ID:** F2");
+    expect(prompt).toContain('- F1 — "alpha issue"');
+    expect(prompt).toContain('- F2 — "beta issue"');
+    // The long hash never reaches the model — nothing to truncate or mangle.
+    expect(prompt).not.toContain("finding_");
+  });
+});

--- a/packages/processor/src/agents/claude-agent-sdk.ts
+++ b/packages/processor/src/agents/claude-agent-sdk.ts
@@ -16,6 +16,7 @@ import {
   parseRevalidateVerdicts,
   QuotaExhaustedError,
   REFUSAL_FOLLOWUP_PROMPT,
+  runRevalidateIdRepairLoop,
   writeParseFailureDebug,
 } from "./shared.js";
 import type {
@@ -27,6 +28,7 @@ import type {
   InvestigateResult,
   RevalidateOutput,
   RevalidateParams,
+  RevalidateRawResponse,
   RevalidateVerdict,
 } from "./types.js";
 
@@ -476,7 +478,16 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
   }
 
   async *revalidate(params: RevalidateParams): AsyncGenerator<AgentProgress, RevalidateOutput> {
-    const { batch, projectRoot, projectInfo, config, force = false, signal, projectId } = params;
+    const {
+      batch,
+      projectRoot,
+      projectInfo,
+      config,
+      force = false,
+      onlyFindingIds,
+      signal,
+      projectId,
+    } = params;
     const model = (config.model as string) ?? "claude-opus-4-8";
     const maxTurns = (config.maxTurns as number) ?? 150;
 
@@ -488,11 +499,12 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
       else signal.addEventListener("abort", () => abortController.abort(), { once: true });
     }
 
-    const { prompt, totalFindings } = buildRevalidatePrompt({
+    const { prompt, totalFindings, expected } = buildRevalidatePrompt({
       batch,
       projectRoot,
       projectInfo,
       force,
+      onlyFindingIds: onlyFindingIds ? new Set(onlyFindingIds) : undefined,
     });
 
     yield {
@@ -614,6 +626,7 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
     }
 
     const durationMs = Date.now() - startTime;
+    const preResponses: RevalidateRawResponse[] = [];
     let verdicts: RevalidateVerdict[];
     try {
       verdicts = parseRevalidateVerdicts(resultText);
@@ -622,11 +635,12 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
         type: "thinking" as const,
         message: "Claude returned non-JSON revalidation output; requesting JSON-only repair",
       };
+      const jsonRepairPrompt = buildRevalidateJsonRepairPrompt(expected);
       const repairText = await runToollessFollowUp(
         sdkMeta.agentSessionId,
         model,
         projectRoot,
-        buildRevalidateJsonRepairPrompt(),
+        jsonRepairPrompt,
       );
       if (repairText === undefined) {
         writeParseFailureDebug({
@@ -641,6 +655,7 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
       }
       try {
         verdicts = parseRevalidateVerdicts(repairText);
+        preResponses.push({ kind: "json-repair", prompt: jsonRepairPrompt, rawText: resultText });
         resultText = repairText;
         yield { type: "thinking" as const, message: "Claude JSON repair succeeded" };
       } catch (repairErr) {
@@ -656,6 +671,19 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
         throw combinedError;
       }
     }
+
+    // Id-repair: recover verdicts the model returned under a mangled
+    // identifier by continuing the same session tool-free.
+    const repair = yield* runRevalidateIdRepairLoop({
+      expected,
+      verdicts,
+      initialRawText: resultText,
+      followUp: sdkMeta.agentSessionId
+        ? (p) => runToollessFollowUp(sdkMeta.agentSessionId, model, projectRoot, p)
+        : undefined,
+      agentLabel: "Claude",
+    });
+    verdicts = repair.verdicts;
 
     const refusal = await runRefusalFollowUp(sdkMeta.agentSessionId, model, projectRoot);
     if (refusal?.refused) {
@@ -674,6 +702,8 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
     return {
       verdicts,
       meta: { durationMs, ...sdkMeta, refusal },
+      rawResponses: [...preResponses, ...repair.rawResponses],
+      repairAttempts: repair.repairAttempts,
     };
   }
 }

--- a/packages/processor/src/agents/codex-sdk.ts
+++ b/packages/processor/src/agents/codex-sdk.ts
@@ -28,6 +28,7 @@ import {
   parseRevalidateVerdicts,
   QuotaExhaustedError,
   REFUSAL_FOLLOWUP_PROMPT,
+  runRevalidateIdRepairLoop,
   writeParseFailureDebug,
 } from "./shared.js";
 import type {
@@ -39,6 +40,7 @@ import type {
   InvestigateResult,
   RevalidateOutput,
   RevalidateParams,
+  RevalidateRawResponse,
   RevalidateVerdict,
 } from "./types.js";
 
@@ -951,7 +953,16 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
   }
 
   async *revalidate(params: RevalidateParams): AsyncGenerator<AgentProgress, RevalidateOutput> {
-    const { batch, projectRoot, projectInfo, config, force = false, signal, projectId } = params;
+    const {
+      batch,
+      projectRoot,
+      projectInfo,
+      config,
+      force = false,
+      onlyFindingIds,
+      signal,
+      projectId,
+    } = params;
     const model = (config.model as string) ?? DEFAULT_MODEL;
     const effort = (config.reasoningEffort as ModelReasoningEffort) ?? DEFAULT_EFFORT;
 
@@ -960,8 +971,10 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
       projectRoot,
       projectInfo,
       force,
+      onlyFindingIds: onlyFindingIds ? new Set(onlyFindingIds) : undefined,
     });
     const totalFindings = built.totalFindings;
+    const expected = built.expected;
     const prompt = `${codexEnvironmentPreamble(projectRoot)}\n\n${built.prompt}`;
 
     yield {
@@ -1129,6 +1142,8 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
         );
       }
 
+      const preResponses: RevalidateRawResponse[] = [];
+      let parsedText = resultText;
       let verdicts: RevalidateVerdict[];
       try {
         verdicts = parseRevalidateVerdicts(resultText);
@@ -1137,12 +1152,13 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
           type: "thinking" as const,
           message: "Codex returned non-JSON revalidation output; requesting JSON-only repair",
         };
+        const jsonRepairPrompt = buildRevalidateJsonRepairPrompt(expected);
         const repairText = await runToollessFollowUp(
           codex,
           threadId,
           projectRoot,
           model,
-          buildRevalidateJsonRepairPrompt(),
+          jsonRepairPrompt,
         );
         if (repairText === undefined) {
           writeParseFailureDebug({
@@ -1157,6 +1173,8 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
         }
         try {
           verdicts = parseRevalidateVerdicts(repairText);
+          preResponses.push({ kind: "json-repair", prompt: jsonRepairPrompt, rawText: resultText });
+          parsedText = repairText;
           yield { type: "thinking" as const, message: "Codex JSON repair succeeded" };
         } catch (repairErr) {
           const combinedError = jsonRepairFailureError(err, repairErr);
@@ -1178,6 +1196,19 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
         };
       }
 
+      // Id-repair inside the still-live thread (must run before the
+      // finally block tears down CODEX_HOME).
+      const repair = yield* runRevalidateIdRepairLoop({
+        expected,
+        verdicts,
+        initialRawText: parsedText,
+        followUp: threadId
+          ? (p) => runToollessFollowUp(codex, threadId, projectRoot, model, p)
+          : undefined,
+        agentLabel: "Codex",
+      });
+      verdicts = repair.verdicts;
+
       const refusal = await runRefusalFollowUp(codex, threadId, projectRoot, model);
       if (refusal?.refused) {
         yield {
@@ -1195,6 +1226,8 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
       return {
         verdicts,
         meta: { durationMs, ...sdkMeta, refusal },
+        rawResponses: [...preResponses, ...repair.rawResponses],
+        repairAttempts: repair.repairAttempts,
       };
     } finally {
       cleanup();

--- a/packages/processor/src/agents/pi-sdk.ts
+++ b/packages/processor/src/agents/pi-sdk.ts
@@ -34,6 +34,7 @@ import {
   parseRevalidateVerdicts,
   QuotaExhaustedError,
   REFUSAL_FOLLOWUP_PROMPT,
+  runRevalidateIdRepairLoop,
   writeParseFailureDebug,
 } from "./shared.js";
 import type {
@@ -45,6 +46,7 @@ import type {
   InvestigateResult,
   RevalidateOutput,
   RevalidateParams,
+  RevalidateRawResponse,
   RevalidateVerdict,
 } from "./types.js";
 
@@ -912,14 +914,24 @@ export class PiAgentPlugin implements AgentPlugin {
   }
 
   async *revalidate(params: RevalidateParams): AsyncGenerator<AgentProgress, RevalidateOutput> {
-    const { batch, projectRoot, projectInfo, config, force = false, signal, projectId } = params;
+    const {
+      batch,
+      projectRoot,
+      projectInfo,
+      config,
+      force = false,
+      onlyFindingIds,
+      signal,
+      projectId,
+    } = params;
     const cfg = readConfig(config);
     const maxTurns = cfg.maxTurns ?? 150;
-    const { prompt, totalFindings } = buildRevalidatePrompt({
+    const { prompt, totalFindings, expected } = buildRevalidatePrompt({
       batch,
       projectRoot,
       projectInfo,
       force,
+      onlyFindingIds: onlyFindingIds ? new Set(onlyFindingIds) : undefined,
     });
     const startTime = Date.now();
 
@@ -990,6 +1002,8 @@ export class PiAgentPlugin implements AgentPlugin {
     }
 
     const durationMs = Date.now() - startTime;
+    const preResponses: RevalidateRawResponse[] = [];
+    const jsonRepairPrompt = buildRevalidateJsonRepairPrompt(expected);
     let verdicts: RevalidateVerdict[];
     try {
       verdicts = parseRevalidateVerdicts(resultText);
@@ -998,11 +1012,7 @@ export class PiAgentPlugin implements AgentPlugin {
         type: "thinking",
         message: "Pi returned non-JSON revalidation output; requesting JSON-only repair",
       };
-      const repairText = await runToollessFollowUp(
-        session,
-        buildRevalidateJsonRepairPrompt(),
-        signal,
-      );
+      const repairText = await runToollessFollowUp(session, jsonRepairPrompt, signal);
       if (repairText === undefined) {
         writeParseFailureDebug({
           projectId,
@@ -1017,6 +1027,7 @@ export class PiAgentPlugin implements AgentPlugin {
       }
       try {
         verdicts = parseRevalidateVerdicts(repairText);
+        preResponses.push({ kind: "json-repair", prompt: jsonRepairPrompt, rawText: resultText });
         resultText = repairText;
         yield { type: "thinking", message: "Pi JSON repair succeeded" };
       } catch (repairErr) {
@@ -1033,6 +1044,18 @@ export class PiAgentPlugin implements AgentPlugin {
         throw combinedError;
       }
     }
+
+    // Id-repair against the still-live in-memory Pi session (must run
+    // before dispose()).
+    const liveSession = session;
+    const repair = yield* runRevalidateIdRepairLoop({
+      expected,
+      verdicts,
+      initialRawText: resultText,
+      followUp: liveSession ? (p) => runToollessFollowUp(liveSession, p, signal) : undefined,
+      agentLabel: "Pi",
+    });
+    verdicts = repair.verdicts;
 
     const refusal = await runRefusalFollowUp(session, signal);
     if (refusal?.refused) {
@@ -1052,6 +1075,8 @@ export class PiAgentPlugin implements AgentPlugin {
     return {
       verdicts,
       meta: { durationMs, ...sdkMeta, refusal },
+      rawResponses: [...preResponses, ...repair.rawResponses],
+      repairAttempts: repair.repairAttempts,
     };
   }
 }

--- a/packages/processor/src/agents/shared.ts
+++ b/packages/processor/src/agents/shared.ts
@@ -3,7 +3,18 @@ import fs from "node:fs";
 import path from "node:path";
 import { dataDir, type FileRecord, type Finding, type RefusalReport } from "@deepsec/core";
 import { jsonrepair } from "jsonrepair";
-import type { InvestigateResult, RevalidateVerdict } from "./types.js";
+import {
+  type ExpectedFinding,
+  expectedFindingsForBatch,
+  reconcileVerdicts,
+  shouldRevalidateFinding,
+} from "../reconcile.js";
+import type {
+  AgentProgress,
+  InvestigateResult,
+  RevalidateRawResponse,
+  RevalidateVerdict,
+} from "./types.js";
 
 // --- Retry / backoff -------------------------------------------------------
 
@@ -473,7 +484,11 @@ Use this exact schema:
 \`severity\` must be one of \`CRITICAL\`, \`HIGH\`, \`MEDIUM\`, \`HIGH_BUG\`, or \`BUG\`. \`confidence\` must be one of \`high\`, \`medium\`, or \`low\`.`;
 }
 
-export function buildRevalidateJsonRepairPrompt(): string {
+export function buildRevalidateJsonRepairPrompt(expected?: ExpectedFinding[]): string {
+  const idList =
+    expected && expected.length > 0
+      ? `\nReturn exactly one verdict for every Finding ID below, copying each \`findingId\` exactly:\n\n${expected.map((e) => `- ${e.alias ?? e.findingId} — "${e.title}"`).join("\n")}\n`
+      : "";
   return `Your previous response was not valid JSON, so the scanner could not parse it.
 
 Do not redo the revalidation and do not use tools. Re-output the same verdicts and reasoning from your previous response as ONLY one valid JSON array. No prose before or after. No "Confirmed:" preface. A \`\`\`json fenced block is acceptable, but the content inside must be valid JSON.
@@ -485,17 +500,158 @@ Use this exact schema:
 \`\`\`json
 [
   {
-    "filePath": "exact/path/to/file.ts",
-    "title": "exact title from the finding",
+    "findingId": "the exact Finding ID from the finding, e.g. F3",
     "verdict": "true-positive",
     "adjustedSeverity": "HIGH",
-    "duplicateOf": "title of the primary finding (only when verdict is duplicate)",
+    "duplicateOf": "Finding ID of the primary finding (only when verdict is duplicate)",
     "reasoning": "Detailed explanation. Show your work."
   }
 ]
 \`\`\`
-
+${idList}
 \`verdict\` must be one of \`true-positive\`, \`false-positive\`, \`fixed\`, \`uncertain\`, or \`duplicate\`. \`adjustedSeverity\` is optional and must be one of \`CRITICAL\`, \`HIGH\`, \`MEDIUM\`, \`HIGH_BUG\`, or \`BUG\` when present. \`duplicateOf\` is required only when \`verdict\` is \`"duplicate"\`; omit it otherwise.`;
+}
+
+/**
+ * Follow-up prompt for the id-repair turn: the previous response parsed
+ * as JSON, but some requested findings got no reconcilable verdict. Ask
+ * only for the missing ones, show which returned identifiers didn't
+ * match, and echo the unmatched verdicts back so the model mostly just
+ * has to fix the ID rather than restate its analysis.
+ */
+function buildRevalidateIdRepairPrompt(params: {
+  appliedCount: number;
+  missing: ExpectedFinding[];
+  unmatchedVerdicts: RevalidateVerdict[];
+}): string {
+  const { appliedCount, missing, unmatchedVerdicts } = params;
+
+  const missingList = missing
+    .map((e) => `- ${e.alias ?? e.findingId} — ${e.filePath} — "${e.title}"`)
+    .join("\n");
+
+  const unknownIdentifiers = unmatchedVerdicts
+    .map((v) => v.findingId ?? v.title ?? "")
+    .filter(Boolean)
+    .map((s) => `- ${JSON.stringify(s)}`)
+    .join("\n");
+  const unknownBlock = unknownIdentifiers
+    ? `\nThe following identifiers from your response could not be matched to any requested finding:\n\n${unknownIdentifiers}\n`
+    : "";
+
+  const nearMissBlock =
+    unmatchedVerdicts.length > 0
+      ? `\nThese verdicts from your previous response could not be matched. If one of them corresponds to a missing finding ID above, re-emit it with the corrected \`findingId\` — keep the verdict and reasoning as they were:\n\n\`\`\`json\n${JSON.stringify(
+          unmatchedVerdicts.map((v) => ({
+            findingId: v.findingId,
+            title: v.title,
+            verdict: v.verdict,
+            adjustedSeverity: v.adjustedSeverity,
+            duplicateOf: v.duplicateOf,
+            reasoning: v.reasoning,
+          })),
+          null,
+          2,
+        )}\n\`\`\`\n`
+      : "";
+
+  return `Your previous response was parsed, and ${appliedCount} verdict(s) were successfully matched to findings.
+
+The following required finding IDs are still missing a verdict:
+
+${missingList}
+${unknownBlock}${nearMissBlock}
+Return ONLY a JSON array containing verdicts for the missing Finding IDs listed above. Copy each \`findingId\` exactly as shown — do not invent or modify IDs. Preserve your previous conclusions; do not repeat the investigation and do not use tools.
+
+\`\`\`json
+[
+  {
+    "findingId": "F3",
+    "verdict": "true-positive" | "false-positive" | "fixed" | "uncertain" | "duplicate",
+    "adjustedSeverity": "HIGH",
+    "duplicateOf": "Finding ID of the primary finding (only when verdict is duplicate)",
+    "reasoning": "Your reasoning from before, compact."
+  }
+]
+\`\`\``;
+}
+
+/**
+ * In-session id-repair loop, shared by every agent plugin. After the
+ * initial revalidation response parses, reconcile it against the
+ * requested findings; while any finding is still missing a verdict, ask
+ * the SAME session (tool-free) for just the missing ones — up to
+ * `maxRepairs` times. The session still holds the full investigation
+ * context, so this recovers verdicts the model produced under a mangled
+ * identifier without re-running any analysis.
+ *
+ * Returns the merged verdict list (initial + repair turns; the
+ * reconciler's first-match-wins ordering means repaired verdicts only
+ * fill gaps, never displace an already-matched verdict) plus the raw
+ * responses for artifact logging.
+ */
+export async function* runRevalidateIdRepairLoop(params: {
+  expected: ExpectedFinding[];
+  verdicts: RevalidateVerdict[];
+  initialRawText: string;
+  followUp: ((prompt: string) => Promise<string | undefined>) | undefined;
+  agentLabel: string;
+  maxRepairs?: number;
+}): AsyncGenerator<
+  AgentProgress,
+  { verdicts: RevalidateVerdict[]; rawResponses: RevalidateRawResponse[]; repairAttempts: number }
+> {
+  const { expected, initialRawText, followUp, agentLabel, maxRepairs = 2 } = params;
+  let verdicts = params.verdicts;
+  const rawResponses: RevalidateRawResponse[] = [
+    { kind: "initial", rawText: initialRawText, parsedCount: verdicts.length },
+  ];
+  let repairAttempts = 0;
+
+  while (repairAttempts < maxRepairs) {
+    const rec = reconcileVerdicts(expected, verdicts);
+    if (rec.missing.length === 0) break;
+    if (!followUp) break;
+
+    repairAttempts++;
+    yield {
+      type: "thinking",
+      message: `${agentLabel}: ${rec.missing.length}/${expected.length} verdict(s) missing after reconciliation; requesting id-repair (attempt ${repairAttempts}/${maxRepairs})`,
+    };
+
+    const prompt = buildRevalidateIdRepairPrompt({
+      appliedCount: rec.matches.length,
+      missing: rec.missing,
+      unmatchedVerdicts: [...rec.unknown, ...rec.ambiguous],
+    });
+    const repairText = await followUp(prompt);
+    if (repairText === undefined) {
+      rawResponses.push({ kind: "id-repair", prompt, rawText: "(follow-up failed)" });
+      break;
+    }
+
+    let repairVerdicts: RevalidateVerdict[];
+    try {
+      repairVerdicts = parseRevalidateVerdicts(repairText);
+    } catch {
+      rawResponses.push({ kind: "id-repair", prompt, rawText: repairText });
+      yield {
+        type: "thinking",
+        message: `${agentLabel}: id-repair response was not parseable JSON; stopping repair`,
+      };
+      break;
+    }
+    rawResponses.push({
+      kind: "id-repair",
+      prompt,
+      rawText: repairText,
+      parsedCount: repairVerdicts.length,
+    });
+    if (repairVerdicts.length === 0) break;
+    verdicts = [...verdicts, ...repairVerdicts];
+  }
+
+  return { verdicts, rawResponses, repairAttempts };
 }
 
 export function formatJsonRepairFailureDebugText(originalText: string, repairText: string): string {
@@ -621,18 +777,29 @@ export function buildRevalidatePrompt(params: {
   projectRoot: string;
   projectInfo: string;
   force: boolean;
-}): { prompt: string; totalFindings: number } {
-  const { batch, projectRoot, projectInfo, force } = params;
+  /** See RevalidateParams.onlyFindingIds. */
+  onlyFindingIds?: ReadonlySet<string>;
+}): { prompt: string; totalFindings: number; expected: ExpectedFinding[] } {
+  const { batch, projectRoot, projectInfo, force, onlyFindingIds } = params;
+  const filterOpts = { force, onlyFindingIds };
+
+  // Single source of truth for identity AND aliases: the processor
+  // reconciles against expectedFindingsForBatch with the same inputs, so
+  // the short alias shown here ("F3") maps back to the same findingId on
+  // both sides.
+  const expected = expectedFindingsForBatch(batch, filterOpts);
+  const aliasById = new Map(expected.map((e) => [e.findingId, e.alias]));
 
   const fileSections: string[] = [];
 
   for (const file of batch) {
-    const findingsToCheck = file.findings.filter((f) => force || !f.revalidation);
+    const findingsToCheck = file.findings.filter((f) => shouldRevalidateFinding(f, filterOpts));
     if (findingsToCheck.length === 0) continue;
 
     const findingsList = findingsToCheck
       .map((f) => {
         return `### Finding: ${f.title}
+- **Finding ID:** ${aliasById.get(f.findingId!) ?? f.findingId}
 - **Severity:** ${f.severity}
 - **Slug:** ${f.vulnSlug}
 - **Lines:** ${f.lineNumbers.join(", ")}
@@ -666,10 +833,7 @@ export function buildRevalidatePrompt(params: {
     fileSections.push(`## File: ${file.filePath}\n\n${findingsList}\n${gitContext}`);
   }
 
-  const totalFindings = batch.reduce(
-    (s, f) => s + f.findings.filter((ff) => force || !ff.revalidation).length,
-    0,
-  );
+  const totalFindings = expected.length;
 
   const prompt = `You are a world-class security researcher performing an adversarial review of vulnerability findings. Your goal is to determine, with high confidence, whether each finding is real and exploitable. You must be thorough — incorrect verdicts here directly impact security decisions.
 
@@ -699,14 +863,14 @@ For EACH finding, perform ALL of these steps before rendering a verdict:
 - **false-positive** — Not exploitable. Name the specific mitigation.
 - **fixed** — Was real but has been patched. Cite the change.
 - **uncertain** — Can't determine. Explain what's ambiguous.
-- **duplicate** — This finding describes the **same underlying vulnerability** at the **same code location** as another finding in the **same file** (e.g., two matchers flagged the same line range from different angles, or the same auth bypass surfaced twice with different phrasing). Set \`duplicateOf\` to the exact \`title\` of the primary finding — the one that should keep the canonical verdict. Same vuln class in a different location is **not** a duplicate.
+- **duplicate** — This finding describes the **same underlying vulnerability** at the **same code location** as another finding in the **same file** (e.g., two matchers flagged the same line range from different angles, or the same auth bypass surfaced twice with different phrasing). Set \`duplicateOf\` to the Finding ID of the primary finding — the one that should keep the canonical verdict. Same vuln class in a different location is **not** a duplicate.
 
 If severity should change, set \`adjustedSeverity\`. Omit if correct.
 
 ### Duplicate rules (read carefully)
 
 - \`duplicate\` is only valid within a single file. Cross-file similarity does **not** count.
-- For any equivalence class of duplicates, **exactly one finding stays primary** with a real verdict (true-positive / false-positive / fixed / uncertain). The other(s) are \`duplicate\` with \`duplicateOf\` pointing at the primary's title.
+- For any equivalence class of duplicates, **exactly one finding stays primary** with a real verdict (true-positive / false-positive / fixed / uncertain). The other(s) are \`duplicate\` with \`duplicateOf\` pointing at the primary's Finding ID.
 - The primary you reference in \`duplicateOf\` **must itself have a non-duplicate verdict** in your output (or already in the file's prior revalidation). If you mark every member of a group as duplicate, all of them will be rejected.
 - Pick the primary as the most precise / highest-confidence statement of the issue. The duplicates should add context in their \`reasoning\`, not repeat the full analysis.
 
@@ -715,21 +879,24 @@ If severity should change, set \`adjustedSeverity\`. Omit if correct.
 \`\`\`json
 [
   {
-    "filePath": "exact/path/to/file.ts",
-    "title": "exact title from the finding",
+    "findingId": "the exact Finding ID from the finding, e.g. F3",
     "verdict": "true-positive" | "false-positive" | "fixed" | "uncertain" | "duplicate",
     "adjustedSeverity": "CRITICAL" | "HIGH" | "MEDIUM" | "HIGH_BUG" | "BUG",
-    "duplicateOf": "title of the primary finding (only when verdict is duplicate)",
+    "duplicateOf": "Finding ID of the primary finding (only when verdict is duplicate)",
     "reasoning": "Detailed explanation (5-10 sentences). Show your work."
   }
 ]
 \`\`\`
 
-**Include \`filePath\` for every verdict** so we can match verdicts to the correct file. \`adjustedSeverity\` is optional. \`duplicateOf\` is required iff \`verdict === "duplicate"\` and is otherwise ignored.
+You must return exactly one verdict for every Finding ID below:
+
+${expected.map((e) => `- ${e.alias ?? e.findingId} — "${e.title}"`).join("\n")}
+
+**Copy each \`findingId\` exactly as shown. Do not invent or modify IDs.** The Finding ID — not the title — is how verdicts are matched back to findings. \`adjustedSeverity\` is optional. \`duplicateOf\` is required iff \`verdict === "duplicate"\` and is otherwise ignored; it must also be a Finding ID.
 
 **Your reasoning is the most important part.** A verdict without thorough reasoning is worthless.`;
 
-  return { prompt, totalFindings };
+  return { prompt, totalFindings, expected };
 }
 
 export function parseRevalidateVerdicts(resultText: string): RevalidateVerdict[] {

--- a/packages/processor/src/agents/types.ts
+++ b/packages/processor/src/agents/types.ts
@@ -69,6 +69,13 @@ export interface RevalidateParams {
   config: Record<string, unknown>;
   /** When true, re-check findings that already have a revalidation verdict */
   force?: boolean;
+  /**
+   * Restrict the prompt to exactly these findingIds. Used by the
+   * processor's adaptive-split retries: after a partial batch is
+   * persisted, only the unresolved findings are re-requested —
+   * regardless of `force` and of what got a verdict in the meantime.
+   */
+  onlyFindingIds?: string[];
   /** See InvestigateParams.signal — same semantics for revalidation. */
   signal?: AbortSignal;
   /** See InvestigateParams.projectId — used for debug-log placement. */
@@ -76,23 +83,51 @@ export interface RevalidateParams {
 }
 
 export interface RevalidateVerdict {
-  filePath: string;
-  title: string;
+  /**
+   * Primary identity in the response contract: the stable `findingId`
+   * echoed back from the prompt. Old responses (and old prompts) carry
+   * filePath+title instead — the reconciliation layer accepts either.
+   */
+  findingId?: string;
+  filePath?: string;
+  title?: string;
   verdict: RevalidationVerdict;
   reasoning: string;
   adjustedSeverity?: "CRITICAL" | "HIGH" | "MEDIUM" | "HIGH_BUG" | "BUG";
   /**
-   * Required when `verdict === "duplicate"`. `title` of the primary
-   * finding in the same file — the canonical one that should keep its
-   * real verdict. The processor rejects DUPEs that don't reference a
-   * non-DUPE primary in the same file.
+   * Required when `verdict === "duplicate"`. The `findingId` of the
+   * primary finding (preferred), or its `title` for legacy responses —
+   * the canonical finding that should keep its real verdict. The
+   * processor rejects DUPEs that don't reference a non-DUPE primary.
    */
   duplicateOf?: string;
+}
+
+/**
+ * One raw agent response captured during a revalidation batch — the
+ * initial answer plus any repair turns. Persisted verbatim under the
+ * project data dir so mismatches can be diagnosed and rescored without
+ * repeating model work.
+ */
+export interface RevalidateRawResponse {
+  kind: "initial" | "json-repair" | "id-repair";
+  /** The follow-up prompt that produced this response (repair turns only). */
+  prompt?: string;
+  rawText: string;
+  /** How many verdicts parsed out of this response (undefined if parsing failed). */
+  parsedCount?: number;
 }
 
 export interface RevalidateOutput {
   verdicts: RevalidateVerdict[];
   meta: BatchMeta;
+  /**
+   * Raw model responses (initial + repair turns) for artifact logging.
+   * Optional: plugins that predate the field simply produce no artifact.
+   */
+  rawResponses?: RevalidateRawResponse[];
+  /** Number of in-session id-repair turns the plugin ran. */
+  repairAttempts?: number;
 }
 
 export interface AgentPlugin {

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -8,6 +8,7 @@ import {
   createRunMeta,
   dataDir,
   defaultConcurrency,
+  ensureFindingIds,
   getRegistry,
   isPidAlive,
   loadAllFileRecords,
@@ -34,6 +35,13 @@ import { batchCandidates } from "./batch.js";
 import { enrichFileRecord } from "./enrich.js";
 import { assemblePrompt } from "./prompt/assemble.js";
 import { languagesForBatch } from "./prompt/file-language.js";
+import {
+  buildAliasMap,
+  type ExpectedFinding,
+  expectedFindingsForBatch,
+  reconcileVerdicts,
+  resolveDuplicateRef,
+} from "./reconcile.js";
 
 export { ClaudeAgentSdkPlugin } from "./agents/claude-agent-sdk.js";
 export { CodexAgentSdkPlugin } from "./agents/codex-sdk.js";
@@ -57,6 +65,20 @@ export {
   noteForSlug,
   TECH_HIGHLIGHTS,
 } from "./prompt/index.js";
+export {
+  buildAliasMap,
+  type ExpectedFinding,
+  expectedFindingsForBatch,
+  type MatchedBy,
+  normalizeAliasRef,
+  normalizePath,
+  normalizeTitle,
+  type ReconcileDiagnostic,
+  type ReconcileMatch,
+  type ReconcileResult,
+  reconcileVerdicts,
+  resolveDuplicateRef,
+} from "./reconcile.js";
 export { triage } from "./triage.js";
 
 export function createDefaultAgentRegistry(): AgentRegistry {
@@ -662,6 +684,9 @@ export async function process(params: {
             // undefined for findings written before this field existed.
             .map((f) => ({ ...f, producedByRunId: runId }));
           record.findings = [...(record.findings ?? []), ...newFindings];
+          // Stamp stable findingIds on the appended findings at creation
+          // time (existing findings already have theirs from load).
+          ensureFindingIds(record);
           const findingsForHistoryCount = newFindings.length;
 
           record.analysisHistory.push({
@@ -838,6 +863,12 @@ export async function revalidate(params: {
   onlySlugs?: string[];
   /** Skip findings with any of these vulnSlugs */
   skipSlugs?: string[];
+  /**
+   * Allow a `duplicateOf` reference to resolve to a finding in another
+   * file of the same batch. Default false — duplicates are same-file
+   * only, matching the prompt's instructions.
+   */
+  crossFileDuplicates?: boolean;
   onProgress?: (progress: ProcessProgress) => void;
 }): Promise<{
   runId: string;
@@ -854,6 +885,15 @@ export async function revalidate(params: {
    * on the next run.
    */
   duplicatesRejected: number;
+  /** Total findings this run asked the agent(s) to revalidate. */
+  requested: number;
+  /**
+   * Findings that still have no persisted verdict after in-session
+   * repair and adaptive batch splitting. Non-empty means the run is
+   * incomplete — the CLI treats this as a failure exit. Each entry
+   * identifies the finding so a follow-up run can target it.
+   */
+  unresolved: Array<{ findingId: string; filePath: string; title: string }>;
   /** Same semantics as `process()` — see that return type. */
   quotaExhausted?: { source: QuotaSource; rawMessage: string };
 }> {
@@ -863,6 +903,7 @@ export async function revalidate(params: {
     config = {},
     minSeverity,
     force = false,
+    crossFileDuplicates = false,
   } = params;
 
   const emitProgress = (progress: ProcessProgress) => {
@@ -988,6 +1029,8 @@ export async function revalidate(params: {
         uncertain: 0,
         duplicates: 0,
         duplicatesRejected: 0,
+        requested: 0,
+        unresolved: [],
       };
     }
 
@@ -997,8 +1040,12 @@ export async function revalidate(params: {
     let totalFixed = 0;
     let totalUncertain = 0;
     let totalDuplicate = 0;
-    let totalDupeRejected = 0;
+    // Rejected DUPEs keyed by findingId — split retries re-reject the
+    // same finding, and counting per attempt would inflate the stat.
+    const dupeRejectedIds = new Set<string>();
     let totalCostUsd = 0;
+    let totalRequested = 0;
+    const totalUnresolved: ExpectedFinding[] = [];
     let batchesCompleted = 0;
     let batchesInFlight = 0;
     const concurrency = params.concurrency ?? defaultConcurrency();
@@ -1010,181 +1057,440 @@ export async function revalidate(params: {
     const quotaAbort = new AbortController();
     let quotaExhausted: { source: QuotaSource; rawMessage: string } | undefined;
 
+    // Every agent invocation (initial batch, per-file retry, per-finding
+    // retry) drops one artifact here: raw model responses, parsed
+    // verdicts, reconciliation diagnostics, and repair prompts. Lives in
+    // the project data dir — not an ephemeral debug location — so
+    // failures can be diagnosed and rescored without repeating model
+    // work.
+    const artifactsDir = path.join(dataDir(projectId), "revalidation", runId);
+    let artifactSeq = 0;
+    const writeInvocationArtifact = (artifact: Record<string, unknown>): void => {
+      try {
+        fs.mkdirSync(artifactsDir, { recursive: true });
+        const name = `invocation-${String(artifactSeq++).padStart(3, "0")}.json`;
+        fs.writeFileSync(
+          path.join(artifactsDir, name),
+          JSON.stringify(artifact, null, 2) + "\n",
+          "utf-8",
+        );
+      } catch (e) {
+        console.error(
+          `[deepsec] failed to write revalidation artifact: ${e instanceof Error ? e.message : e}`,
+        );
+      }
+    };
+
+    interface InvocationResult {
+      expectedCount: number;
+      returnedCount: number;
+      matchedCount: number;
+      persistedCount: number;
+      /** Expected findings that still have no persisted verdict. */
+      unresolved: ExpectedFinding[];
+    }
+
+    /**
+     * One agent call + reconcile + persist. Verdicts that reconcile
+     * unambiguously are applied and written to disk IMMEDIATELY — a miss
+     * elsewhere in the batch never discards them. Returns the findings
+     * that remain unresolved so the caller can retry just those.
+     */
+    async function runRevalidateInvocation(inv: {
+      files: FileRecord[];
+      onlyFindingIds?: string[];
+      batchIdx: number;
+      label: string;
+    }): Promise<InvocationResult> {
+      const { files, onlyFindingIds, batchIdx, label } = inv;
+      const onlySet = onlyFindingIds ? new Set(onlyFindingIds) : undefined;
+      const expected = expectedFindingsForBatch(files, { force, onlyFindingIds: onlySet });
+      if (expected.length === 0) {
+        return {
+          expectedCount: 0,
+          returnedCount: 0,
+          matchedCount: 0,
+          persistedCount: 0,
+          unresolved: [],
+        };
+      }
+
+      const gen = agent.revalidate({
+        batch: files,
+        projectRoot: effectiveRootPath,
+        projectInfo,
+        config,
+        force,
+        onlyFindingIds,
+        signal: quotaAbort.signal,
+        projectId,
+      });
+
+      let result = await gen.next();
+      while (!result.done) {
+        emitProgress({
+          type: "agent_progress",
+          message: (result.value as AgentProgress).message,
+          batchIndex: batchIdx,
+          totalBatches: batches.length,
+          agentProgress: result.value as AgentProgress,
+        });
+        result = await gen.next();
+      }
+
+      const output = result.value as RevalidateOutput;
+      const batchMeta = output.meta;
+      totalCostUsd += batchMeta.costUsd ?? 0;
+
+      const reconciled = reconcileVerdicts(expected, output.verdicts);
+      // Translates "F2"-style duplicateOf references (the short aliases
+      // the prompt displayed) back to stable findingIds.
+      const aliasMap = buildAliasMap(expected);
+
+      // Index findings by their stable id — reconciliation already
+      // resolved every match to a findingId, so application is exact.
+      const byId = new Map<
+        string,
+        { file: FileRecord; finding: (typeof files)[0]["findings"][0] }
+      >();
+      for (const file of files) {
+        for (const finding of file.findings) {
+          if (finding.findingId) byId.set(finding.findingId, { file, finding });
+        }
+      }
+
+      // Two-pass apply + writeback. Pass 1 applies every non-duplicate
+      // verdict. Pass 2 applies "duplicate" verdicts, but only when the
+      // referenced primary has a non-duplicate verdict — either freshly
+      // applied in pass 1 or already on the file from a prior run. This
+      // enforces the invariant that every equivalence class of
+      // duplicates has exactly one non-duplicate primary; an all-DUPE
+      // group gets every member rejected (they stay unresolved and get
+      // retried in the split stage / next run).
+      const nowIso = new Date().toISOString();
+      const resolvedIds = new Set<string>();
+      let persistedCount = 0;
+      const dupeMatches: typeof reconciled.matches = [];
+
+      for (const m of reconciled.matches) {
+        if (m.verdict.verdict === "duplicate") {
+          dupeMatches.push(m);
+          continue;
+        }
+        const target = byId.get(m.expected.findingId);
+        if (!target) continue;
+        const { finding } = target;
+        // Never overwrite the manual accepted-risk marker, and never
+        // re-apply over an existing verdict outside force mode (keeps
+        // restarts/retries idempotent). Both count as resolved so the
+        // finding isn't retried.
+        if (finding.revalidation?.verdict === "accepted-risk") {
+          resolvedIds.add(m.expected.findingId);
+          continue;
+        }
+        if (finding.revalidation && !force) {
+          resolvedIds.add(m.expected.findingId);
+          continue;
+        }
+        finding.revalidation = {
+          verdict: m.verdict.verdict,
+          reasoning: m.verdict.reasoning,
+          adjustedSeverity: m.verdict.adjustedSeverity,
+          revalidatedAt: nowIso,
+          runId,
+          model,
+        };
+        if (m.verdict.adjustedSeverity) {
+          finding.severity = m.verdict.adjustedSeverity;
+        }
+        resolvedIds.add(m.expected.findingId);
+        dupeRejectedIds.delete(m.expected.findingId);
+        persistedCount++;
+        totalRevalidated++;
+        if (m.verdict.verdict === "true-positive") totalTP++;
+        else if (m.verdict.verdict === "false-positive") totalFP++;
+        else if (m.verdict.verdict === "fixed") totalFixed++;
+        else totalUncertain++;
+      }
+
+      for (const m of dupeMatches) {
+        const target = byId.get(m.expected.findingId);
+        if (!target) continue;
+        const { file, finding } = target;
+        if (finding.revalidation?.verdict === "accepted-risk") {
+          resolvedIds.add(m.expected.findingId);
+          continue;
+        }
+        if (finding.revalidation && !force) {
+          resolvedIds.add(m.expected.findingId);
+          continue;
+        }
+        // `duplicateOf` resolves through the same reconciliation-style
+        // matching: short alias / findingId first, then exact /
+        // normalized title. Reject self-reference, unresolvable
+        // reference, and pointing at another DUPE. Rejected DUPEs are
+        // NOT discarded silently — they stay unresolved and are retried
+        // by the split stage.
+        const ref = m.verdict.duplicateOf;
+        if (!ref) {
+          dupeRejectedIds.add(m.expected.findingId);
+          continue;
+        }
+        const primary = resolveDuplicateRef({
+          ref,
+          file,
+          batch: files,
+          crossFile: crossFileDuplicates,
+          aliasMap,
+        });
+        if (!primary || primary.finding === finding) {
+          dupeRejectedIds.add(m.expected.findingId);
+          continue;
+        }
+        if (!primary.finding.revalidation || primary.finding.revalidation.verdict === "duplicate") {
+          dupeRejectedIds.add(m.expected.findingId);
+          continue;
+        }
+        finding.revalidation = {
+          verdict: "duplicate",
+          reasoning: m.verdict.reasoning,
+          // Persist the primary's stable id (falls back to the raw ref
+          // for pre-findingId primaries, matching the legacy format).
+          duplicateOf: primary.finding.findingId ?? ref,
+          revalidatedAt: nowIso,
+          runId,
+          model,
+        };
+        resolvedIds.add(m.expected.findingId);
+        dupeRejectedIds.delete(m.expected.findingId);
+        persistedCount++;
+        totalRevalidated++;
+        totalDuplicate++;
+      }
+
+      // Push a per-file `analysisHistory` entry for this invocation.
+      // Without this, revalidate cost is only ever recorded in
+      // `runMeta.stats.totalCostUsd` and is invisible to the `metrics`
+      // command (which aggregates strictly off `record.analysisHistory`).
+      // We split invocation-level cost / tokens / duration / turns evenly
+      // over the files so per-file totals add up to actual spend.
+      const splitN = Math.max(1, files.length);
+      const perFileCost = batchMeta.costUsd != null ? batchMeta.costUsd / splitN : undefined;
+      const perFileUsage = batchMeta.usage
+        ? {
+            inputTokens: batchMeta.usage.inputTokens / splitN,
+            outputTokens: batchMeta.usage.outputTokens / splitN,
+            cacheReadInputTokens: batchMeta.usage.cacheReadInputTokens / splitN,
+            cacheCreationInputTokens: batchMeta.usage.cacheCreationInputTokens / splitN,
+          }
+        : undefined;
+      const perFileDurationMs = batchMeta.durationMs / splitN;
+      const perFileDurationApiMs =
+        batchMeta.durationApiMs != null ? batchMeta.durationApiMs / splitN : undefined;
+      const perFileNumTurns = batchMeta.numTurns != null ? batchMeta.numTurns / splitN : undefined;
+      const investigatedAt = new Date().toISOString();
+
+      for (const file of files) {
+        const persistedForFile = reconciled.matches.filter(
+          (m) => resolvedIds.has(m.expected.findingId) && m.expected.filePath === file.filePath,
+        ).length;
+        file.analysisHistory.push({
+          runId,
+          investigatedAt,
+          durationMs: perFileDurationMs,
+          durationApiMs: perFileDurationApiMs,
+          agentType,
+          model,
+          modelConfig: config,
+          agentSessionId: batchMeta.agentSessionId,
+          findingCount: persistedForFile,
+          numTurns: perFileNumTurns,
+          phase: "revalidate",
+          costUsd: perFileCost,
+          usage: perFileUsage,
+          refusal: batchMeta.refusal,
+          codexStderr: batchMeta.codexStderr,
+        });
+
+        try {
+          enrichFileRecord(file, effectiveRootPath);
+        } catch (e) {
+          console.error(
+            `[deepsec] enrich failed for ${file.filePath}: ${e instanceof Error ? e.message : e}`,
+          );
+        }
+        writeFileRecord(file);
+      }
+
+      const unresolved = expected.filter((e) => !resolvedIds.has(e.findingId));
+
+      writeInvocationArtifact({
+        batchIndex: batchIdx,
+        label,
+        timestamp: investigatedAt,
+        files: files.map((f) => f.filePath),
+        requested: expected,
+        rawResponses: output.rawResponses,
+        repairAttempts: output.repairAttempts,
+        parsedVerdicts: output.verdicts,
+        reconciliation: {
+          matches: reconciled.matches.map((m) => m.diagnostic),
+          missingFindingIds: reconciled.missing.map((e) => e.findingId),
+          unknownVerdicts: reconciled.unknown,
+          ambiguousVerdicts: reconciled.ambiguous,
+        },
+        persistedCount,
+        unresolvedFindingIds: unresolved.map((e) => e.findingId),
+      });
+
+      return {
+        expectedCount: expected.length,
+        returnedCount: output.verdicts.length,
+        matchedCount: reconciled.matches.length,
+        persistedCount,
+        unresolved,
+      };
+    }
+
+    /**
+     * Retry wrapper for the split stages: a non-quota failure in a
+     * sub-invocation shouldn't sink verdicts already persisted for the
+     * rest of the batch — record its findings as unresolved and move on.
+     */
+    async function runInvocationSafe(inv: {
+      files: FileRecord[];
+      onlyFindingIds: string[];
+      batchIdx: number;
+      label: string;
+      fallbackUnresolved: ExpectedFinding[];
+    }): Promise<InvocationResult> {
+      try {
+        return await runRevalidateInvocation(inv);
+      } catch (err) {
+        if (err instanceof QuotaExhaustedError) throw err;
+        emitProgress({
+          type: "agent_progress",
+          message: `Retry ${inv.label} failed: ${err instanceof Error ? err.message : String(err)}`,
+          batchIndex: inv.batchIdx,
+          totalBatches: batches.length,
+          agentProgress: {
+            type: "error",
+            message: `Retry ${inv.label} failed: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        });
+        return {
+          expectedCount: inv.fallbackUnresolved.length,
+          returnedCount: 0,
+          matchedCount: 0,
+          persistedCount: 0,
+          unresolved: inv.fallbackUnresolved,
+        };
+      }
+    }
+
     async function revalidateBatch(batch: FileRecord[], idx: number) {
       batchesInFlight++;
-      const findingCount = batch.reduce(
-        (s, f) => s + f.findings.filter((ff) => (!force ? !ff.revalidation : true)).length,
-        0,
-      );
+      const requested = expectedFindingsForBatch(batch, { force });
+      totalRequested += requested.length;
       emitProgress({
         type: "batch_started",
-        message: `Revalidating batch ${idx + 1}/${batches.length} (${batch.length} files, ${findingCount} findings, ${batchesInFlight} in flight)`,
+        message: `Revalidating batch ${idx + 1}/${batches.length} (${batch.length} files, ${requested.length} findings, ${batchesInFlight} in flight)`,
         batchIndex: idx,
         totalBatches: batches.length,
       });
 
       try {
-        const gen = agent.revalidate({
-          batch,
-          projectRoot: effectiveRootPath,
-          projectInfo,
-          config,
-          force,
-          signal: quotaAbort.signal,
-          projectId,
+        const first = await runRevalidateInvocation({
+          files: batch,
+          batchIdx: idx,
+          label: "initial",
         });
+        let persisted = first.persistedCount;
+        let unresolved = first.unresolved;
 
-        let result = await gen.next();
-        while (!result.done) {
+        // Adaptive split, stage 1: retry each file that still has
+        // unresolved findings on its own — fewer identifiers to
+        // reproduce, less output to format. Already-persisted findings
+        // are never re-requested (onlyFindingIds pins the subset).
+        const perFileRequestSize = new Map<string, number>();
+        if (unresolved.length > 0 && !quotaAbort.signal.aborted) {
           emitProgress({
-            type: "agent_progress",
-            message: (result.value as AgentProgress).message,
+            type: "batch_complete",
+            message: `Batch ${idx + 1}/${batches.length}: ${unresolved.length} unresolved after repair — retrying per file`,
             batchIndex: idx,
             totalBatches: batches.length,
-            agentProgress: result.value as AgentProgress,
           });
-          result = await gen.next();
-        }
-
-        const output = result.value as RevalidateOutput;
-        const batchMeta = output.meta;
-        totalCostUsd += batchMeta.costUsd ?? 0;
-
-        // Two-pass match + writeback. Pass 1 applies every non-duplicate
-        // verdict. Pass 2 applies "duplicate" verdicts, but only when the
-        // referenced primary (within the same file) has a non-duplicate
-        // verdict — either freshly applied in pass 1 or already on the
-        // file from a prior revalidation run. This is the invariant
-        // enforcement: every equivalence class of duplicates must have
-        // exactly one non-duplicate primary, so an agent that marks
-        // every member of a group as duplicate has all of those DUPEs
-        // rejected (they just stay unrevalidated and get retried on
-        // the next pass).
-        const dupeVerdicts: typeof output.verdicts = [];
-        const nowIso = new Date().toISOString();
-        for (const verdict of output.verdicts) {
-          if (verdict.verdict === "duplicate") {
-            dupeVerdicts.push(verdict);
-            continue;
+          const byFile = new Map<string, ExpectedFinding[]>();
+          for (const e of unresolved) {
+            byFile.set(e.filePath, [...(byFile.get(e.filePath) ?? []), e]);
           }
-          const file = batch.find((f) => f.filePath === verdict.filePath);
-          if (!file) continue;
-          const finding = file.findings.find((f) => f.title === verdict.title);
-          if (!finding) continue;
-          finding.revalidation = {
-            verdict: verdict.verdict,
-            reasoning: verdict.reasoning,
-            adjustedSeverity: verdict.adjustedSeverity,
-            revalidatedAt: nowIso,
-            runId,
-            model,
-          };
-          if (verdict.adjustedSeverity) {
-            finding.severity = verdict.adjustedSeverity;
-          }
-          totalRevalidated++;
-          if (verdict.verdict === "true-positive") totalTP++;
-          else if (verdict.verdict === "false-positive") totalFP++;
-          else if (verdict.verdict === "fixed") totalFixed++;
-          else totalUncertain++;
-        }
-
-        for (const verdict of dupeVerdicts) {
-          const file = batch.find((f) => f.filePath === verdict.filePath);
-          if (!file) continue;
-          const finding = file.findings.find((f) => f.title === verdict.title);
-          if (!finding) continue;
-          // Reject self-reference, missing reference, and pointing at
-          // another DUPE — these all violate the single-primary
-          // invariant. The agent will re-see this finding as
-          // unrevalidated on the next run and can re-classify it.
-          const ref = verdict.duplicateOf;
-          if (!ref || ref === verdict.title) {
-            totalDupeRejected++;
-            continue;
-          }
-          const primary = file.findings.find((f) => f.title === ref);
-          if (!primary) {
-            totalDupeRejected++;
-            continue;
-          }
-          if (!primary.revalidation || primary.revalidation.verdict === "duplicate") {
-            totalDupeRejected++;
-            continue;
-          }
-          finding.revalidation = {
-            verdict: "duplicate",
-            reasoning: verdict.reasoning,
-            duplicateOf: ref,
-            revalidatedAt: nowIso,
-            runId,
-            model,
-          };
-          totalRevalidated++;
-          totalDuplicate++;
-        }
-
-        // Push a per-file `analysisHistory` entry for this revalidate batch.
-        // Without this, revalidate cost is only ever recorded in
-        // `runMeta.stats.totalCostUsd` and is invisible to the `metrics`
-        // command (which aggregates strictly off `record.analysisHistory`).
-        // We split batch-level cost / tokens / duration / turns evenly over
-        // the files in the batch so the per-file totals add up to the
-        // batch's actual spend.
-        const splitN = Math.max(1, batch.length);
-        const perFileCost = batchMeta.costUsd != null ? batchMeta.costUsd / splitN : undefined;
-        const perFileUsage = batchMeta.usage
-          ? {
-              inputTokens: batchMeta.usage.inputTokens / splitN,
-              outputTokens: batchMeta.usage.outputTokens / splitN,
-              cacheReadInputTokens: batchMeta.usage.cacheReadInputTokens / splitN,
-              cacheCreationInputTokens: batchMeta.usage.cacheCreationInputTokens / splitN,
+          const next: ExpectedFinding[] = [];
+          for (const [filePath, findings] of byFile) {
+            if (quotaAbort.signal.aborted) {
+              next.push(...findings);
+              continue;
             }
-          : undefined;
-        const perFileDurationMs = batchMeta.durationMs / splitN;
-        const perFileDurationApiMs =
-          batchMeta.durationApiMs != null ? batchMeta.durationApiMs / splitN : undefined;
-        const perFileNumTurns =
-          batchMeta.numTurns != null ? batchMeta.numTurns / splitN : undefined;
-        const investigatedAt = new Date().toISOString();
-
-        for (const file of batch) {
-          const verdictsForFile = output.verdicts.filter(
-            (v) => v.filePath === file.filePath,
-          ).length;
-          file.analysisHistory.push({
-            runId,
-            investigatedAt,
-            durationMs: perFileDurationMs,
-            durationApiMs: perFileDurationApiMs,
-            agentType,
-            model,
-            modelConfig: config,
-            agentSessionId: batchMeta.agentSessionId,
-            findingCount: verdictsForFile,
-            numTurns: perFileNumTurns,
-            phase: "revalidate",
-            costUsd: perFileCost,
-            usage: perFileUsage,
-            refusal: batchMeta.refusal,
-            codexStderr: batchMeta.codexStderr,
-          });
-
-          try {
-            enrichFileRecord(file, effectiveRootPath);
-          } catch (e) {
-            console.error(
-              `[deepsec] enrich failed for ${file.filePath}: ${e instanceof Error ? e.message : e}`,
-            );
+            const file = batch.find((f) => f.filePath === filePath);
+            if (!file) {
+              next.push(...findings);
+              continue;
+            }
+            perFileRequestSize.set(filePath, findings.length);
+            const res = await runInvocationSafe({
+              files: [file],
+              onlyFindingIds: findings.map((e) => e.findingId),
+              batchIdx: idx,
+              label: `retry-file:${filePath}`,
+              fallbackUnresolved: findings,
+            });
+            persisted += res.persistedCount;
+            next.push(...res.unresolved);
           }
-          writeFileRecord(file);
+          unresolved = next;
         }
+
+        // Stage 2: findings from files that were retried with more than
+        // one finding and still have misses get retried individually. A
+        // finding whose per-file retry already asked for exactly one is
+        // skipped — an individual retry would be the identical request.
+        if (unresolved.length > 0 && !quotaAbort.signal.aborted) {
+          const individual = unresolved.filter(
+            (e) => (perFileRequestSize.get(e.filePath) ?? 0) > 1,
+          );
+          const skipped = unresolved.filter((e) => (perFileRequestSize.get(e.filePath) ?? 0) <= 1);
+          const next: ExpectedFinding[] = [...skipped];
+          for (const e of individual) {
+            if (quotaAbort.signal.aborted) {
+              next.push(e);
+              continue;
+            }
+            const file = batch.find((f) => f.filePath === e.filePath);
+            if (!file) {
+              next.push(e);
+              continue;
+            }
+            const res = await runInvocationSafe({
+              files: [file],
+              onlyFindingIds: [e.findingId],
+              batchIdx: idx,
+              label: `retry-finding:${e.findingId}`,
+              fallbackUnresolved: [e],
+            });
+            persisted += res.persistedCount;
+            next.push(...res.unresolved);
+          }
+          unresolved = next;
+        }
+
+        totalUnresolved.push(...unresolved);
 
         batchesInFlight--;
         batchesCompleted++;
         emitProgress({
           type: "batch_complete",
-          message: `Batch ${idx + 1}/${batches.length}: ${output.verdicts.length} verdicts (${batchesInFlight} in flight, ${batchesCompleted}/${batches.length} done)`,
+          message: `Batch ${idx + 1}/${batches.length}: requested ${first.expectedCount}, returned ${first.returnedCount}, matched ${first.matchedCount}, persisted ${persisted}${
+            unresolved.length > 0 ? `, unresolved ${unresolved.length}` : ""
+          } (${batchesInFlight} in flight, ${batchesCompleted}/${batches.length} done)`,
           batchIndex: idx,
           totalBatches: batches.length,
         });
@@ -1194,6 +1500,21 @@ export async function revalidate(params: {
         if (err instanceof QuotaExhaustedError && !quotaExhausted) {
           quotaExhausted = { source: err.source, rawMessage: err.rawMessage };
           quotaAbort.abort(err);
+        }
+        // Whatever this batch persisted before the throw is already on
+        // disk; only the requested findings that never got a verdict are
+        // lost, and they surface as unresolved. (In force mode a finding
+        // counts as done only when THIS run wrote its verdict.)
+        for (const e of requested) {
+          const file = batch.find((f) => f.filePath === e.filePath);
+          const finding = file?.findings.find((f) => f.findingId === e.findingId);
+          if (!finding) continue;
+          const doneThisRun =
+            finding.revalidation !== undefined &&
+            (!force ||
+              finding.revalidation.runId === runId ||
+              finding.revalidation.verdict === "accepted-risk");
+          if (!doneThisRun) totalUnresolved.push(e);
         }
         emitProgress({
           type: "batch_complete",
@@ -1233,12 +1554,15 @@ export async function revalidate(params: {
       totalCostUsd,
     });
 
+    const totalDupeRejected = dupeRejectedIds.size;
     const dupeRejectedSuffix = totalDupeRejected > 0 ? `, ${totalDupeRejected} DUPE rejected` : "";
+    const unresolvedSuffix =
+      totalUnresolved.length > 0 ? `, ${totalUnresolved.length} UNRESOLVED` : "";
     emitProgress({
       type: "all_complete",
       message: quotaExhausted
         ? `Revalidation stopped: ${quotaExhausted.source} quota/credits exhausted (${totalRevalidated} verdicts before stop)`
-        : `Revalidation complete: ${totalRevalidated} findings — TP: ${totalTP}, FP: ${totalFP}, Fixed: ${totalFixed}, Uncertain: ${totalUncertain}, Dupe: ${totalDuplicate}${dupeRejectedSuffix}`,
+        : `Revalidation complete: ${totalRevalidated}/${totalRequested} findings — TP: ${totalTP}, FP: ${totalFP}, Fixed: ${totalFixed}, Uncertain: ${totalUncertain}, Dupe: ${totalDuplicate}${dupeRejectedSuffix}${unresolvedSuffix}`,
     });
 
     return {
@@ -1250,6 +1574,8 @@ export async function revalidate(params: {
       uncertain: totalUncertain,
       duplicates: totalDuplicate,
       duplicatesRejected: totalDupeRejected,
+      requested: totalRequested,
+      unresolved: totalUnresolved,
       quotaExhausted,
     };
   } catch (err) {

--- a/packages/processor/src/reconcile.ts
+++ b/packages/processor/src/reconcile.ts
@@ -1,0 +1,305 @@
+import type { FileRecord, Finding } from "@deepsec/core";
+import { ensureFindingIds } from "@deepsec/core";
+import type { RevalidateVerdict } from "./agents/types.js";
+
+/**
+ * Reconciliation layer between "what the agent returned" and "which stored
+ * finding it meant". Agents reproduce identifiers stochastically — titles
+ * get re-worded, backticks appear, paths gain a leading `./` — and the
+ * previous exact filePath+title equality silently discarded any verdict
+ * that didn't match byte-for-byte. This module matches permissively but
+ * deterministically, never guessing when more than one finding remains
+ * plausible.
+ */
+
+/** The identity of one finding we asked the agent to revalidate. */
+export interface ExpectedFinding {
+  findingId: string;
+  filePath: string;
+  title: string;
+  /**
+   * Short per-invocation alias (`F1`, `F2`, …) — the ID the prompt shows
+   * and the model is asked to echo back. Two characters are far harder
+   * to mangle than a 16-hex hash. Assigned in prompt order by
+   * `expectedFindingsForBatch`; storage identity remains `findingId`.
+   */
+  alias?: string;
+}
+
+/**
+ * Normalize an identifier the model returned for alias comparison:
+ * accepts `F3`, `f3`, `#3`, `F 3`, and bare `3` — all normalize to "3".
+ * Returns undefined for anything that isn't an alias-shaped token, so a
+ * real `finding_…` ID or a title never accidentally alias-matches.
+ */
+export function normalizeAliasRef(s: string): string | undefined {
+  const m = s.trim().match(/^#?\s*[Ff]?\s*(\d{1,4})$/);
+  return m ? String(Number(m[1])) : undefined;
+}
+
+function aliasKey(alias: string | undefined): string | undefined {
+  if (!alias) return undefined;
+  return normalizeAliasRef(alias);
+}
+
+export type MatchedBy = "finding-id" | "exact-title" | "normalized-title" | "unique-remainder";
+
+export interface ReconcileDiagnostic {
+  matchedBy: MatchedBy;
+  returnedFindingId?: string;
+  returnedTitle?: string;
+  returnedFilePath?: string;
+  resolvedFindingId: string;
+}
+
+export interface ReconcileMatch {
+  expected: ExpectedFinding;
+  verdict: RevalidateVerdict;
+  diagnostic: ReconcileDiagnostic;
+}
+
+export interface ReconcileResult {
+  matches: ReconcileMatch[];
+  /** Expected findings that received no verdict. */
+  missing: ExpectedFinding[];
+  /** Verdicts whose identifiers matched no expected finding. */
+  unknown: RevalidateVerdict[];
+  /**
+   * Verdicts whose normalized identifiers matched MORE than one expected
+   * finding. Never applied — they go to repair, not to a guess.
+   */
+  ambiguous: RevalidateVerdict[];
+}
+
+export function normalizePath(p: string): string {
+  return p.replaceAll("\\", "/").replace(/^\.\//, "").trim();
+}
+
+/**
+ * Title normalization for fallback matching: Unicode NFKC, Markdown
+ * quoting/backticks stripped, whitespace collapsed, case-insensitive,
+ * trailing sentence punctuation dropped.
+ */
+export function normalizeTitle(t: string): string {
+  return t
+    .normalize("NFKC")
+    .replace(/[`*_"'‘’“”]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase()
+    .replace(/[.,:;!?]+$/, "");
+}
+
+/**
+ * The exact set of findings a revalidation prompt asks about: unrevalidated
+ * (or all, under force), optionally restricted to an explicit findingId
+ * subset (used by the adaptive-split retries so already-persisted verdicts
+ * are never re-requested). Mirrors the filter in buildRevalidatePrompt —
+ * the two MUST stay in sync so reconciliation expects exactly what the
+ * prompt asked for.
+ */
+export function expectedFindingsForBatch(
+  batch: FileRecord[],
+  opts: { force?: boolean; onlyFindingIds?: ReadonlySet<string> } = {},
+): ExpectedFinding[] {
+  const expected: ExpectedFinding[] = [];
+  for (const file of batch) {
+    ensureFindingIds(file);
+    for (const f of file.findings) {
+      if (!shouldRevalidateFinding(f, opts)) continue;
+      expected.push({
+        findingId: f.findingId!,
+        filePath: file.filePath,
+        title: f.title,
+        // Short prompt-facing alias, assigned in iteration order. The
+        // prompt builder and the processor both derive expectations from
+        // this function with identical inputs, so the alias→findingId
+        // mapping is consistent across the prompt, the plugin's repair
+        // loop, and the processor's reconciliation.
+        alias: `F${expected.length + 1}`,
+      });
+    }
+  }
+  return expected;
+}
+
+export function shouldRevalidateFinding(
+  f: Finding,
+  opts: { force?: boolean; onlyFindingIds?: ReadonlySet<string> },
+): boolean {
+  if (opts.onlyFindingIds) {
+    return f.findingId !== undefined && opts.onlyFindingIds.has(f.findingId);
+  }
+  return opts.force ? true : !f.revalidation;
+}
+
+/**
+ * Match verdicts to expected findings, most-deterministic rule first:
+ *
+ *   1. exact findingId, or the finding's short alias (`F3` / `f3` /
+ *      `#3` / `3`)
+ *   2. exact title within the exact (path-normalized) file — the legacy
+ *      contract, kept for old agents/responses
+ *   3. normalized title within the exact file
+ *   4. unique remainder — exactly one unmatched verdict AND one unmatched
+ *      finding left in the batch
+ *
+ * Each finding gets at most one verdict (first match in verdict order
+ * wins); each verdict resolves to at most one finding. A verdict that
+ * would match multiple findings under a rule is ambiguous and is NOT
+ * applied.
+ */
+export function reconcileVerdicts(
+  expected: ExpectedFinding[],
+  verdicts: RevalidateVerdict[],
+): ReconcileResult {
+  const matches: ReconcileMatch[] = [];
+  const unmatchedExpected = new Set(expected);
+  const remaining: RevalidateVerdict[] = [];
+  const ambiguous: RevalidateVerdict[] = [];
+
+  const record = (exp: ExpectedFinding, verdict: RevalidateVerdict, matchedBy: MatchedBy) => {
+    unmatchedExpected.delete(exp);
+    matches.push({
+      expected: exp,
+      verdict,
+      diagnostic: {
+        matchedBy,
+        returnedFindingId: verdict.findingId,
+        returnedTitle: verdict.title,
+        returnedFilePath: verdict.filePath,
+        resolvedFindingId: exp.findingId,
+      },
+    });
+  };
+
+  // Pass 1: exact findingId, or the short alias the prompt displayed.
+  for (const v of verdicts) {
+    const id = typeof v.findingId === "string" ? v.findingId.trim() : undefined;
+    let exp: ExpectedFinding | undefined;
+    if (id) {
+      exp = [...unmatchedExpected].find((e) => e.findingId === id);
+      if (!exp) {
+        const refKey = normalizeAliasRef(id);
+        if (refKey !== undefined) {
+          exp = [...unmatchedExpected].find((e) => aliasKey(e.alias) === refKey);
+        }
+      }
+    }
+    if (exp) record(exp, v, "finding-id");
+    else remaining.push(v);
+  }
+
+  // Pass 2: exact title within the exact file (legacy contract).
+  let pass2Remaining: RevalidateVerdict[] = [];
+  for (const v of remaining) {
+    if (typeof v.filePath !== "string" || typeof v.title !== "string") {
+      pass2Remaining.push(v);
+      continue;
+    }
+    const vPath = normalizePath(v.filePath);
+    const candidates = [...unmatchedExpected].filter(
+      (e) => normalizePath(e.filePath) === vPath && e.title === v.title,
+    );
+    if (candidates.length === 1) record(candidates[0], v, "exact-title");
+    else if (candidates.length > 1) ambiguous.push(v);
+    else pass2Remaining.push(v);
+  }
+
+  // Pass 3: normalized title within the exact file.
+  const pass3Remaining: RevalidateVerdict[] = [];
+  for (const v of pass2Remaining) {
+    if (typeof v.filePath !== "string" || typeof v.title !== "string") {
+      pass3Remaining.push(v);
+      continue;
+    }
+    const vPath = normalizePath(v.filePath);
+    const vTitle = normalizeTitle(v.title);
+    const candidates = [...unmatchedExpected].filter(
+      (e) => normalizePath(e.filePath) === vPath && normalizeTitle(e.title) === vTitle,
+    );
+    if (candidates.length === 1) record(candidates[0], v, "normalized-title");
+    else if (candidates.length > 1) ambiguous.push(v);
+    else pass3Remaining.push(v);
+  }
+  pass2Remaining = [];
+
+  // Pass 4: unique one-to-one remainder recovery. Only when the entire
+  // batch has exactly one unmatched verdict and one unmatched finding —
+  // there is nothing else the verdict could mean.
+  let unknown = pass3Remaining;
+  if (pass3Remaining.length === 1 && ambiguous.length === 0 && unmatchedExpected.size === 1) {
+    const exp = [...unmatchedExpected][0];
+    record(exp, pass3Remaining[0], "unique-remainder");
+    unknown = [];
+  }
+
+  return {
+    matches,
+    missing: expected.filter((e) => unmatchedExpected.has(e)),
+    unknown,
+    ambiguous,
+  };
+}
+
+/**
+ * Alias-lookup table for an invocation: normalized alias key → findingId.
+ * Used to translate a `duplicateOf` reference like "F2" back to the
+ * stable id before resolution.
+ */
+export function buildAliasMap(expected: ExpectedFinding[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const e of expected) {
+    const key = aliasKey(e.alias);
+    if (key !== undefined) map.set(key, e.findingId);
+  }
+  return map;
+}
+
+/**
+ * Resolve a `duplicateOf` reference against the findings of its file (or,
+ * when `crossFile` is enabled, all files in the batch). Accepts a short
+ * alias (via `aliasMap`), a findingId, or a title (exact, then
+ * normalized). Returns the referenced Finding, or undefined when nothing
+ * — or more than one thing — matches. Same never-guess rule as verdict
+ * matching.
+ */
+export function resolveDuplicateRef(params: {
+  ref: string;
+  file: FileRecord;
+  batch?: FileRecord[];
+  crossFile?: boolean;
+  /** From buildAliasMap — translates "F2"-style refs to findingIds. */
+  aliasMap?: ReadonlyMap<string, string>;
+}): { file: FileRecord; finding: Finding } | undefined {
+  const { ref, file, batch, crossFile = false, aliasMap } = params;
+  const scope: FileRecord[] = crossFile && batch ? batch : [file];
+  let trimmed = ref.trim();
+
+  // Alias translation first: "F2" → the stable findingId it was shown as.
+  const refKey = normalizeAliasRef(trimmed);
+  if (refKey !== undefined && aliasMap?.has(refKey)) {
+    trimmed = aliasMap.get(refKey)!;
+  }
+
+  // findingId is globally unique — search the whole scope directly.
+  for (const rec of scope) {
+    const byId = rec.findings.find((f) => f.findingId === trimmed);
+    if (byId) return { file: rec, finding: byId };
+  }
+
+  const byTitle = (match: (f: Finding) => boolean) => {
+    const hits: Array<{ file: FileRecord; finding: Finding }> = [];
+    for (const rec of scope) {
+      for (const f of rec.findings) {
+        if (match(f)) hits.push({ file: rec, finding: f });
+      }
+    }
+    return hits.length === 1 ? hits[0] : undefined;
+  };
+
+  return (
+    byTitle((f) => f.title === trimmed) ??
+    byTitle((f) => normalizeTitle(f.title) === normalizeTitle(trimmed))
+  );
+}


### PR DESCRIPTION
## Problem

`revalidate` matched agent verdicts to stored findings by exact `filePath` + `title` equality and silently dropped misses. Agents reproduce titles stochastically (rewording, backticks, case, `./` path prefixes), so entire batches would report success while zero verdicts persisted — the observed 2.2.4 repro: 12 parseable verdicts across two batches, correct paths, none applied.

## Changes

**Stable finding IDs** — every finding gets a deterministic `findingId` (sha256 of projectId + normalized path + title). Assigned at append time, lazily backfilled when old records load; old data stays readable.

**Short prompt aliases** — the model never sees the hash. Prompts show per-invocation aliases (`F1`…`Fn`) as the Finding ID, with an explicit allowed-ID checklist. Aliases map back to stable IDs deterministically because prompt and processor derive them from the same function with the same inputs.

**Permissive, deterministic reconciliation** — verdicts match by: alias/findingId → exact title in file (legacy contract) → normalized title in file → unique 1:1 remainder. Never guesses: multiple plausible candidates are ambiguous, not applied. Every match records a `matchedBy` diagnostic.

**Persist-first + targeted repair** — unambiguous verdicts are written to disk immediately. Missing verdicts trigger up to 2 tool-free id-repair turns on the *same agent session* (no re-investigation), then adaptive splitting: per-file retries, then per-finding — only unresolved findings are ever re-requested.

**Diagnostics** — raw model responses, repair prompts, parsed verdicts, and reconciliation decisions are persisted per invocation under `data/<projectId>/revalidation/<runId>/` (sandbox download allowlist updated). Progress now reports `requested/returned/matched/persisted`, and the CLI exits 1 if any requested finding ends without a persisted verdict.

**Duplicates** — `duplicateOf` uses Finding IDs (alias-aware), resolves through the same reconciliation layer, persists the primary's stable ID, and rejected DUPEs are retried instead of silently discarded. Optional `crossFileDuplicates` for cross-file primaries.

## Behavior changes

- `deepsec revalidate` exits 1 when requested findings remain unresolved after repair + splitting.
- `Revalidation.duplicateOf` is now persisted as the primary's `findingId` (was title).

## Tests

40+ new tests: ID determinism/backfill/collisions, all reconciliation rules incl. ambiguity, alias forms (`F3`/`f3`/`#3`/`3`), repair-loop behavior, partial persistence + per-file/per-finding fallback, restart idempotency, accepted-risk protection, and a regression fixture for the observed failure (6 verdicts, correct paths, mangled titles — all applied in one call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)