### PR TITLE
Add first-class Kimi K3 support through Fireworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ for the Vercel Sandbox setup. To bypass the gateway, set
 explicitly. Explicit values always win over the `AI_GATEWAY_API_KEY`
 expansion.
 
+The Pi backend also includes a direct
+[Kimi K3 on Fireworks](docs/models.md#kimi-k3-on-fireworks) preset for
+`FIREWORKS_API_KEY`; no custom Pi model registry entry is required.
+
 If a `process` or `revalidate` run halts because the upstream credential
 ran out of quota or credits, deepsec stops gracefully and tells you
 where to top up. Re-run the same command afterward and it picks up

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,6 +117,7 @@ backend you're using.
 |---|---|---|
 | `OPENAI_API_KEY` | `--agent codex`, `--agent pi --model openai/...` | Codex SDK token or Pi OpenAI-provider token. Unset is fine if `AI_GATEWAY_API_KEY` is set. |
 | `OPENAI_BASE_URL` | `--agent codex` | Default (when `AI_GATEWAY_API_KEY` is set): `https://ai-gateway.vercel.sh/v1`. |
+| `FIREWORKS_API_KEY` | `--agent pi --model fireworks/accounts/fireworks/models/kimi-k3` | Fireworks credential used by the built-in Kimi K3 preset. See [models.md](models.md#kimi-k3-on-fireworks). |
 | `PI_CODING_AGENT_DIR` | `--agent pi` | Optional Pi config/auth directory. Defaults to `~/.pi/agent`; local non-sandbox runs can reuse `auth.json` there. |
 | `DEEPSEC_AGENT_DEBUG` | both backends | Set to `1` to enable verbose agent logging. |
 | `DEEPSEC_DATA_ROOT` | core | Override the data directory location. Equivalent to `dataDir` in config. |

--- a/docs/models.md
+++ b/docs/models.md
@@ -132,6 +132,57 @@ Repeat `--ai-header name=value` for provider-specific headers. There is
 no Martian-specific first-class integration; these flags are the generic
 provider override path.
 
+### Kimi K3 on Fireworks
+
+Kimi K3 is available through the Pi backend using deepsec's built-in
+Fireworks preset. Set a Fireworks API key and select the full provider/model
+identifier:
+
+```bash
+FIREWORKS_API_KEY=...
+pnpm deepsec process --project-id my-app \
+  --agent pi \
+  --model fireworks/accounts/fireworks/models/kimi-k3
+```
+
+The same selection works for revalidation:
+
+```bash
+FIREWORKS_API_KEY=...
+pnpm deepsec revalidate --project-id my-app \
+  --agent pi \
+  --model fireworks/accounts/fireworks/models/kimi-k3
+```
+
+No Pi `models.json` entry is required. deepsec registers the model in Pi's
+offline catalog with Fireworks' OpenAI-compatible endpoint, 1,048,576-token
+context window, text/image input metadata, and current serverless pricing:
+$3.00 input, $0.30 cached input, and $15.00 output per million tokens.
+deepsec's Pi harness currently exposes source-reading text tools only, so the
+model's image support is not used during an investigation.
+
+`--thinking-level` uses the same Pi reasoning control described above. For a
+small smoke run, `--thinking-level low --limit 1 --concurrency 1` keeps the
+test bounded.
+
+The preset supplies `https://api.fireworks.ai/inference/v1` and reads
+`FIREWORKS_API_KEY`. Explicit provider options still win, so a compatible
+proxy can replace either value:
+
+```bash
+CUSTOM_FIREWORKS_KEY=...
+pnpm deepsec process --project-id my-app \
+  --agent pi \
+  --model fireworks/accounts/fireworks/models/kimi-k3 \
+  --ai-base-url https://fireworks-proxy.example.com/v1 \
+  --ai-api-key-env CUSTOM_FIREWORKS_KEY \
+  --ai-header x-account=my-team
+```
+
+Sandbox runs use the same model command. The orchestrator places only a
+placeholder key in the worker, restricts AI egress to the selected base URL
+host, and injects the real Fireworks credential at the firewall.
+
 ### `claude-sonnet-4-6` for `triage`
 
 Triage buckets findings into P0/P1/P2/skip without re-reading the code

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -151,6 +151,23 @@ as needed. In sandbox mode, deepsec passes only a placeholder env var
 into the worker and injects the real token at egress for the
 `--ai-base-url` host.
 
+Kimi K3 has a built-in Fireworks preset, so it does not need those routing
+flags:
+
+```bash
+FIREWORKS_API_KEY=...
+pnpm deepsec process --project-id my-app \
+  --agent pi \
+  --model fireworks/accounts/fireworks/models/kimi-k3
+```
+
+The preset selects `https://api.fireworks.ai/inference/v1` and
+`FIREWORKS_API_KEY`. It works in sandbox mode too: the orchestrator derives
+the same values, gives the worker a placeholder, allowlists
+`api.fireworks.ai`, and injects the real bearer token at egress. See
+[models.md](models.md#kimi-k3-on-fireworks) for model metadata, pricing, and
+override examples.
+
 ---
 
 ## Vercel Sandbox

--- a/packages/deepsec/src/__tests__/agent-config.test.ts
+++ b/packages/deepsec/src/__tests__/agent-config.test.ts
@@ -2,6 +2,60 @@ import { describe, expect, it } from "vitest";
 import { buildAgentConfig } from "../agent-config.js";
 
 describe("buildAgentConfig", () => {
+  it("applies the Fireworks Kimi K3 provider preset", () => {
+    expect(
+      buildAgentConfig({
+        model: "fireworks/accounts/fireworks/models/kimi-k3",
+      }),
+    ).toMatchObject({
+      model: "fireworks/accounts/fireworks/models/kimi-k3",
+      aiProvider: "fireworks",
+      aiBaseUrl: "https://api.fireworks.ai/inference/v1",
+      aiBaseUrlFromPreset: true,
+      aiApiKeyEnv: "FIREWORKS_API_KEY",
+    });
+  });
+
+  it("lets explicit Fireworks overrides replace the Kimi K3 preset defaults", () => {
+    expect(
+      buildAgentConfig({
+        model: "fireworks/accounts/fireworks/models/kimi-k3",
+        aiBaseUrl: "https://fireworks.example.test/v1",
+        aiApiKeyEnv: "CUSTOM_FIREWORKS_KEY",
+        aiHeader: ["x-fireworks-account=test"],
+      }),
+    ).toMatchObject({
+      aiProvider: "fireworks",
+      aiBaseUrl: "https://fireworks.example.test/v1",
+      aiApiKeyEnv: "CUSTOM_FIREWORKS_KEY",
+      aiHeaders: { "x-fireworks-account": "test" },
+    });
+    expect(
+      buildAgentConfig({
+        model: "fireworks/accounts/fireworks/models/kimi-k3",
+        aiBaseUrl: "https://fireworks.example.test/v1",
+      }),
+    ).not.toHaveProperty("aiBaseUrlFromPreset");
+  });
+
+  it("does not apply Fireworks defaults to other models", () => {
+    const config = buildAgentConfig({ model: "fireworks/accounts/fireworks/models/glm-5p2" });
+    expect(config).not.toHaveProperty("aiBaseUrl");
+    expect(config).not.toHaveProperty("aiApiKeyEnv");
+  });
+
+  it("does not silently apply Fireworks routing to a conflicting explicit provider", () => {
+    expect(
+      buildAgentConfig({
+        model: "fireworks/accounts/fireworks/models/kimi-k3",
+        aiProvider: "custom",
+      }),
+    ).toEqual({
+      model: "fireworks/accounts/fireworks/models/kimi-k3",
+      aiProvider: "custom",
+    });
+  });
+
   it("infers the provider for Pi custom API key env overrides from provider/model", () => {
     expect(
       buildAgentConfig({

--- a/packages/deepsec/src/__tests__/credential-brokering.test.ts
+++ b/packages/deepsec/src/__tests__/credential-brokering.test.ts
@@ -8,6 +8,7 @@ const TOUCHED_KEYS = [
   "OPENAI_API_KEY",
   "OPENAI_BASE_URL",
   "MARTIAN_API_KEY",
+  "FIREWORKS_API_KEY",
 ] as const;
 
 describe("credential brokering", () => {
@@ -65,6 +66,15 @@ describe("credential brokering", () => {
       process.env.MARTIAN_API_KEY = "martian-real";
       const c = resolveBrokeredCredentials("pi", { aiApiKeyEnv: "MARTIAN_API_KEY" });
       expect(c.customToken).toEqual({ envName: "MARTIAN_API_KEY", token: "martian-real" });
+    });
+
+    it("captures the Fireworks preset key for the pi path", () => {
+      process.env.FIREWORKS_API_KEY = "fireworks-real";
+      const c = resolveBrokeredCredentials("pi", { aiApiKeyEnv: "FIREWORKS_API_KEY" });
+      expect(c.customToken).toEqual({
+        envName: "FIREWORKS_API_KEY",
+        token: "fireworks-real",
+      });
     });
   });
 
@@ -143,6 +153,24 @@ describe("credential brokering", () => {
       expect(env.DEEPSEC_PI_AI_BASE_URL).toBe("https://api.withmartian.com/v1");
       for (const v of Object.values(env)) {
         expect(v).not.toContain("martian-real-secret");
+      }
+    });
+
+    it("brokers the Fireworks preset key and base URL without exposing the key", () => {
+      process.env.FIREWORKS_API_KEY = "fireworks-real-secret";
+      const credentials = resolveBrokeredCredentials("pi", {
+        aiApiKeyEnv: "FIREWORKS_API_KEY",
+      });
+      const env = buildSandboxEnv("pi", credentials, {
+        aiApiKeyEnv: "FIREWORKS_API_KEY",
+        aiBaseUrl: "https://api.fireworks.ai/inference/v1",
+      });
+
+      expect(env.FIREWORKS_API_KEY).toBeDefined();
+      expect(env.FIREWORKS_API_KEY).not.toBe("fireworks-real-secret");
+      expect(env.DEEPSEC_PI_AI_BASE_URL).toBe("https://api.fireworks.ai/inference/v1");
+      for (const value of Object.values(env)) {
+        expect(value).not.toContain("fireworks-real-secret");
       }
     });
   });

--- a/packages/deepsec/src/__tests__/network-policy.test.ts
+++ b/packages/deepsec/src/__tests__/network-policy.test.ts
@@ -126,6 +126,37 @@ describe("buildWorkerNetworkPolicy", () => {
       expect(bearerFor(policy, "api.withmartian.com")).toBe("Bearer martian-real");
     });
 
+    it("restricts Fireworks traffic to its API host and injects the brokered key", () => {
+      const policy = buildWorkerNetworkPolicy(
+        { DEEPSEC_PI_AI_BASE_URL: "https://api.fireworks.ai/inference/v1" },
+        "pi",
+        {
+          customToken: {
+            envName: "FIREWORKS_API_KEY",
+            token: "fireworks-real",
+          },
+        },
+      );
+      expect(allowedHosts(policy)).toEqual(["api.fireworks.ai"]);
+      expect(bearerFor(policy, "api.fireworks.ai")).toBe("Bearer fireworks-real");
+    });
+
+    it("does not attach the Fireworks credential to extra allowed hosts", () => {
+      const policy = buildWorkerNetworkPolicy(
+        { DEEPSEC_PI_AI_BASE_URL: "https://api.fireworks.ai/inference/v1" },
+        "pi",
+        {
+          customToken: {
+            envName: "FIREWORKS_API_KEY",
+            token: "fireworks-real",
+          },
+        },
+        ["telemetry.example.com"],
+      );
+      expect(bearerFor(policy, "api.fireworks.ai")).toBe("Bearer fireworks-real");
+      expect(bearerFor(policy, "telemetry.example.com")).toBeNull();
+    });
+
     it("emits no transform when no matching credential is provided", () => {
       const policy = buildWorkerNetworkPolicy(
         { ANTHROPIC_UPSTREAM_BASE_URL: "https://ai-gateway.vercel.sh" },

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -36,6 +36,7 @@ describe("assertAgentCredential", () => {
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
       AI_GATEWAY_API_KEY: process.env.AI_GATEWAY_API_KEY,
       MARTIAN_API_KEY: process.env.MARTIAN_API_KEY,
+      FIREWORKS_API_KEY: process.env.FIREWORKS_API_KEY,
       CLAUDE_HOME: process.env.CLAUDE_HOME,
       CODEX_HOME: process.env.CODEX_HOME,
       PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
@@ -46,6 +47,7 @@ describe("assertAgentCredential", () => {
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.AI_GATEWAY_API_KEY;
     delete process.env.MARTIAN_API_KEY;
+    delete process.env.FIREWORKS_API_KEY;
     // Point CLAUDE_HOME / CODEX_HOME and PATH at empty tmp dirs so the
     // suite is hermetic — the dev running tests may have a real
     // ~/.codex/auth.json or `claude` on $PATH, which would cause
@@ -139,6 +141,26 @@ describe("assertAgentCredential", () => {
   it("passes for pi when a custom --ai-api-key-env is set", () => {
     process.env.MARTIAN_API_KEY = "martian-key";
     expect(() => assertAgentCredential("pi", { aiApiKeyEnv: "MARTIAN_API_KEY" })).not.toThrow();
+  });
+
+  it("passes for pi when the Fireworks preset key is set", () => {
+    process.env.FIREWORKS_API_KEY = "fireworks-key";
+    expect(() => assertAgentCredential("pi", { aiApiKeyEnv: "FIREWORKS_API_KEY" })).not.toThrow();
+    expect(() =>
+      assertAgentCredential("pi", {
+        inSandbox: true,
+        aiApiKeyEnv: "FIREWORKS_API_KEY",
+      }),
+    ).not.toThrow();
+  });
+
+  it("names the missing Fireworks preset key in the credential error", () => {
+    expect(() =>
+      assertAgentCredential("pi", {
+        inSandbox: true,
+        aiApiKeyEnv: "FIREWORKS_API_KEY",
+      }),
+    ).toThrow(/FIREWORKS_API_KEY/);
   });
 
   it("passes for pi when local Pi auth exists outside sandbox", () => {

--- a/packages/deepsec/src/agent-config.ts
+++ b/packages/deepsec/src/agent-config.ts
@@ -1,4 +1,8 @@
 const THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh"] as const;
+const FIREWORKS_KIMI_K3_MODEL = "fireworks/accounts/fireworks/models/kimi-k3";
+const FIREWORKS_PROVIDER = "fireworks";
+const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
+const FIREWORKS_API_KEY_ENV = "FIREWORKS_API_KEY";
 
 interface AgentRuntimeOpts {
   model?: string;
@@ -39,8 +43,17 @@ function providerFromModel(model: string | undefined): string | undefined {
 
 export function buildAgentConfig(opts: AgentRuntimeOpts): Record<string, unknown> {
   const aiHeaders = parseAiHeaders(opts.aiHeader);
-  const hasProviderOverride = Boolean(opts.aiBaseUrl || opts.aiApiKeyEnv || aiHeaders);
-  const effectiveProvider = opts.aiProvider ?? providerFromModel(opts.model);
+  const useFireworksKimiK3Preset =
+    opts.model === FIREWORKS_KIMI_K3_MODEL &&
+    (!opts.aiProvider || opts.aiProvider === FIREWORKS_PROVIDER);
+  const aiBaseUrl = opts.aiBaseUrl ?? (useFireworksKimiK3Preset ? FIREWORKS_BASE_URL : undefined);
+  const aiBaseUrlFromPreset = !opts.aiBaseUrl && useFireworksKimiK3Preset;
+  const aiApiKeyEnv =
+    opts.aiApiKeyEnv ?? (useFireworksKimiK3Preset ? FIREWORKS_API_KEY_ENV : undefined);
+  const hasProviderOverride = Boolean(aiBaseUrl || aiApiKeyEnv || aiHeaders);
+  const effectiveProvider =
+    opts.aiProvider ??
+    (useFireworksKimiK3Preset ? FIREWORKS_PROVIDER : providerFromModel(opts.model));
   if (hasProviderOverride && !effectiveProvider) {
     throw new Error(
       `Pi provider override flags require --ai-provider or a provider/model --model value.`,
@@ -62,8 +75,9 @@ export function buildAgentConfig(opts: AgentRuntimeOpts): Record<string, unknown
     config.reasoningEffort = opts.thinkingLevel;
   }
   if (opts.aiProvider || hasProviderOverride) config.aiProvider = effectiveProvider;
-  if (opts.aiBaseUrl) config.aiBaseUrl = opts.aiBaseUrl;
-  if (opts.aiApiKeyEnv) config.aiApiKeyEnv = opts.aiApiKeyEnv;
+  if (aiBaseUrl) config.aiBaseUrl = aiBaseUrl;
+  if (aiBaseUrlFromPreset) config.aiBaseUrlFromPreset = true;
+  if (aiApiKeyEnv) config.aiApiKeyEnv = aiApiKeyEnv;
   if (aiHeaders) config.aiHeaders = aiHeaders;
   return config;
 }

--- a/packages/deepsec/src/commands/process.ts
+++ b/packages/deepsec/src/commands/process.ts
@@ -129,7 +129,9 @@ async function processStandardMode(opts: Parameters<typeof processCommand>[0]) {
   const model = opts.model ?? defaultModelForAgent(agentType);
   const agentConfig = buildAgentConfig({ ...opts, model });
 
-  assertAgentCredential(agentType, { aiApiKeyEnv: opts.aiApiKeyEnv });
+  assertAgentCredential(agentType, {
+    aiApiKeyEnv: typeof agentConfig.aiApiKeyEnv === "string" ? agentConfig.aiApiKeyEnv : undefined,
+  });
 
   // --reinvestigate  → true (re-investigate all)
   // --reinvestigate 2 → number (only files with < 2 analyses)
@@ -275,7 +277,9 @@ async function processDirectMode(opts: Parameters<typeof processCommand>[0]) {
   const agentType = resolveAgentType(opts.agent);
   const model = opts.model ?? defaultModelForAgent(agentType);
   const agentConfig = buildAgentConfig({ ...opts, model });
-  assertAgentCredential(agentType, { aiApiKeyEnv: opts.aiApiKeyEnv });
+  assertAgentCredential(agentType, {
+    aiApiKeyEnv: typeof agentConfig.aiApiKeyEnv === "string" ? agentConfig.aiApiKeyEnv : undefined,
+  });
 
   // Resolve the file list.
   const resolved = resolveFiles({

--- a/packages/deepsec/src/commands/revalidate.ts
+++ b/packages/deepsec/src/commands/revalidate.ts
@@ -89,7 +89,9 @@ export async function revalidateCommand(opts: {
   const onlySlugs = parseCsv(opts.onlySlugs);
   const skipSlugs = parseCsv(opts.skipSlugs);
 
-  assertAgentCredential(agentType, { aiApiKeyEnv: opts.aiApiKeyEnv });
+  assertAgentCredential(agentType, {
+    aiApiKeyEnv: typeof agentConfig.aiApiKeyEnv === "string" ? agentConfig.aiApiKeyEnv : undefined,
+  });
 
   console.log(`${BOLD}Revalidating${RESET} findings for project ${BOLD}${projectId}${RESET}`);
   console.log(`  Agent: ${agentType} (${model})`);

--- a/packages/deepsec/src/commands/sandbox-all.ts
+++ b/packages/deepsec/src/commands/sandbox-all.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { getDataRoot, readProjectConfig } from "@deepsec/core";
+import { buildAgentConfig } from "../agent-config.js";
 import { defaultModelForAgent } from "../agent-defaults.js";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "../formatters.js";
 import { assertAgentCredential, assertSandboxCredential } from "../preflight.js";
@@ -89,12 +90,22 @@ export async function sandboxAllCommand(
   const vcpus = opts.vcpus ?? Math.min(Math.ceil(concurrency / 2) * 2, 8);
   const timeout = opts.timeout ?? 5 * 60 * 60 * 1000;
   const agentType = resolveAgentType(extractFlag(passthrough, "--agent"));
+  const model = extractFlag(passthrough, "--model") ?? defaultModelForAgent(agentType);
+  const agentConfig = buildAgentConfig({
+    model,
+    aiProvider: extractFlag(passthrough, "--ai-provider"),
+    aiBaseUrl: extractFlag(passthrough, "--ai-base-url"),
+    aiApiKeyEnv: extractFlag(passthrough, "--ai-api-key-env"),
+  });
+  const aiApiKeyEnv =
+    typeof agentConfig.aiApiKeyEnv === "string" ? agentConfig.aiApiKeyEnv : undefined;
+  const aiBaseUrl = typeof agentConfig.aiBaseUrl === "string" ? agentConfig.aiBaseUrl : undefined;
 
   // Same preflight as sandbox-process — fail fast before fanning out.
   assertSandboxCredential();
   assertAgentCredential(agentType, {
     inSandbox: true,
-    aiApiKeyEnv: extractFlag(passthrough, "--ai-api-key-env"),
+    aiApiKeyEnv,
   });
 
   console.log(`${BOLD}Sandbox All${RESET} — ${CYAN}${command}${RESET}`);
@@ -204,9 +215,9 @@ export async function sandboxAllCommand(
       concurrency,
       batchSize: parseInt(extractFlag(passthrough, "--batch-size") ?? "5", 10) || 5,
       agentType,
-      aiApiKeyEnv: extractFlag(passthrough, "--ai-api-key-env"),
-      aiBaseUrl: extractFlag(passthrough, "--ai-base-url"),
-      model: extractFlag(passthrough, "--model") ?? defaultModelForAgent(agentType),
+      aiApiKeyEnv,
+      aiBaseUrl,
+      model,
       snapshotId: undefined,
       saveSnapshot: false,
       keepAlive: false,

--- a/packages/deepsec/src/commands/sandbox-process.ts
+++ b/packages/deepsec/src/commands/sandbox-process.ts
@@ -1,3 +1,4 @@
+import { buildAgentConfig } from "../agent-config.js";
 import { defaultModelForAgent } from "../agent-defaults.js";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET } from "../formatters.js";
 import { assertAgentCredential, assertSandboxCredential } from "../preflight.js";
@@ -64,6 +65,13 @@ function buildConfig(
   // Auto-derive vCPUs from concurrency if not explicitly set (max 8, must be even)
   const vcpus = opts.vcpus ?? Math.min(Math.ceil(concurrency / 2) * 2, 8);
   const agentType = resolveAgentType(extractFlag(args, "--agent"));
+  const model = extractFlag(args, "--model") ?? defaultModelForAgent(agentType);
+  const agentConfig = buildAgentConfig({
+    model,
+    aiProvider: extractFlag(args, "--ai-provider"),
+    aiBaseUrl: extractFlag(args, "--ai-base-url"),
+    aiApiKeyEnv: extractFlag(args, "--ai-api-key-env"),
+  });
   return {
     projectId,
     command: subcommand,
@@ -74,9 +82,9 @@ function buildConfig(
     concurrency,
     batchSize: parseInt(extractFlag(args, "--batch-size") ?? "5", 10) || 5,
     agentType,
-    aiApiKeyEnv: extractFlag(args, "--ai-api-key-env"),
-    aiBaseUrl: extractFlag(args, "--ai-base-url"),
-    model: extractFlag(args, "--model") ?? defaultModelForAgent(agentType),
+    aiApiKeyEnv: typeof agentConfig.aiApiKeyEnv === "string" ? agentConfig.aiApiKeyEnv : undefined,
+    aiBaseUrl: typeof agentConfig.aiBaseUrl === "string" ? agentConfig.aiBaseUrl : undefined,
+    model,
     snapshotId: opts.snapshotId,
     saveSnapshot: opts.saveSnapshot ?? false,
     keepAlive: opts.keepAlive ?? false,

--- a/packages/processor/src/__tests__/pi-sdk-tools.test.ts
+++ b/packages/processor/src/__tests__/pi-sdk-tools.test.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  configureProviderOverrides,
   createPiReadOnlyToolDefinitions,
+  registerFireworksKimiK3ModelIfNeeded,
   resolvePiModelWithDynamicGateway,
 } from "../agents/pi-sdk.js";
 
@@ -70,6 +72,7 @@ describe("Pi model resolution", () => {
     "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_BASE_URL",
+    "FIREWORKS_API_KEY",
   ] as const;
   const originalEnv = Object.fromEntries(KEYS.map((key) => [key, process.env[key]]));
   const originalFetch = globalThis.fetch;
@@ -167,5 +170,200 @@ describe("Pi model resolution", () => {
       }),
     ).rejects.toThrow(/Pi model not found: acme\/nonexistent-model-1/);
     expect(called).toBe(false);
+  });
+
+  it("registers the Fireworks Kimi K3 preset offline without replacing the catalog", async () => {
+    for (const key of KEYS) delete process.env[key];
+    let called = false;
+    globalThis.fetch = async () => {
+      called = true;
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    };
+
+    const registry = await freshRegistry();
+    const existingFireworksModel = registry.find("fireworks", "accounts/fireworks/models/glm-5p2");
+    expect(existingFireworksModel).toBeDefined();
+
+    const config = {
+      model: "fireworks/accounts/fireworks/models/kimi-k3",
+      aiProvider: "fireworks",
+      aiBaseUrl: "https://api.fireworks.ai/inference/v1",
+      aiApiKeyEnv: "FIREWORKS_API_KEY",
+    };
+    registerFireworksKimiK3ModelIfNeeded(
+      registry,
+      "fireworks/accounts/fireworks/models/kimi-k3",
+      config,
+    );
+
+    const model = await resolvePiModelWithDynamicGateway(
+      registry,
+      "fireworks/accounts/fireworks/models/kimi-k3",
+      config,
+    );
+    expect(model.provider).toBe("fireworks");
+    expect(model.id).toBe("accounts/fireworks/models/kimi-k3");
+    expect(model.name).toBe("Kimi K3");
+    expect(model.api).toBe("openai-completions");
+    expect(model.reasoning).toBe(true);
+    expect(model.input).toEqual(["text", "image"]);
+    expect(model.cost).toEqual({
+      input: 3,
+      output: 15,
+      cacheRead: 0.3,
+      cacheWrite: 0,
+    });
+    expect(model.contextWindow).toBe(1_048_576);
+    expect(model.maxTokens).toBe(131_072);
+    expect(registry.find("fireworks", "accounts/fireworks/models/glm-5p2")).toBeDefined();
+    expect(called).toBe(false);
+  });
+
+  it("registers the Fireworks Kimi K3 preset idempotently", async () => {
+    const registry = await freshRegistry();
+    const requested = "fireworks/accounts/fireworks/models/kimi-k3";
+    const config = {
+      model: requested,
+      aiProvider: "fireworks",
+      aiBaseUrl: "https://api.fireworks.ai/inference/v1",
+    };
+
+    registerFireworksKimiK3ModelIfNeeded(registry, requested, config);
+    registerFireworksKimiK3ModelIfNeeded(registry, requested, config);
+
+    expect(
+      registry
+        .getAll()
+        .filter(
+          (model) =>
+            model.provider === "fireworks" && model.id === "accounts/fireworks/models/kimi-k3",
+        ),
+    ).toHaveLength(1);
+  });
+
+  it("preserves an existing Fireworks Kimi K3 model entry", async () => {
+    const registry = await freshRegistry();
+    registry.registerProvider("fireworks", {
+      baseUrl: "https://user-fireworks.example.test/v1",
+      api: "openai-completions",
+      models: [
+        {
+          id: "accounts/fireworks/models/kimi-k3",
+          name: "User-configured Kimi K3",
+          api: "openai-completions",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 196_608,
+          maxTokens: 32_768,
+        },
+      ],
+    });
+
+    registerFireworksKimiK3ModelIfNeeded(registry, "fireworks/accounts/fireworks/models/kimi-k3", {
+      model: "fireworks/accounts/fireworks/models/kimi-k3",
+      aiProvider: "fireworks",
+      aiBaseUrl: "https://api.fireworks.ai/inference/v1",
+      aiBaseUrlFromPreset: true,
+    });
+
+    const model = registry.find("fireworks", "accounts/fireworks/models/kimi-k3");
+    expect(model?.name).toBe("User-configured Kimi K3");
+    expect(model?.contextWindow).toBe(196_608);
+    expect(registry.getRegisteredProviderConfig("fireworks")?.baseUrl).toBe(
+      "https://user-fireworks.example.test/v1",
+    );
+  });
+
+  it("preserves a user Fireworks endpoint when the base URL came from the preset", async () => {
+    const registry = await freshRegistry();
+    registry.registerProvider("fireworks", {
+      baseUrl: "https://user-fireworks.example.test/v1",
+      api: "openai-completions",
+      models: [
+        {
+          id: "accounts/fireworks/models/kimi-k3",
+          name: "User-configured Kimi K3",
+          api: "openai-completions",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 196_608,
+          maxTokens: 32_768,
+        },
+      ],
+    });
+    const config = {
+      model: "fireworks/accounts/fireworks/models/kimi-k3",
+      aiProvider: "fireworks",
+      aiBaseUrl: "https://api.fireworks.ai/inference/v1",
+      aiBaseUrlFromPreset: true,
+    };
+
+    configureProviderOverrides(registry, config);
+    registerFireworksKimiK3ModelIfNeeded(
+      registry,
+      "fireworks/accounts/fireworks/models/kimi-k3",
+      config,
+    );
+
+    expect(registry.getRegisteredProviderConfig("fireworks")?.baseUrl).toBe(
+      "https://user-fireworks.example.test/v1",
+    );
+  });
+
+  it("applies an explicit Fireworks base URL to an existing Kimi K3 entry", async () => {
+    const registry = await freshRegistry();
+    registry.registerProvider("fireworks", {
+      baseUrl: "https://user-fireworks.example.test/v1",
+      api: "openai-completions",
+      models: [
+        {
+          id: "accounts/fireworks/models/kimi-k3",
+          name: "User-configured Kimi K3",
+          api: "openai-completions",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 196_608,
+          maxTokens: 32_768,
+        },
+      ],
+    });
+
+    configureProviderOverrides(registry, {
+      model: "fireworks/accounts/fireworks/models/kimi-k3",
+      aiProvider: "fireworks",
+      aiBaseUrl: "https://explicit-fireworks.example.test/v1",
+    });
+
+    expect(registry.getRegisteredProviderConfig("fireworks")?.baseUrl).toBe(
+      "https://explicit-fireworks.example.test/v1",
+    );
+  });
+
+  it("keeps explicit Fireworks base URL and headers on the preset", async () => {
+    const registry = await freshRegistry();
+    registerFireworksKimiK3ModelIfNeeded(registry, "fireworks/accounts/fireworks/models/kimi-k3", {
+      model: "fireworks/accounts/fireworks/models/kimi-k3",
+      aiProvider: "fireworks",
+      aiBaseUrl: "https://fireworks.example.test/v1",
+      aiHeaders: { "x-fireworks-account": "test" },
+    });
+
+    expect(registry.getRegisteredProviderConfig("fireworks")).toMatchObject({
+      baseUrl: "https://fireworks.example.test/v1",
+      headers: { "x-fireworks-account": "test" },
+    });
+  });
+
+  it("does not register Kimi K3 for a conflicting provider override", async () => {
+    const registry = await freshRegistry();
+    registerFireworksKimiK3ModelIfNeeded(registry, "fireworks/accounts/fireworks/models/kimi-k3", {
+      model: "fireworks/accounts/fireworks/models/kimi-k3",
+      aiProvider: "custom",
+    });
+
+    expect(registry.find("fireworks", "accounts/fireworks/models/kimi-k3")).toBeUndefined();
   });
 });

--- a/packages/processor/src/agents/pi-sdk.ts
+++ b/packages/processor/src/agents/pi-sdk.ts
@@ -65,6 +65,11 @@ const GATEWAY_PROVIDER = "vercel-ai-gateway";
 // the same api/baseUrl as the built-in provider.
 const GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh";
 const GATEWAY_API = "anthropic-messages" as const;
+const FIREWORKS_PROVIDER = "fireworks";
+const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
+const FIREWORKS_API = "openai-completions" as const;
+const FIREWORKS_KIMI_K3_MODEL_ID = "accounts/fireworks/models/kimi-k3";
+const FIREWORKS_KIMI_K3_MODEL = `${FIREWORKS_PROVIDER}/${FIREWORKS_KIMI_K3_MODEL_ID}`;
 const TOOL_ERROR_DETAIL_LIMIT = 500;
 
 const DEEPSEC_SYSTEM_NOTE =
@@ -76,6 +81,7 @@ interface PiAgentConfig {
   maxTurns?: number;
   aiProvider?: string;
   aiBaseUrl?: string;
+  aiBaseUrlFromPreset?: boolean;
   aiApiKeyEnv?: string;
   aiHeaders?: Record<string, string>;
   thinkingLevel?: string;
@@ -84,6 +90,22 @@ interface PiAgentConfig {
 type PiModel = ReturnType<ModelRegistry["getAll"]>[number];
 type PiProviderConfig = Parameters<ModelRegistry["registerProvider"]>[1];
 type PiProviderModelConfig = NonNullable<PiProviderConfig["models"]>[number];
+
+const FIREWORKS_KIMI_K3_CONFIG: PiProviderModelConfig = {
+  id: FIREWORKS_KIMI_K3_MODEL_ID,
+  name: "Kimi K3",
+  api: FIREWORKS_API,
+  reasoning: true,
+  input: ["text", "image"],
+  cost: {
+    input: 3,
+    output: 15,
+    cacheRead: 0.3,
+    cacheWrite: 0,
+  },
+  contextWindow: 1_048_576,
+  maxTokens: 131_072,
+};
 
 interface PiSessionSetup {
   session: AgentSession;
@@ -274,6 +296,8 @@ function readConfig(config: Record<string, unknown>): PiAgentConfig {
     maxTurns: typeof config.maxTurns === "number" ? config.maxTurns : undefined,
     aiProvider: typeof config.aiProvider === "string" ? config.aiProvider : undefined,
     aiBaseUrl: typeof config.aiBaseUrl === "string" ? config.aiBaseUrl : undefined,
+    aiBaseUrlFromPreset:
+      typeof config.aiBaseUrlFromPreset === "boolean" ? config.aiBaseUrlFromPreset : undefined,
     aiApiKeyEnv: typeof config.aiApiKeyEnv === "string" ? config.aiApiKeyEnv : undefined,
     aiHeaders:
       config.aiHeaders && typeof config.aiHeaders === "object" && !Array.isArray(config.aiHeaders)
@@ -342,7 +366,7 @@ async function configureRuntimeAuth(runtime: ModelRuntime, cfg: PiAgentConfig): 
   }
 }
 
-function configureProviderOverrides(registry: ModelRegistry, cfg: PiAgentConfig): void {
+export function configureProviderOverrides(registry: ModelRegistry, cfg: PiAgentConfig): void {
   if (process.env.ANTHROPIC_BASE_URL) {
     registry.registerProvider("anthropic", { baseUrl: process.env.ANTHROPIC_BASE_URL });
   }
@@ -353,7 +377,13 @@ function configureProviderOverrides(registry: ModelRegistry, cfg: PiAgentConfig)
   const provider = cfg.aiProvider ?? modelProviderFromName(cfg.model);
   if (!provider) return;
   const override: Parameters<ModelRegistry["registerProvider"]>[1] = {};
-  if (cfg.aiBaseUrl) override.baseUrl = cfg.aiBaseUrl;
+  const preserveExistingFireworksKimiK3BaseUrl =
+    cfg.aiBaseUrlFromPreset &&
+    cfg.model === FIREWORKS_KIMI_K3_MODEL &&
+    Boolean(registry.find(FIREWORKS_PROVIDER, FIREWORKS_KIMI_K3_MODEL_ID));
+  if (cfg.aiBaseUrl && !preserveExistingFireworksKimiK3BaseUrl) {
+    override.baseUrl = cfg.aiBaseUrl;
+  }
   if (cfg.aiHeaders && Object.keys(cfg.aiHeaders).length > 0) override.headers = cfg.aiHeaders;
   if (Object.keys(override).length > 0) {
     registry.registerProvider(provider, override);
@@ -397,6 +427,29 @@ function dedupeProviderModels(models: PiProviderModelConfig[]): PiProviderModelC
   const byId = new Map<string, PiProviderModelConfig>();
   for (const model of models) byId.set(model.id, model);
   return Array.from(byId.values());
+}
+
+export function registerFireworksKimiK3ModelIfNeeded(
+  registry: ModelRegistry,
+  requested: string,
+  cfg: PiAgentConfig,
+): void {
+  if (requested !== FIREWORKS_KIMI_K3_MODEL) return;
+  if (cfg.aiProvider && cfg.aiProvider !== FIREWORKS_PROVIDER) return;
+  if (registry.find(FIREWORKS_PROVIDER, FIREWORKS_KIMI_K3_MODEL_ID)) return;
+
+  const existingFireworksModels = registry
+    .getAll()
+    .filter((model) => model.provider === FIREWORKS_PROVIDER)
+    .map(piModelToProviderModelConfig);
+  const models = dedupeProviderModels([...existingFireworksModels, FIREWORKS_KIMI_K3_CONFIG]);
+
+  registry.registerProvider(FIREWORKS_PROVIDER, {
+    baseUrl: cfg.aiBaseUrl ?? FIREWORKS_BASE_URL,
+    api: FIREWORKS_API,
+    ...(cfg.aiHeaders && Object.keys(cfg.aiHeaders).length > 0 ? { headers: cfg.aiHeaders } : {}),
+    models,
+  });
 }
 
 function registerGatewayModelIfNeeded(
@@ -514,6 +567,7 @@ async function createPiSession(projectRoot: string, cfg: PiAgentConfig): Promise
   configureProviderOverrides(modelRegistry, cfg);
 
   const modelName = cfg.model ?? DEFAULT_MODEL;
+  registerFireworksKimiK3ModelIfNeeded(modelRegistry, modelName, cfg);
   const model = await resolvePiModelWithDynamicGateway(modelRegistry, modelName, cfg);
   const settingsManager = SettingsManager.inMemory({
     defaultThinkingLevel: (cfg.thinkingLevel ?? DEFAULT_THINKING_LEVEL) as never,


### PR DESCRIPTION
## What changed

Added a first-class Pi preset for Kimi K3 on Fireworks, including offline model registration, local and sandbox credential routing, regression coverage, and setup/model documentation.

## Why

Pi's bundled Fireworks catalog predates Kimi K3, so using `fireworks/accounts/fireworks/models/kimi-k3` currently requires every user to maintain a private `models.json` entry. This compatibility overlay makes the model work with only `FIREWORKS_API_KEY`, preserves existing Fireworks models and explicit overrides, and becomes a no-op when a future Pi catalog includes the model.

## Verification

- [x] `pnpm test` passes — 2,256 tests passed, 1 credential-gated live-sandbox test skipped
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [x] `pnpm test:bundle` passes — 23 tests
- [x] `pnpm test:e2e` passes — 29 tests, 1 credential-gated live-sandbox test skipped
- [x] `pnpm validate` passes
- [x] Live Fireworks smoke passed without a Pi `models.json`

The final live smoke processed one intentionally vulnerable fixture with Kimi K3 at low thinking and concurrency 1. It completed one tool-using analysis in 23.4 seconds, returned four findings, recorded 3,426 input / 869 output tokens at $0.0239274, produced no refusal or parse failure, and did not persist the Fireworks credential.

## Notes for reviewer

The preset is exact-model scoped and does not change any default model. It merges Kimi K3 into Pi's existing Fireworks catalog only when the model is missing, preserves an existing exact-model custom endpoint, retains explicit base URL/key/header overrides, and sends sandbox workers only a placeholder token while the firewall injects the real credential on `api.fireworks.ai`.

Model metadata and pricing follow the [Fireworks Kimi K3 listing](https://fireworks.ai/models/fireworks/kimi-k3); the endpoint follows [Fireworks' OpenAI compatibility documentation](https://docs.fireworks.ai/tools-sdks/openai-compatibility).
