### PR TITLE
docs: add Chinese and Japanese README translations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,138 @@
+# deepsec
+
+[English](README.md) | [简体中文](README.zh-CN.md) | **日本語**
+
+`deepsec` は、自社のインフラストラクチャで実行できるエージェント駆動型の脆弱性スキャナーです。
+既存の大規模リポジトリに含まれるすべてのコードをオンデマンドでレビューできるよう最適化されています。
+
+`deepsec` は、アプリケーションに長期間潜んでいる、見つけにくい問題を明らかにするために設計されています。最高のモデルを最大の思考レベルで使用するよう構成されており（`--thinking-level` で調整可能。詳細は [docs/models.md](./docs/models.md) を参照）、大規模なコードベースではスキャンに数千ドル、場合によっては数万ドルかかることがあります。お客様からは、そうでなければ未修正のままだった脆弱性を迅速に修正できることを考えれば、その費用には価値があるとの評価をいただいています。
+
+大規模なコードベースでは、作業が複数のワーカーマシンへ並列に分散されます。
+実行が中断した場合や途中でエラーが発生した場合は、同じ
+コマンドを再実行するだけです。deepsec は中断した箇所から再開し、
+解析済みのファイルをスキップして残りだけを調査します。
+
+## はじめに
+
+スキャンするリポジトリのルートへ移動し、次を実行します：
+
+```bash
+npx deepsec init       # creates .deepsec/ with this repo as the first project
+cd .deepsec
+pnpm install           # installs deepsec from npm
+
+# Proceed as instructed by `init` output
+```
+
+次に、コーディングエージェントにインストールの初期設定を行わせます。
+使用するエージェントを開き、次のように指示します：
+
+> `.deepsec/node_modules/deepsec/SKILL.md` を読み、このツールを理解してください。
+> 次に `.deepsec/data/<id>/SETUP.md` を読み、その手順に従ってください：
+> このリポジトリの README、AGENTS.md/CLAUDE.md（存在する場合）、
+> および代表的なコードファイルをいくつか確認し、
+> `.deepsec/data/<id>/INFO.md` の各セクションを置き換えてください。
+>
+> 必ず簡潔にし、全体で 50～100 行を目安にしてください。各セクションは
+> 網羅せず、3～5 個の例を選びます。プリミティブ（認証ヘルパー、
+> ミドルウェア）の名前は示しますが、行番号は不要です。一般的な CWE
+> カテゴリは組み込みマッチャーが扱うため省略し、プロジェクト固有の
+> 内容だけを記載してください。INFO.md はすべてのスキャンバッチに
+> 注入されるため、冗長なコンテキストはシグナルを弱めます。
+
+その後、`.deepsec/` 内からスキャンを実行します：
+
+```bash
+pnpm deepsec scan
+pnpm deepsec process
+pnpm deepsec revalidate # optional, cuts FP rate
+pnpm deepsec export --format md-dir --out ./findings
+```
+
+`deepsec` にコードのより多くの箇所を調べさせたい場合は、価値のある開始点をさらに見つけられるよう、[マッチャーの作成](docs/writing-matchers.md)ドキュメントを渡してください。
+
+## ドキュメント
+
+- [docs/getting-started.md](docs/getting-started.md) — 初回スキャンの手順
+- [docs/reviewing-changes.md](docs/reviewing-changes.md) — PR レビューと CI ゲート向けの `process --diff`
+- [docs/supported-tech.md](docs/supported-tech.md) — deepsec が標準で認識するフレームワークとエコシステム
+- [docs/writing-matchers.md](docs/writing-matchers.md) — **コーディングエージェントにマッチャーセットを拡張させる**
+- [docs/configuration.md](docs/configuration.md) — `deepsec.config.ts` リファレンス
+- [docs/plugins.md](docs/plugins.md) — プラグイン作成リファレンス
+- [docs/models.md](docs/models.md) — モデルの選択、既定値、拒否、将来のモデル
+- [docs/vercel-setup.md](docs/vercel-setup.md) — AI Gateway と Vercel Sandbox のキー/トークン
+- [docs/architecture.md](docs/architecture.md) — パイプライン内部
+- [docs/data-layout.md](docs/data-layout.md) — `data/` スキーマ（FileRecord、RunMeta など）
+- [docs/faq.md](docs/faq.md) — 費用、モデル選択、サンドボックスモード、誤検知率
+- [samples/](samples/) — コピーして使える開始例（現在は `webapp/`）
+- [CONTRIBUTING.md](CONTRIBUTING.md) — リポジトリ構成と開発ワークフロー
+
+## AI プロバイダー
+
+ローカルで実行する場合、このマシンでログイン済みであれば、`deepsec` は既存の `claude` /
+`codex` サブスクリプションへフォールバックします。サブスクリプション
+（Claude Pro/Max、ChatGPT Plus）は deepsec の評価には役立ちますが、
+通常はリポジトリ全体をスキャンできるほどの余裕はありません。
+
+実際のスキャンには Vercel AI Gateway を使用してください。1 つのキーで Claude と
+Codex の両方を利用でき、ゲートウェイの既定クォータは高い同時実行性を
+伴う調査に適した規模です。
+
+```
+AI_GATEWAY_API_KEY=vck_...
+```
+
+キーの取得方法については [docs/vercel-setup.md](docs/vercel-setup.md) を参照し、
+Vercel Sandbox を設定してください。ゲートウェイを経由しない場合は、
+`ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL`（または対応する OpenAI の組み合わせ）を
+明示的に設定します。明示的な値は常に `AI_GATEWAY_API_KEY` の
+展開より優先されます。
+
+`process` または `revalidate` の実行が、上流の認証情報の
+クォータやクレジット切れで停止した場合、deepsec は正常に停止し、
+補充先を案内します。その後同じコマンドを再実行すると、
+中断した箇所から再開します。
+
+## 分散実行（任意）
+
+大規模なモノリポでは、処理を [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) の microVM に分散できます：
+
+```bash
+pnpm deepsec sandbox process --project-id my-app --sandboxes 10 --concurrency 4
+```
+
+Vercel アカウントが必要です。ローカルのワーキングツリーは tar にまとめて
+アップロードされ、`.git` は除外されます。OIDC トークン（ローカル）と
+アクセストークン（CI）の両方に対応しています。詳細は
+[docs/vercel-setup.md](docs/vercel-setup.md) を参照してください。
+
+## deepsec 自体のセキュリティモデル
+
+`deepsec` は、実行環境への完全な shell アクセス権を持つコーディングエージェントとして扱ってください。
+信頼できる入力（自分のソースコード）で実行するよう設計されていますが、外部依存関係や
+ベンダーコードによるプロンプトインジェクションが気になる場合もあります。
+
+サンドボックスで実行すると（上記参照）、潜在的な露出を大幅に制限できます：
+
+- コーディングエージェント用の API キーはサンドボックス外部で注入されるため、持ち出すことはできません
+- ワーカーサンドボックスからのネットワーク送信先はコーディングエージェントのホストに限定されます（ブートストラップ中は外向き通信が許可されますが、この処理ではコーディングエージェントを実行しません）
+
+## ワークフローリファレンス
+
+| コマンド | 動作 |
+|-----------------|----------------------------------------------------------|
+| `scan` | 正規表現マッチャーで候補箇所を探す（高速、AI 不使用） |
+| `process` | AI による調査。検出結果と推奨事項を出力 |
+| `process --diff` | PR モード：差分で変更されたファイルだけをスキャンして調査 |
+| `triage` | 軽量な P0/P1/P2 分類（低コストのモデル） |
+| `revalidate` | 既存の検出結果を再確認し、Git 履歴から修正を確認 |
+| `enrich` | Git コミッター情報と（プラグインを使用する場合）所有者データを追加 |
+| `report` | 1 プロジェクトの Markdown + JSON サマリー |
+| `export` | 検出結果ごとの JSON、または Markdown ファイルのディレクトリ |
+| `metrics` | プロジェクト横断の集計：重大度、種類別の脆弱性、TP |
+| `status` | プロジェクトミラーのスナップショット |
+| `sandbox <cmd>` | 上記の任意のコマンドを Vercel Sandbox microVM 上で実行 |
+
+## ライセンス
+
+Apache 2.0。詳細は [LICENSE](LICENSE) と [NOTICE](NOTICE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # deepsec
 
+**English** | [简体中文](README.zh-CN.md) | [日本語](README.ja.md)
+
 `deepsec` an agent-powered vulnerability scanner that you can run in your own infrastructure, optimized to perform on-demand review of all code in existing 
 large-scale repos.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,138 @@
+# deepsec
+
+[English](README.md) | **简体中文** | [日本語](README.ja.md)
+
+`deepsec` 是一款由智能体驱动的漏洞扫描器，可在你自己的基础设施中运行，经过优化，能够按需审查
+现有大型仓库中的全部代码。
+
+`deepsec` 旨在发现长期潜藏在应用程序中、难以察觉的问题。它被配置为使用最高思考等级的最佳模型（可通过 `--thinking-level` 调整，参阅 [docs/models.md](./docs/models.md)），这意味着对大型代码库的扫描可能花费数千甚至数万美元。我们的客户发现，与快速修补那些原本可能一直得不到修复的漏洞相比，这些成本是值得的。
+
+对于大型代码库，工作会并行分散到多台工作机上。
+如果运行中断或在中途出错，只需重新运行相同的
+命令——deepsec 会从上次停止的位置继续，跳过已经
+分析的文件，只调查其余部分。
+
+## 开始使用
+
+进入要扫描的仓库根目录，然后运行：
+
+```bash
+npx deepsec init       # creates .deepsec/ with this repo as the first project
+cd .deepsec
+pnpm install           # installs deepsec from npm
+
+# Proceed as instructed by `init` output
+```
+
+现在让你的编码智能体引导完成安装。打开你选择的智能体
+并输入以下提示：
+
+> 阅读 `.deepsec/node_modules/deepsec/SKILL.md` 以了解该工具。
+> 然后阅读 `.deepsec/data/<id>/SETUP.md` 并按照说明操作：
+> 浏览此仓库的 README、任何 AGENTS.md/CLAUDE.md，以及一些
+> 具有代表性的代码文件，然后替换
+> `.deepsec/data/<id>/INFO.md` 的每个章节。
+>
+> 内容务必简短——总计以 50–100 行为目标。每个章节选择 3–5 个
+> 示例，不要穷举。说出具体原语（身份验证辅助函数、
+> 中间件），但不要写行号。跳过通用 CWE 类别——
+> 内置匹配器已覆盖这些内容。只介绍项目特有的部分。
+> INFO.md 会注入每个扫描批次；冗长的上下文
+> 会稀释信号。
+
+然后在 `.deepsec/` 中运行扫描：
+
+```bash
+pnpm deepsec scan
+pnpm deepsec process
+pnpm deepsec revalidate # optional, cuts FP rate
+pnpm deepsec export --format md-dir --out ./findings
+```
+
+如果你希望 `deepsec` 检查代码的更多部分，请向它提供[编写匹配器](docs/writing-matchers.md)文档，以寻找更多有价值的起始位置。
+
+## 文档
+
+- [docs/getting-started.md](docs/getting-started.md)——首次扫描演练
+- [docs/reviewing-changes.md](docs/reviewing-changes.md)——用于 PR 审查和 CI 门禁的 `process --diff`
+- [docs/supported-tech.md](docs/supported-tech.md)——deepsec 开箱即用所识别的框架与生态系统
+- [docs/writing-matchers.md](docs/writing-matchers.md)——**提示你的编码智能体扩展匹配器集合**
+- [docs/configuration.md](docs/configuration.md)——`deepsec.config.ts` 参考
+- [docs/plugins.md](docs/plugins.md)——插件编写指南
+- [docs/models.md](docs/models.md)——模型选择、默认设置、拒绝情况和未来模型
+- [docs/vercel-setup.md](docs/vercel-setup.md)——AI Gateway 与 Vercel Sandbox 密钥/令牌
+- [docs/architecture.md](docs/architecture.md)——流水线内部原理
+- [docs/data-layout.md](docs/data-layout.md)——`data/` 架构（FileRecord、RunMeta 等）
+- [docs/faq.md](docs/faq.md)——成本、模型选择、沙箱模式和误报率
+- [samples/](samples/)——可直接复制的起始示例（目前为 `webapp/`）
+- [CONTRIBUTING.md](CONTRIBUTING.md)——仓库布局与开发工作流
+
+## AI 提供商
+
+在本地运行时，如果你已在这台机器上登录，`deepsec` 会回退到现有的 `claude` /
+`codex` 订阅。订阅（Claude Pro/Max、ChatGPT Plus）
+适合用于评估 deepsec，但通常没有足够的额度
+完成整个仓库的扫描。
+
+对于实际扫描，请使用 Vercel AI Gateway。一个密钥同时覆盖 Claude 和
+Codex，而且网关的默认配额适合高并发
+研究。
+
+```
+AI_GATEWAY_API_KEY=vck_...
+```
+
+获取密钥及设置 Vercel Sandbox 的方法，请参阅 [docs/vercel-setup.md](docs/vercel-setup.md)，
+要绕过网关，请显式设置
+`ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL`（或对应的 OpenAI 变量对）。
+显式值始终优先于 `AI_GATEWAY_API_KEY`
+展开。
+
+如果 `process` 或 `revalidate` 运行因上游凭据耗尽
+配额或余额而停止，deepsec 会正常退出，并告知你
+在哪里充值。随后重新运行相同命令，它会从
+上次停止的位置继续。
+
+## 分布式执行（可选）
+
+大型单体仓库可以将工作分散到 [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) 微型虚拟机：
+
+```bash
+pnpm deepsec sandbox process --project-id my-app --sandboxes 10 --concurrency 4
+```
+
+需要 Vercel 账户。本地工作树会被打包并
+上传；`.git` 会被排除。OIDC 令牌（本地）和访问
+令牌（CI）均受支持——参阅
+[docs/vercel-setup.md](docs/vercel-setup.md)。
+
+## deepsec 自身的安全模型
+
+请将 `deepsec` 视为一个在运行环境中拥有完整 shell 访问权限的编码智能体。
+它设计为在可信输入（你的源代码）上运行，但由于存在外部依赖项或
+供应商代码，你仍可能担心提示注入。
+
+在沙箱中运行（见上文）可以大幅限制潜在暴露：
+
+- 编码智能体的 API 密钥在沙箱之外注入，因此无法被窃取
+- 对于工作器沙箱，沙箱的网络出口仅限编码智能体主机（引导过程中允许出口，但该过程不会运行编码智能体）
+
+## 工作流参考
+
+| 命令 | 作用 |
+|-----------------|----------------------------------------------------------|
+| `scan` | 使用正则表达式匹配器查找候选位置（快速，不使用 AI） |
+| `process` | AI 调查；输出发现与建议 |
+| `process --diff` | PR 模式：仅扫描并调查差异中变更的文件 |
+| `triage` | 轻量级 P0/P1/P2 分类（使用成本较低的模型） |
+| `revalidate` | 重新检查现有发现；查看 Git 历史记录以确认修复 |
+| `enrich` | 添加 Git 提交者信息及（通过插件）所有权数据 |
+| `report` | 单个项目的 Markdown + JSON 摘要 |
+| `export` | 每项发现的 JSON，或包含 Markdown 文件的目录 |
+| `metrics` | 跨项目计数：严重性、按类型划分的漏洞、TP |
+| `status` | 项目镜像快照 |
+| `sandbox <cmd>` | 在 Vercel Sandbox 微型虚拟机上运行上述任意命令 |
+
+## 许可证
+
+Apache 2.0。详情请参阅 [LICENSE](LICENSE) 和 [NOTICE](NOTICE)。


### PR DESCRIPTION
## What changed

Adds complete Simplified Chinese and Japanese README translations, with language links in all versions.

## Why

Makes the project overview and setup guidance accessible to Chinese- and Japanese-speaking users.

## Verification

- [ ] `pnpm test` passes (2,182 passed; 15 existing Windows path/CRLF and missing-bundle failures)
- [ ] `pnpm lint` passes (Windows CRLF checkout causes repository-wide formatting failures)
- [x] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

`pnpm -r build` and `git diff --check` pass. Translation structure, code blocks, links, tables, and inline code were checked against the source.

## Notes for reviewer

Documentation-only.