### PR TITLE
feat(pi): add built-in MiniMax provider presets

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,6 +117,9 @@ backend you're using.
 |---|---|---|
 | `OPENAI_API_KEY` | `--agent codex`, `--agent pi --model openai/...` | Codex SDK token or Pi OpenAI-provider token. Unset is fine if `AI_GATEWAY_API_KEY` is set. |
 | `OPENAI_BASE_URL` | `--agent codex` | Default (when `AI_GATEWAY_API_KEY` is set): `https://ai-gateway.vercel.sh/v1`. |
+| `MINIMAX_API_KEY` | `--agent pi --model minimax/...` | Auth for the built-in MiniMax provider preset. |
+| `MINIMAX_REGION` | `--agent pi --model minimax/...` | Endpoint preset: `global` (default) or `cn`. See [models.md](models.md). |
+| `MINIMAX_BASE_URL` | `--agent pi --model minimax/...` | Override the region preset with a custom base URL. |
 | `PI_CODING_AGENT_DIR` | `--agent pi` | Optional Pi config/auth directory. Defaults to `~/.pi/agent`; local non-sandbox runs can reuse `auth.json` there. |
 | `DEEPSEC_AGENT_DEBUG` | both backends | Set to `1` to enable verbose agent logging. |
 | `DEEPSEC_DATA_ROOT` | core | Override the data directory location. Equivalent to `dataDir` in config. |

--- a/docs/models.md
+++ b/docs/models.md
@@ -132,6 +132,37 @@ Repeat `--ai-header name=value` for provider-specific headers. There is
 no Martian-specific first-class integration; these flags are the generic
 provider override path.
 
+### MiniMax (`minimax/…`) presets
+
+MiniMax ships as a built-in Pi provider preset, so you can select its
+models by id without spelling out the base URL. The provider registers
+`minimax/MiniMax-M3` (1M-token context) and `minimax/MiniMax-M2.7`
+(204,800-token context):
+
+```bash
+MINIMAX_API_KEY=...
+pnpm deepsec process --project-id my-app --agent pi --model minimax/MiniMax-M3
+```
+
+Two regional endpoint presets are built in. The default is the global
+endpoint (`https://api.minimax.io/v1`); set `MINIMAX_REGION=cn` to use
+the CN endpoint (`https://api.minimaxi.com/v1`) instead:
+
+```bash
+MINIMAX_API_KEY=...
+MINIMAX_REGION=cn
+pnpm deepsec process --project-id my-app --agent pi --model minimax/MiniMax-M2.7
+```
+
+`MINIMAX_BASE_URL` (or `--ai-base-url`) overrides the region preset for a
+custom endpoint. Auth comes from `MINIMAX_API_KEY`, or point
+`--ai-api-key-env` at a different variable.
+
+`--thinking-level` flows through to the model: `MiniMax-M3`'s reasoning is
+adaptive and can be dialed down for cheaper waves, while `MiniMax-M2.7`
+always reasons. In sandbox mode, add the endpoint host to `allowedHosts`
+so worker egress can reach it.
+
 ### `claude-sonnet-4-6` for `triage`
 
 Triage buckets findings into P0/P1/P2/skip without re-reading the code

--- a/packages/processor/src/__tests__/pi-sdk-tools.test.ts
+++ b/packages/processor/src/__tests__/pi-sdk-tools.test.ts
@@ -5,6 +5,7 @@ import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createPiReadOnlyToolDefinitions,
+  registerMiniMaxProvider,
   resolvePiModelWithDynamicGateway,
 } from "../agents/pi-sdk.js";
 
@@ -70,6 +71,9 @@ describe("Pi model resolution", () => {
     "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_BASE_URL",
+    "MINIMAX_API_KEY",
+    "MINIMAX_BASE_URL",
+    "MINIMAX_REGION",
   ] as const;
   const originalEnv = Object.fromEntries(KEYS.map((key) => [key, process.env[key]]));
   const originalFetch = globalThis.fetch;
@@ -167,5 +171,68 @@ describe("Pi model resolution", () => {
       }),
     ).rejects.toThrow(/Pi model not found: acme\/nonexistent-model-1/);
     expect(called).toBe(false);
+  });
+
+  it("registers the built-in MiniMax presets and resolves them offline", async () => {
+    for (const key of KEYS) delete process.env[key];
+    let called = false;
+    globalThis.fetch = async () => {
+      called = true;
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    };
+
+    const registry = await freshRegistry();
+    registerMiniMaxProvider(registry, {});
+
+    const m3 = await resolvePiModelWithDynamicGateway(registry, "minimax/MiniMax-M3", {});
+    expect(m3.provider).toBe("minimax");
+    expect(m3.id).toBe("MiniMax-M3");
+    expect(m3.api).toBe("openai-completions");
+    expect(m3.reasoning).toBe(true);
+    expect(m3.input).toEqual(["text", "image"]);
+    expect(m3.contextWindow).toBe(1_000_000);
+    expect(m3.cost.input).toBe(0.6);
+
+    const m27 = await resolvePiModelWithDynamicGateway(registry, "minimax/MiniMax-M2.7", {});
+    expect(m27.provider).toBe("minimax");
+    expect(m27.id).toBe("MiniMax-M2.7");
+    expect(m27.contextWindow).toBe(204_800);
+    expect(m27.cost.cacheWrite).toBe(0.375);
+
+    expect(called).toBe(false);
+  });
+
+  it("selects the CN MiniMax endpoint preset via MINIMAX_REGION", async () => {
+    for (const key of KEYS) delete process.env[key];
+    process.env.MINIMAX_REGION = "cn";
+
+    const registry = await freshRegistry();
+    registerMiniMaxProvider(registry, {});
+
+    expect(registry.getRegisteredProviderConfig("minimax")?.baseUrl).toBe(
+      "https://api.minimaxi.com/v1",
+    );
+  });
+
+  it("defaults MiniMax to the global endpoint preset", async () => {
+    for (const key of KEYS) delete process.env[key];
+
+    const registry = await freshRegistry();
+    registerMiniMaxProvider(registry, {});
+
+    expect(registry.getRegisteredProviderConfig("minimax")?.baseUrl).toBe(
+      "https://api.minimax.io/v1",
+    );
+  });
+
+  it("lets --ai-base-url override the MiniMax region preset", async () => {
+    for (const key of KEYS) delete process.env[key];
+
+    const registry = await freshRegistry();
+    registerMiniMaxProvider(registry, { aiBaseUrl: "https://example.test/v1" });
+
+    expect(registry.getRegisteredProviderConfig("minimax")?.baseUrl).toBe(
+      "https://example.test/v1",
+    );
   });
 });

--- a/packages/processor/src/agents/pi-sdk.ts
+++ b/packages/processor/src/agents/pi-sdk.ts
@@ -85,6 +85,78 @@ type PiModel = ReturnType<ModelRegistry["getAll"]>[number];
 type PiProviderConfig = Parameters<ModelRegistry["registerProvider"]>[1];
 type PiProviderModelConfig = NonNullable<PiProviderConfig["models"]>[number];
 
+// MiniMax exposes an OpenAI-compatible endpoint on two regional hosts that
+// share the same model catalog. We register the provider so `--model
+// minimax/<id>` resolves offline (deepsec pins PI_OFFLINE, so pi never
+// fetches a remote catalog for it). The region is selected with
+// MINIMAX_REGION, or overridden outright with MINIMAX_BASE_URL /
+// --ai-base-url; the model ids stay stable across regions.
+const MINIMAX_PROVIDER = "minimax";
+const MINIMAX_API = "openai-completions" as const;
+const MINIMAX_REGION_BASE_URLS = {
+  global: "https://api.minimax.io/v1",
+  cn: "https://api.minimaxi.com/v1",
+} as const;
+type MiniMaxRegion = keyof typeof MINIMAX_REGION_BASE_URLS;
+const MINIMAX_DEFAULT_REGION: MiniMaxRegion = "global";
+// Output cap applied on the deepsec side; matches the generic pass-through
+// default. deepsec's investigation JSON fits well under this.
+const MINIMAX_MAX_TOKENS = 32_000;
+
+// Built-in model presets. cost is USD per million tokens (pi divides usage
+// by 1e6). `reasoning: true` routes deepsec's --thinking-level through to
+// each model: MiniMax-M3's thinking is adaptive and can be turned down for
+// cheaper waves, while MiniMax-M2.7 always reasons. pi's `input` union
+// covers only text/image, so the video modality is not represented here.
+const MINIMAX_MODELS: PiProviderModelConfig[] = [
+  {
+    id: "MiniMax-M3",
+    name: "MiniMax-M3",
+    api: MINIMAX_API,
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0 },
+    contextWindow: 1_000_000,
+    maxTokens: MINIMAX_MAX_TOKENS,
+  },
+  {
+    id: "MiniMax-M2.7",
+    name: "MiniMax-M2.7",
+    api: MINIMAX_API,
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
+    contextWindow: 204_800,
+    maxTokens: MINIMAX_MAX_TOKENS,
+  },
+];
+
+function resolveMiniMaxBaseUrl(cfg: PiAgentConfig): string {
+  if (cfg.aiBaseUrl) return cfg.aiBaseUrl;
+  if (process.env.MINIMAX_BASE_URL) return process.env.MINIMAX_BASE_URL;
+  const region = process.env.MINIMAX_REGION as MiniMaxRegion | undefined;
+  if (region && region in MINIMAX_REGION_BASE_URLS) return MINIMAX_REGION_BASE_URLS[region];
+  return MINIMAX_REGION_BASE_URLS[MINIMAX_DEFAULT_REGION];
+}
+
+/**
+ * Register the built-in MiniMax provider preset (regional base URL + model
+ * catalog). Auth is layered separately in configureRuntimeAuth, or via the
+ * generic --ai-api-key-env override; a missing key just leaves the provider
+ * unauthenticated. Registering an unused provider is cheap.
+ */
+export function registerMiniMaxProvider(registry: ModelRegistry, cfg: PiAgentConfig): void {
+  const override: PiProviderConfig = {
+    baseUrl: resolveMiniMaxBaseUrl(cfg),
+    api: MINIMAX_API,
+    models: MINIMAX_MODELS,
+  };
+  const key = cfg.aiApiKeyEnv ? process.env[cfg.aiApiKeyEnv] : process.env.MINIMAX_API_KEY;
+  if (key) override.apiKey = key;
+  if (cfg.aiHeaders && Object.keys(cfg.aiHeaders).length > 0) override.headers = cfg.aiHeaders;
+  registry.registerProvider(MINIMAX_PROVIDER, override);
+}
+
 interface PiSessionSetup {
   session: AgentSession;
   modelLabel: string;
@@ -335,6 +407,9 @@ async function configureRuntimeAuth(runtime: ModelRuntime, cfg: PiAgentConfig): 
   const openaiKey = process.env.OPENAI_API_KEY;
   if (openaiKey) await runtime.setRuntimeApiKey("openai", openaiKey, offline);
 
+  const minimaxKey = process.env.MINIMAX_API_KEY;
+  if (minimaxKey) await runtime.setRuntimeApiKey(MINIMAX_PROVIDER, minimaxKey, offline);
+
   const customProvider = cfg.aiProvider ?? modelProviderFromName(cfg.model);
   if (customProvider && cfg.aiApiKeyEnv) {
     const key = process.env[cfg.aiApiKeyEnv];
@@ -512,6 +587,7 @@ async function createPiSession(projectRoot: string, cfg: PiAgentConfig): Promise
   // their tests) on the same ModelRegistry API as before.
   const modelRegistry = new ModelRegistry(runtime);
   configureProviderOverrides(modelRegistry, cfg);
+  registerMiniMaxProvider(modelRegistry, cfg);
 
   const modelName = cfg.model ?? DEFAULT_MODEL;
   const model = await resolvePiModelWithDynamicGateway(modelRegistry, modelName, cfg);


### PR DESCRIPTION
Reason: The Pi backend had no built-in MiniMax provider or MiniMax-M3/MiniMax-M2.7 presets; add the global and CN endpoint presets and map thinking through the existing agent configuration surface.

## What this adds

The Pi backend already accepts arbitrary providers through `--ai-provider` /
`--ai-base-url` / `--ai-api-key-env`, but there was no first-class MiniMax
preset, so `--model minimax/…` did not resolve. This registers a built-in
`minimax` provider so the models can be selected by id:

- `minimax/MiniMax-M3` — 1,000,000-token context, adaptive reasoning
- `minimax/MiniMax-M2.7` — 204,800-token context, always reasons

Two regional endpoint presets are built in and selected with `MINIMAX_REGION`:

- `global` (default): `https://api.minimax.io/v1`
- `cn`: `https://api.minimaxi.com/v1`

`MINIMAX_BASE_URL` (or `--ai-base-url`) overrides the region preset; auth comes
from `MINIMAX_API_KEY` or a variable named via `--ai-api-key-env`. The provider
speaks the OpenAI-compatible endpoint. Because deepsec pins `PI_OFFLINE`, the
model presets are registered explicitly so resolution works without a remote
catalog fetch.

`--thinking-level` flows through unchanged: both models are registered with
`reasoning: true`, so deepsec's existing thinking dial applies. Pricing is set
per million tokens for the cost-per-batch readout, and the `input` modalities
use pi's supported `text`/`image` union.

## Files

- `packages/processor/src/agents/pi-sdk.ts` — `registerMiniMaxProvider`, model
  presets, region resolution, and runtime auth wiring.
- `packages/processor/src/__tests__/pi-sdk-tools.test.ts` — offline resolution
  of both model ids and both endpoint presets, plus the `--ai-base-url`
  override.
- `docs/models.md`, `docs/configuration.md` — preset usage and env vars.

## Checks

- `pnpm --filter @deepsec/processor build` (tsc) — passed.
- `pnpm exec biome check` on the changed files — passed.

The vitest suite requires Node >= 22 (repo `engines`); the added unit tests
follow the existing `Pi model resolution` cases and are covered by CI.
