### PR TITLE
Round fractional token counts in metrics output

### DIFF
--- a/packages/deepsec/src/__tests__/metrics.test.ts
+++ b/packages/deepsec/src/__tests__/metrics.test.ts
@@ -38,6 +38,12 @@ describe("formatTokens", () => {
     expect(formatTokens(2_500_000)).toBe("2.5M");
     expect(formatTokens(3_500_000_000)).toBe("3.5B");
   });
+
+  it("rounds fractional counts from the per-file batch split", () => {
+    expect(formatTokens(2500 / 3)).toBe("833");
+    expect(formatTokens(0.1 + 0.2)).toBe("0");
+    expect(formatTokens(999.6)).toBe("1.0K");
+  });
 });
 
 describe("formatPct", () => {

--- a/packages/deepsec/src/commands/metrics.ts
+++ b/packages/deepsec/src/commands/metrics.ts
@@ -159,6 +159,7 @@ export function formatCost(n: number): string {
 }
 
 export function formatTokens(n: number): string {
+  n = Math.round(n);
   if (n === 0) return "0";
   if (n < 1000) return String(n);
   if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;


### PR DESCRIPTION
Fixes #135

Per-file token counts are a batch total divided by batch size, so they arrive fractional. `formatTokens` passed values under 1K through unrounded, which overflowed the 8-wide `Input`/`Output` columns and broke the table borders.

Long project/model names can still overflow the fixed widths. Not worth a table library. Sizing columns to content would do.