### PR TITLE
feat(export): add SARIF 2.1.0 export format for GitHub Code Scanning

### DIFF
--- a/e2e/pipeline.test.ts
+++ b/e2e/pipeline.test.ts
@@ -297,6 +297,20 @@ describe("pipeline e2e", () => {
         .filter((e) => typeof e === "string" && e.endsWith(".md"));
       expect(mdFiles.length).toBeGreaterThan(0);
 
+      // export --format sarif — SARIF 2.1.0 for GitHub Code Scanning.
+      const sarifPath = path.join(workspaceDir, "findings.sarif");
+      const exportSarif = runBundle(
+        ["export", "--format", "sarif", "--out", sarifPath],
+        workspaceDir,
+      );
+      expect(exportSarif.status, `export-sarif stderr: ${exportSarif.stderr}`).toBe(0);
+      const sarif = JSON.parse(fs.readFileSync(sarifPath, "utf-8"));
+      expect(sarif.version).toBe("2.1.0");
+      expect(sarif.runs[0].tool.driver.name).toBe("deepsec");
+      expect(sarif.runs[0].results.length).toBeGreaterThan(0);
+      expect(sarif.runs[0].results[0].ruleId).toBeDefined();
+      expect(sarif.runs[0].results[0].level).toMatch(/^(error|warning|note)$/);
+
       // status — prints run history. Should mention both runs.
       const status = runBundle(["status"], workspaceDir);
       expect(status.status, `status stderr: ${status.stderr}`).toBe(0);

--- a/packages/deepsec/src/__tests__/export-sarif.test.ts
+++ b/packages/deepsec/src/__tests__/export-sarif.test.ts
@@ -141,6 +141,18 @@ describe("buildSarifLog()", () => {
     expect(fp1).not.toBe(fp2);
   });
 
+  it("produces different fingerprints for different vulnSlugs on the same line", () => {
+    const log = buildSarifLog([
+      makeFinding({ filePath: "src/a.ts", lineNumbers: [10], vulnSlug: "sql-injection" }),
+      makeFinding({ filePath: "src/a.ts", lineNumbers: [10], vulnSlug: "xss" }),
+    ]);
+
+    const fp1 = log.runs[0].results[0].partialFingerprints.primaryLocationLineHash;
+    const fp2 = log.runs[0].results[1].partialFingerprints.primaryLocationLineHash;
+
+    expect(fp1).not.toBe(fp2);
+  });
+
   it("preserves original severity in result.properties", () => {
     const log = buildSarifLog([makeFinding({ severity: "CRITICAL" })]);
     const props = log.runs[0].results[0].properties;

--- a/packages/deepsec/src/__tests__/export-sarif.test.ts
+++ b/packages/deepsec/src/__tests__/export-sarif.test.ts
@@ -1,0 +1,214 @@
+import type { Severity } from "@deepsec/core";
+import { describe, expect, it } from "vitest";
+import { buildSarifLog } from "../commands/export.js";
+
+/**
+ * Minimal ExportedFinding factory for testing. The full ExportedFinding
+ * interface is large; we fill only the fields buildSarifLog reads, plus
+ * stubs for the rest to satisfy the type.
+ */
+function makeFinding(overrides: {
+  projectId?: string;
+  filePath?: string;
+  lineNumbers?: number[];
+  severity?: Severity;
+  vulnSlug?: string;
+  confidence?: string;
+  title?: string;
+  description?: string;
+  revalidation?: { verdict: string; reasoning: string };
+}): import("../commands/export.js").ExportedFinding {
+  return {
+    title: overrides.title ?? `[${overrides.severity ?? "HIGH"}] Test finding`,
+    description: overrides.description ?? "Test description",
+    severity: overrides.severity ?? "HIGH",
+    labels: [],
+    metadata: {
+      projectId: overrides.projectId ?? "my-app",
+      filePath: overrides.filePath ?? "src/api/users.ts",
+      lineNumbers: overrides.lineNumbers ?? [42],
+      severity: overrides.severity ?? "HIGH",
+      vulnSlug: overrides.vulnSlug ?? "sql-injection",
+      confidence: overrides.confidence ?? "high",
+      discoveredAt: "2026-07-29T00:00:00.000Z",
+      runId: "run-1",
+      revalidation: overrides.revalidation,
+      owners: {
+        teams: [],
+        oncall: [],
+        managers: [],
+        contributors: [],
+        recentCommitters: [],
+      },
+    },
+  };
+}
+
+describe("buildSarifLog()", () => {
+  it("produces a valid SARIF 2.1.0 top-level structure", () => {
+    const log = buildSarifLog([makeFinding({})]);
+
+    expect(log.$schema).toBe("https://json.schemastore.org/sarif-2.1.0.json");
+    expect(log.version).toBe("2.1.0");
+    expect(Array.isArray(log.runs)).toBe(true);
+    expect(log.runs.length).toBe(1);
+  });
+
+  it("sets tool driver metadata correctly", () => {
+    const log = buildSarifLog([makeFinding({})]);
+    const driver = log.runs[0].tool.driver;
+
+    expect(driver.name).toBe("deepsec");
+    expect(typeof driver.version).toBe("string");
+    expect(driver.version.length).toBeGreaterThan(0);
+    expect(driver.informationUri).toBe("https://deepsec.sh");
+  });
+
+  it("maps severity to SARIF level correctly", () => {
+    const cases: Array<{ severity: Severity; level: string }> = [
+      { severity: "CRITICAL", level: "error" },
+      { severity: "HIGH", level: "error" },
+      { severity: "HIGH_BUG", level: "warning" },
+      { severity: "MEDIUM", level: "warning" },
+      { severity: "BUG", level: "note" },
+      { severity: "LOW", level: "note" },
+    ];
+
+    for (const { severity, level } of cases) {
+      const log = buildSarifLog([makeFinding({ severity })]);
+      expect(log.runs[0].results[0].level, `severity ${severity}`).toBe(level);
+    }
+  });
+
+  it("deduplicates rules by vulnSlug within a run", () => {
+    const findings = [
+      makeFinding({ vulnSlug: "sql-injection", filePath: "a.ts", lineNumbers: [1] }),
+      makeFinding({ vulnSlug: "sql-injection", filePath: "b.ts", lineNumbers: [5] }),
+      makeFinding({ vulnSlug: "xss", filePath: "c.ts", lineNumbers: [10] }),
+    ];
+
+    const log = buildSarifLog(findings);
+    const rules = log.runs[0].tool.driver.rules;
+
+    expect(rules.length).toBe(2);
+    expect(rules.map((r) => r.id).sort()).toEqual(["sql-injection", "xss"]);
+  });
+
+  it("sets location with startLine and endLine for multi-line findings", () => {
+    const log = buildSarifLog([makeFinding({ lineNumbers: [10, 11, 12] })]);
+    const region = log.runs[0].results[0].locations[0].physicalLocation.region;
+
+    expect(region.startLine).toBe(10);
+    expect(region.endLine).toBe(12);
+  });
+
+  it("sets location with startLine only for single-line findings", () => {
+    const log = buildSarifLog([makeFinding({ lineNumbers: [42] })]);
+    const region = log.runs[0].results[0].locations[0].physicalLocation.region;
+
+    expect(region.startLine).toBe(42);
+    expect(region.endLine).toBeUndefined();
+  });
+
+  it("uses relative file path as artifact URI", () => {
+    const log = buildSarifLog([makeFinding({ filePath: "src/lib/auth.ts" })]);
+    const uri = log.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri;
+
+    expect(uri).toBe("src/lib/auth.ts");
+  });
+
+  it("produces stable partialFingerprints across calls", () => {
+    const finding = makeFinding({ filePath: "src/a.ts", lineNumbers: [7] });
+    const log1 = buildSarifLog([finding]);
+    const log2 = buildSarifLog([finding]);
+
+    const fp1 = log1.runs[0].results[0].partialFingerprints.primaryLocationLineHash;
+    const fp2 = log2.runs[0].results[0].partialFingerprints.primaryLocationLineHash;
+
+    expect(fp1).toBe(fp2);
+    expect(fp1.length).toBe(32);
+  });
+
+  it("produces different fingerprints for different files", () => {
+    const log = buildSarifLog([
+      makeFinding({ filePath: "src/a.ts", lineNumbers: [1] }),
+      makeFinding({ filePath: "src/b.ts", lineNumbers: [1] }),
+    ]);
+
+    const fp1 = log.runs[0].results[0].partialFingerprints.primaryLocationLineHash;
+    const fp2 = log.runs[0].results[1].partialFingerprints.primaryLocationLineHash;
+
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it("preserves original severity in result.properties", () => {
+    const log = buildSarifLog([makeFinding({ severity: "CRITICAL" })]);
+    const props = log.runs[0].results[0].properties;
+
+    expect(props["deepsec-severity"]).toBe("CRITICAL");
+    expect(props["deepsec-confidence"]).toBe("high");
+    expect(props["deepsec-vuln-slug"]).toBe("sql-injection");
+    expect(props["deepsec-project-id"]).toBe("my-app");
+  });
+
+  it("includes revalidation verdict in properties when present", () => {
+    const log = buildSarifLog([
+      makeFinding({ revalidation: { verdict: "true-positive", reasoning: "confirmed" } }),
+    ]);
+    const props = log.runs[0].results[0].properties;
+
+    expect(props["deepsec-revalidation"]).toBe("true-positive");
+  });
+
+  it("omits revalidation property when not present", () => {
+    const log = buildSarifLog([makeFinding({})]);
+    const props = log.runs[0].results[0].properties;
+
+    expect(props["deepsec-revalidation"]).toBeUndefined();
+  });
+
+  it("creates one run per project", () => {
+    const findings = [
+      makeFinding({ projectId: "app-a", filePath: "a.ts" }),
+      makeFinding({ projectId: "app-b", filePath: "b.ts" }),
+      makeFinding({ projectId: "app-a", filePath: "c.ts" }),
+    ];
+
+    const log = buildSarifLog(findings);
+
+    expect(log.runs.length).toBe(2);
+    const projectIds = log.runs.map((r) => r.properties?.["deepsec-project-id"]).sort();
+    expect(projectIds).toEqual(["app-a", "app-b"]);
+  });
+
+  it("produces valid empty SARIF when no findings", () => {
+    const log = buildSarifLog([]);
+
+    expect(log.version).toBe("2.1.0");
+    expect(log.runs).toEqual([]);
+  });
+
+  it("humanizes vulnSlug for rule name", () => {
+    const log = buildSarifLog([makeFinding({ vulnSlug: "sql-injection" })]);
+    const rule = log.runs[0].tool.driver.rules[0];
+
+    expect(rule.id).toBe("sql-injection");
+    expect(rule.name).toBe("Sql Injection");
+  });
+
+  it("sets ruleId on each result matching the rule id", () => {
+    const log = buildSarifLog([
+      makeFinding({ vulnSlug: "xss", filePath: "a.ts" }),
+      makeFinding({ vulnSlug: "ssrf", filePath: "b.ts" }),
+    ]);
+
+    expect(log.runs[0].results[0].ruleId).toBe("xss");
+    expect(log.runs[0].results[1].ruleId).toBe("ssrf");
+  });
+
+  it("uses finding description as result message text", () => {
+    const log = buildSarifLog([makeFinding({ description: "Critical vuln here" })]);
+
+    expect(log.runs[0].results[0].message.text).toBe("Critical vuln here");
+  });
+});

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -297,8 +297,8 @@ program
 
 program
   .command("export")
-  .description("Export findings as JSON or as a directory of per-finding markdown files")
-  .option("--format <kind>", "Output format: json (default) or md-dir", "json")
+  .description("Export findings as JSON, SARIF, or a directory of per-finding markdown files")
+  .option("--format <kind>", "Output format: json (default), md-dir, or sarif", "json")
   .option("--project-id <csv>", "Comma-separated project IDs (omit for all)")
   .option(
     "--min-severity <sev>",
@@ -335,7 +335,7 @@ program
   )
   .option(
     "--out <path>",
-    "Output path. JSON format: file (default: stdout). md-dir format: directory (required).",
+    "Output path. JSON/SARIF: file (default: stdout). md-dir: directory (required).",
   )
   .action(exportCommand);
 

--- a/packages/deepsec/src/commands/export.ts
+++ b/packages/deepsec/src/commands/export.ts
@@ -5,6 +5,7 @@ import type { FileRecord, Finding, Severity } from "@deepsec/core";
 import { dataDir, getDataRoot, loadAllFileRecords } from "@deepsec/core";
 import { BOLD, DIM, GREEN, RESET, YELLOW } from "../formatters.js";
 import { resolveAgentType } from "../resolve-agent-type.js";
+import { getDeepsecVersion } from "../version.js";
 
 const SEVERITY_ORDER: Record<Severity, number> = {
   CRITICAL: 0,
@@ -25,7 +26,7 @@ interface OwnerSummary {
   recentCommitters: { name: string; email: string; date: string }[];
 }
 
-interface ExportedFinding {
+export interface ExportedFinding {
   title: string;
   description: string;
   severity: Severity;
@@ -309,6 +310,193 @@ function writeMdDir(findings: ExportedFinding[], out: string) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// SARIF 2.1.0 export
+// Spec: https://docs.oasis.org/projects/sarif/sarif-spec/v2.1.0/sarif-v2.1.0.html
+// GitHub Code Scanning accepts a subset of SARIF 2.1.0; this implementation
+// targets that subset so results can be uploaded via
+// github/codeql-action/upload-sarif@v4 and displayed as PR annotations.
+// ---------------------------------------------------------------------------
+
+/** SARIF `level` only has three values; deepsec has six severities. */
+function severityToSarifLevel(severity: Severity): "error" | "warning" | "note" {
+  switch (severity) {
+    case "CRITICAL":
+    case "HIGH":
+      return "error";
+    case "HIGH_BUG":
+    case "MEDIUM":
+      return "warning";
+    case "BUG":
+    case "LOW":
+      return "note";
+  }
+}
+
+/** Convert "sql-injection" → "SQL Injection" for human-readable rule names. */
+function humanizeSlug(slug: string): string {
+  return slug
+    .split("-")
+    .map((w) => (w.length <= 2 ? w.toUpperCase() : w[0].toUpperCase() + w.slice(1)))
+    .join(" ");
+}
+
+/**
+ * Deterministic fingerprint for SARIF `partialFingerprints.primaryLocationLineHash`.
+ *
+ * GitHub's upload-sarif action will auto-compute fingerprints when this field
+ * is absent, but providing a stable value ourselves avoids relying on that
+ * fallback and works with tools that don't recompute. We derive the hash from
+ * the same immutable identity fields deepsec uses for `findingId`
+ * (projectId + normalized filePath + title), plus the first line number —
+ * matching the "primary location" semantics SARIF expects.
+ */
+function sarifFingerprint(f: ExportedFinding): string {
+  const normPath = f.metadata.filePath.replaceAll("\\", "/").replace(/^\.\//, "");
+  const raw = `${f.metadata.projectId}\0${normPath}\0${f.metadata.lineNumbers[0] ?? 1}`;
+  return crypto.createHash("sha256").update(raw).digest("hex").slice(0, 32);
+}
+
+interface SarifRule {
+  id: string;
+  name: string;
+  shortDescription: { text: string };
+}
+
+interface SarifResult {
+  ruleId: string;
+  level: "error" | "warning" | "note";
+  message: { text: string };
+  locations: Array<{
+    physicalLocation: {
+      artifactLocation: { uri: string };
+      region: { startLine: number; endLine?: number };
+    };
+  }>;
+  partialFingerprints: { primaryLocationLineHash: string };
+  properties: Record<string, string>;
+}
+
+interface SarifRun {
+  tool: {
+    driver: {
+      name: string;
+      version: string;
+      informationUri: string;
+      rules: SarifRule[];
+    };
+  };
+  results: SarifResult[];
+  properties?: Record<string, string>;
+}
+
+interface SarifLog {
+  $schema: string;
+  version: string;
+  runs: SarifRun[];
+}
+
+/**
+ * Build a SARIF 2.1.0 log from exported findings. Each project becomes one
+ * `run` so multi-project exports stay isolated. Rules are deduped per run by
+ * `vulnSlug` (the SARIF `ruleId`).
+ *
+ * Exported so unit tests can call it directly without touching the filesystem.
+ */
+export function buildSarifLog(findings: ExportedFinding[]): SarifLog {
+  const version = getDeepsecVersion();
+
+  // Group by project so each project gets its own run.
+  const byProject = new Map<string, ExportedFinding[]>();
+  for (const f of findings) {
+    const list = byProject.get(f.metadata.projectId) ?? [];
+    list.push(f);
+    byProject.set(f.metadata.projectId, list);
+  }
+
+  const runs: SarifRun[] = [];
+
+  for (const [projectId, projectFindings] of byProject) {
+    // Collect deduped rules keyed by vulnSlug.
+    const ruleMap = new Map<string, SarifRule>();
+    for (const f of projectFindings) {
+      if (!ruleMap.has(f.metadata.vulnSlug)) {
+        ruleMap.set(f.metadata.vulnSlug, {
+          id: f.metadata.vulnSlug,
+          name: humanizeSlug(f.metadata.vulnSlug),
+          shortDescription: { text: f.title },
+        });
+      }
+    }
+
+    const results: SarifResult[] = projectFindings.map((f) => {
+      const lines = f.metadata.lineNumbers;
+      const startLine = lines[0] ?? 1;
+      const region: { startLine: number; endLine?: number } = { startLine };
+      if (lines.length > 1) {
+        region.endLine = lines[lines.length - 1];
+      }
+
+      const props: Record<string, string> = {
+        "deepsec-severity": f.metadata.severity,
+        "deepsec-confidence": f.metadata.confidence,
+        "deepsec-vuln-slug": f.metadata.vulnSlug,
+        "deepsec-project-id": f.metadata.projectId,
+      };
+      if (f.metadata.revalidation) {
+        props["deepsec-revalidation"] = f.metadata.revalidation.verdict;
+      }
+
+      return {
+        ruleId: f.metadata.vulnSlug,
+        level: severityToSarifLevel(f.metadata.severity),
+        message: { text: f.description },
+        locations: [
+          {
+            physicalLocation: {
+              artifactLocation: { uri: f.metadata.filePath },
+              region,
+            },
+          },
+        ],
+        partialFingerprints: { primaryLocationLineHash: sarifFingerprint(f) },
+        properties: props,
+      };
+    });
+
+    runs.push({
+      tool: {
+        driver: {
+          name: "deepsec",
+          version,
+          informationUri: "https://deepsec.sh",
+          rules: [...ruleMap.values()],
+        },
+      },
+      results,
+      properties: { "deepsec-project-id": projectId },
+    });
+  }
+
+  return {
+    $schema: "https://json.schemastore.org/sarif-2.1.0.json",
+    version: "2.1.0",
+    runs,
+  };
+}
+
+function writeSarif(findings: ExportedFinding[], out: string | undefined) {
+  const log = buildSarifLog(findings);
+  const json = JSON.stringify(log, null, 2);
+  if (out) {
+    fs.mkdirSync(path.dirname(path.resolve(out)), { recursive: true });
+    fs.writeFileSync(out, json + "\n");
+    console.log(`\n${GREEN}Exported ${findings.length} finding(s)${RESET} → ${BOLD}${out}${RESET}`);
+  } else {
+    process.stdout.write(json + "\n");
+  }
+}
+
 export async function exportCommand(opts: {
   projectId?: string;
   minSeverity?: string;
@@ -342,8 +530,8 @@ export async function exportCommand(opts: {
     : listProjectIds();
 
   const format = opts.format ?? "json";
-  if (format !== "json" && format !== "md-dir") {
-    throw new Error(`--format must be "json" or "md-dir", got "${format}"`);
+  if (format !== "json" && format !== "md-dir" && format !== "sarif") {
+    throw new Error(`--format must be "json", "md-dir", or "sarif", got "${format}"`);
   }
   if (format === "md-dir" && !opts.out) {
     throw new Error(`--format md-dir requires --out <dir>`);
@@ -534,6 +722,8 @@ export async function exportCommand(opts: {
 
   if (format === "md-dir") {
     writeMdDir(findings, opts.out!);
+  } else if (format === "sarif") {
+    writeSarif(findings, opts.out);
   } else {
     writeJson(findings, opts.out);
   }

--- a/packages/deepsec/src/commands/export.ts
+++ b/packages/deepsec/src/commands/export.ts
@@ -347,13 +347,14 @@ function humanizeSlug(slug: string): string {
  * GitHub's upload-sarif action will auto-compute fingerprints when this field
  * is absent, but providing a stable value ourselves avoids relying on that
  * fallback and works with tools that don't recompute. We derive the hash from
- * the same immutable identity fields deepsec uses for `findingId`
- * (projectId + normalized filePath + title), plus the first line number —
- * matching the "primary location" semantics SARIF expects.
+ * projectId + normalized filePath + vulnSlug + first line number.
+ * vulnSlug is included so that distinct findings on the same file+line
+ * (e.g. both SQL injection and XSS on the same line) produce different
+ * fingerprints — otherwise GitHub Code Scanning would drop one alert.
  */
 function sarifFingerprint(f: ExportedFinding): string {
   const normPath = f.metadata.filePath.replaceAll("\\", "/").replace(/^\.\//, "");
-  const raw = `${f.metadata.projectId}\0${normPath}\0${f.metadata.lineNumbers[0] ?? 1}`;
+  const raw = `${f.metadata.projectId}\0${normPath}\0${f.metadata.vulnSlug}\0${f.metadata.lineNumbers[0] ?? 1}`;
   return crypto.createHash("sha256").update(raw).digest("hex").slice(0, 32);
 }
 


### PR DESCRIPTION
Add `--format sarif` to the `export` command, producing SARIF 2.1.0 compliant output that can be uploaded to GitHub Code Scanning via `github/codeql-action/upload-sarif@v4`.

Closes #40

## What
- New `buildSarifLog()` and `writeSarif()` in `export.ts`
- Severity mapping: CRITICAL/HIGH → error, HIGH_BUG/MEDIUM → warning, BUG/LOW → note
- `vulnSlug` → SARIF `ruleId`; rules deduped per run
- Each project → one SARIF `run`
- Custom properties preserve original severity, confidence, revalidation verdict
- Stable `partialFingerprints.primaryLocationLineHash` for cross-run tracking

## Why
Enables deepsec findings to be displayed as PR annotations and in the repository Security tab, integrating with GitHub's native code scanning workflow.

## Testing
- 18 unit tests in `export-sarif.test.ts` covering structure, severity mapping, rule dedup, locations, fingerprints, properties, multi-project
- E2E test in `pipeline.test.ts` validates the full pipeline produces valid SARIF
- Validated against official SARIF 2.1.0 JSON schema (ajv)
- Validated end-to-end: SARIF uploaded to GitHub Code Scanning via `upload-sarif@v4` action, all 10 findings accepted successfully

## What changed

<!-- 1–2 sentences. -->

## Why

<!-- The motivation, not the diff. -->

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
