### PR TITLE
Classify provider policy refusals instead of parsing them as findings JSON

### DIFF
--- a/packages/processor/src/__tests__/shared.test.ts
+++ b/packages/processor/src/__tests__/shared.test.ts
@@ -3,9 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  AgentPolicyRefusalError,
   buildInvestigateFieldRepairPrompt,
   buildInvestigateJsonRepairPrompt,
   buildRevalidateJsonRepairPrompt,
+  classifyPolicyRefusal,
   classifyQuotaError,
   formatJsonRepairFailureDebugText,
   isTransientError,
@@ -198,6 +200,50 @@ describe("QuotaExhaustedError", () => {
   });
 });
 
+describe("classifyPolicyRefusal", () => {
+  it("recognizes the Claude Code usage-policy refusal (issue #92)", () => {
+    const text =
+      "API Error: Claude Code is unable to respond to this request, which appears to violate our Usage Policy (https://www.anthropic.com/legal/aup). Try rephrasing the request or attempting a different approach. Request ID: req_123";
+    expect(classifyPolicyRefusal(text)).toBe("anthropic-usage-policy");
+  });
+
+  it("recognizes OpenAI safety-system rejections", () => {
+    expect(classifyPolicyRefusal('{"error":{"code":"invalid_prompt"}}')).toBe(
+      "openai-safety-system",
+    );
+    expect(classifyPolicyRefusal("The prompt was rejected as a result of our safety system.")).toBe(
+      "openai-safety-system",
+    );
+  });
+
+  it("recognizes generic content-policy envelopes", () => {
+    expect(classifyPolicyRefusal('{"error":{"type":"content_policy_violation"}}')).toBe(
+      "content-policy",
+    );
+  });
+
+  it("returns undefined for ordinary malformed output and prose", () => {
+    // Strict on purpose: relabeling broken JSON as a refusal would report
+    // zero coverage where the real problem is formatting — worse than the
+    // status quo. Misses degrade to the existing fail-loud parse error.
+    expect(classifyPolicyRefusal("not JSON at all")).toBeUndefined();
+    expect(classifyPolicyRefusal('```json\n[{"filePath":')).toBeUndefined();
+    expect(classifyPolicyRefusal("")).toBeUndefined();
+    expect(classifyPolicyRefusal("You've hit your usage limit.")).toBeUndefined();
+  });
+});
+
+describe("AgentPolicyRefusalError", () => {
+  it("carries source + raw, and the message includes both", () => {
+    const e = new AgentPolicyRefusalError("anthropic-usage-policy", "API Error: Claude Code…");
+    expect(e.source).toBe("anthropic-usage-policy");
+    expect(e.rawMessage).toContain("API Error");
+    expect(e.message).toContain("anthropic-usage-policy");
+    expect(e.name).toBe("AgentPolicyRefusalError");
+    expect(e instanceof Error).toBe(true);
+  });
+});
+
 describe("isUsingAiGateway", () => {
   // We mutate process.env directly — capture and restore so tests don't
   // bleed environment into each other.
@@ -357,6 +403,28 @@ describe("parseInvestigateResults", () => {
     expect(() => parseInvestigateResults('```json\n{"oops":"object"}\n```', batch)).toThrow(
       /not an array/,
     );
+  });
+
+  it("throws AgentPolicyRefusalError (not a parse error) on a provider policy refusal", () => {
+    // A refusal must never reach jsonrepair or surface as a formatting
+    // problem: the batch has zero coverage, and the repair follow-up would
+    // accept an empty findings array as a valid answer.
+    const refusal =
+      "API Error: Claude Code is unable to respond to this request, which appears to violate our Usage Policy (https://www.anthropic.com/legal/aup). Try rephrasing the request or attempting a different approach.";
+    expect(() => parseInvestigateResults(refusal, batch)).toThrow(AgentPolicyRefusalError);
+  });
+
+  it("does NOT flag valid findings JSON that quotes refusal text as evidence", () => {
+    // Classification runs only inside the JSON.parse catch, so a finding
+    // citing a refusal string parses like any other.
+    const finding = validFinding({
+      description:
+        "Endpoint relays the upstream string 'unable to respond to this request, which appears to violate our Usage Policy (https://www.anthropic.com/legal/aup)' verbatim to clients.",
+    });
+    const text = `\`\`\`json\n[{"filePath":"a.ts","findings":[${JSON.stringify(finding)}]}]\n\`\`\``;
+    const out = parseInvestigateResults(text, batch);
+    expect(out.results.find((r) => r.filePath === "a.ts")?.findings).toHaveLength(1);
+    expect(out.invalid).toEqual([]);
   });
 
   it("salvages valid findings and reports invalid ones instead of dropping the file", () => {
@@ -534,6 +602,12 @@ describe("parseRevalidateVerdicts", () => {
 
   it("throws on parse failure", () => {
     expect(() => parseRevalidateVerdicts("garbage")).toThrow(/wasn't parseable JSON/);
+  });
+
+  it("throws AgentPolicyRefusalError on a provider policy refusal", () => {
+    const refusal =
+      "API Error: Claude Code is unable to respond to this request, which appears to violate our Usage Policy (https://www.anthropic.com/legal/aup).";
+    expect(() => parseRevalidateVerdicts(refusal)).toThrow(AgentPolicyRefusalError);
   });
 });
 

--- a/packages/processor/src/agents/claude-agent-sdk.ts
+++ b/packages/processor/src/agents/claude-agent-sdk.ts
@@ -1,6 +1,7 @@
 import { query, type SandboxSettings } from "@anthropic-ai/claude-agent-sdk";
 import type { RefusalReport } from "@deepsec/core";
 import {
+  AgentPolicyRefusalError,
   backoff,
   buildInvestigateJsonRepairPrompt,
   buildInvestigatePrompt,
@@ -413,6 +414,17 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
     try {
       parsed = parseInvestigateResults(resultText, batch);
     } catch (err) {
+      if (err instanceof AgentPolicyRefusalError) {
+        writeParseFailureDebug({
+          projectId,
+          phase: "investigate",
+          agentType: this.type,
+          resultText,
+          error: err,
+          batch,
+        });
+        throw err;
+      }
       yield {
         type: "thinking" as const,
         message: "Claude returned non-JSON investigation output; requesting JSON-only repair",
@@ -647,6 +659,17 @@ export class ClaudeAgentSdkPlugin implements AgentPlugin {
     try {
       verdicts = parseRevalidateVerdicts(resultText);
     } catch (err) {
+      if (err instanceof AgentPolicyRefusalError) {
+        writeParseFailureDebug({
+          projectId,
+          phase: "revalidate",
+          agentType: this.type,
+          resultText,
+          error: err,
+          batch,
+        });
+        throw err;
+      }
       yield {
         type: "thinking" as const,
         message: "Claude returned non-JSON revalidation output; requesting JSON-only repair",

--- a/packages/processor/src/agents/codex-sdk.ts
+++ b/packages/processor/src/agents/codex-sdk.ts
@@ -13,6 +13,7 @@ import {
   type ThreadItem,
 } from "@openai/codex-sdk";
 import {
+  AgentPolicyRefusalError,
   backoff,
   buildInvestigateJsonRepairPrompt,
   buildInvestigatePrompt,
@@ -879,6 +880,17 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
       try {
         parsedOutcome = parseInvestigateResults(resultText, batch);
       } catch (err) {
+        if (err instanceof AgentPolicyRefusalError) {
+          writeParseFailureDebug({
+            projectId,
+            phase: "investigate",
+            agentType: this.type,
+            resultText,
+            error: err,
+            batch,
+          });
+          throw err;
+        }
         yield {
           type: "thinking" as const,
           message: "Codex returned non-JSON investigation output; requesting JSON-only repair",
@@ -1164,6 +1176,17 @@ export class CodexAgentSdkPlugin implements AgentPlugin {
       try {
         verdicts = parseRevalidateVerdicts(resultText);
       } catch (err) {
+        if (err instanceof AgentPolicyRefusalError) {
+          writeParseFailureDebug({
+            projectId,
+            phase: "revalidate",
+            agentType: this.type,
+            resultText,
+            error: err,
+            batch,
+          });
+          throw err;
+        }
         yield {
           type: "thinking" as const,
           message: "Codex returned non-JSON revalidation output; requesting JSON-only repair",

--- a/packages/processor/src/agents/pi-sdk.ts
+++ b/packages/processor/src/agents/pi-sdk.ts
@@ -18,6 +18,7 @@ import {
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import {
+  AgentPolicyRefusalError,
   backoff,
   buildInvestigateJsonRepairPrompt,
   buildInvestigatePrompt,
@@ -906,6 +907,18 @@ export class PiAgentPlugin implements AgentPlugin {
     try {
       parsed = parseInvestigateResults(resultText, batch);
     } catch (err) {
+      if (err instanceof AgentPolicyRefusalError) {
+        writeParseFailureDebug({
+          projectId,
+          phase: "investigate",
+          agentType: this.type,
+          resultText,
+          error: err,
+          batch,
+        });
+        session?.dispose();
+        throw err;
+      }
       yield {
         type: "thinking",
         message: "Pi returned non-JSON investigation output; requesting JSON-only repair",
@@ -1083,6 +1096,18 @@ export class PiAgentPlugin implements AgentPlugin {
     try {
       verdicts = parseRevalidateVerdicts(resultText);
     } catch (err) {
+      if (err instanceof AgentPolicyRefusalError) {
+        writeParseFailureDebug({
+          projectId,
+          phase: "revalidate",
+          agentType: this.type,
+          resultText,
+          error: err,
+          batch,
+        });
+        session?.dispose();
+        throw err;
+      }
       yield {
         type: "thinking",
         message: "Pi returned non-JSON revalidation output; requesting JSON-only repair",

--- a/packages/processor/src/agents/shared.ts
+++ b/packages/processor/src/agents/shared.ts
@@ -218,6 +218,74 @@ export class QuotaExhaustedError extends Error {
   }
 }
 
+// --- Policy refusal --------------------------------------------------------
+
+/**
+ * Hard provider refusals (safety policy), distinct from quota: the provider
+ * declined the request itself, so the agent never produced findings JSON.
+ *   - `anthropic-usage-policy` — Claude Code usage-policy (AUP) block
+ *   - `openai-safety-system`   — OpenAI `invalid_prompt` / safety-system prose
+ *   - `content-policy`         — generic `content_policy_violation` envelope
+ */
+type RefusalSource = "anthropic-usage-policy" | "openai-safety-system" | "content-policy";
+
+/**
+ * Classify agent output as a hard provider policy refusal, or `undefined`.
+ *
+ * Matching is intentionally strict — the opposite trade-off from
+ * `classifyQuotaError`: a false positive here would relabel ordinary
+ * malformed JSON as "the model declined" (zero coverage over the batch),
+ * which is worse than the status quo. Misses fall through to the existing
+ * fail-loud parse error, which stays accurate.
+ */
+export function classifyPolicyRefusal(msg: string): RefusalSource | undefined {
+  if (!msg) return undefined;
+  const m = msg.toLowerCase();
+
+  // Claude Code usage-policy block:
+  //   "API Error: Claude Code is unable to respond to this request, which
+  //   appears to violate our Usage Policy (https://www.anthropic.com/legal/aup)."
+  if (
+    /anthropic\.com\/legal\/aup/.test(m) ||
+    (/unable to respond to this request/.test(m) && /usage polic/.test(m))
+  ) {
+    return "anthropic-usage-policy";
+  }
+
+  // OpenAI safety-system rejection: the `invalid_prompt` error code, or the
+  // prose form that accompanies it.
+  if (/\binvalid_prompt\b/.test(m) || /rejected as a result of our safety system/.test(m)) {
+    return "openai-safety-system";
+  }
+
+  if (/\bcontent_policy_violation\b/.test(m)) {
+    return "content-policy";
+  }
+
+  return undefined;
+}
+
+/**
+ * Thrown when the provider refused the request on policy grounds instead of
+ * producing findings JSON. Unlike `QuotaExhaustedError` this does NOT abort
+ * the run: a refusal depends on the batch's content, so other batches can
+ * proceed — but this batch must surface as errored, and must skip the
+ * JSON-repair follow-up (which would otherwise ask a declining model to
+ * re-emit conclusions it never produced, and accepts an empty findings
+ * array as a valid answer).
+ */
+export class AgentPolicyRefusalError extends Error {
+  readonly source: RefusalSource;
+  readonly rawMessage: string;
+
+  constructor(source: RefusalSource, rawMessage: string) {
+    super(`Agent refused the request on policy grounds (${source}): ${rawMessage.slice(0, 300)}`);
+    this.name = "AgentPolicyRefusalError";
+    this.source = source;
+    this.rawMessage = rawMessage;
+  }
+}
+
 /**
  * Vercel AI Gateway endpoints — duplicated from preflight.ts on purpose:
  * processor doesn't depend on the deepsec CLI package. Keep these in sync
@@ -710,6 +778,14 @@ function parseAgentJsonArray(params: {
   try {
     parsed = JSON.parse(jsonPayload);
   } catch (strictErr) {
+    // Classify before attempting repair, so a refusal is never "repaired"
+    // into a valid-but-empty findings array. Doing it inside the catch —
+    // rather than before JSON.parse — means valid findings JSON that merely
+    // quotes refusal text as evidence parses normally.
+    const refusalSource = classifyPolicyRefusal(resultText);
+    if (refusalSource) {
+      throw new AgentPolicyRefusalError(refusalSource, resultText);
+    }
     const repairCandidate = extractArrayCandidateForRepair(jsonPayload);
     try {
       parsed = JSON.parse(jsonrepair(repairCandidate));


### PR DESCRIPTION
Fixes #92

## What changed

`parseAgentJsonArray` now classifies hard provider policy refusals (Anthropic
AUP blocks, OpenAI safety-system rejections, `content_policy_violation`)
before attempting `jsonrepair`, and throws a dedicated
`AgentPolicyRefusalError`. All six investigate/revalidate parse sites across
the three agent backends rethrow it immediately instead of sending the
JSON-repair follow-up.

## Why

When a provider refuses on policy grounds, the refusal text currently reaches
the findings parser and fails as "wasn't a parseable JSON findings array" —
reported as a formatting problem when the real condition is zero coverage
over the batch.

Worse, the parse-failure path then sends `buildInvestigateJsonRepairPrompt`
to the same session. That prompt asks the model to "re-output the same
conclusions" and explicitly accepts an empty findings array for files with no
issues. If a model that just declined complies, the batch parses cleanly and
those files are recorded as investigated-with-no-findings — a silent coverage
gap, indistinguishable from a clean batch. With models that decline security
work as a documented behavior (e.g. Fable, per the DeepsecBench post), this
is an expected operating condition, not an edge case.

Unlike `QuotaExhaustedError`, this stays per-batch: a refusal depends on
batch content, so the rest of the run continues and a rerun picks the failed
batch up.

## Verification

- [x] `pnpm test` passes (added regression tests: refusal text →
`AgentPolicyRefusalError` from both `parseInvestigateResults` and
`parseRevalidateVerdicts`; valid findings JSON quoting refusal text as
evidence still parses normally)
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [x] If this adds a matcher: n/a

Also ran `pnpm -r build`, `pnpm test:bundle`, and `pnpm typecheck:deepsec` —
all green.

## Notes for reviewer

- **Classifier is strict, not loose** — the opposite trade-off from
`classifyQuotaError`: a false positive would relabel ordinary malformed JSON
as zero-coverage, which is worse than the status quo. Only explicit
provider-refusal strings match; anything else degrades to the existing
fail-loud parse error.
- **Classification happens inside the `JSON.parse` catch**, so valid findings
JSON that merely quotes refusal text (e.g. as evidence in a description)
parses normally — covered by a regression test.
- **Per-batch, not run-aborting** — happy to switch to abort-the-run (like
quota) if you'd rather treat a hard refusal as a stop condition.
- **Out of scope, possible follow-ups:** surfacing refusals as their own
category in the end-of-run summary (they currently collapse into
"N batch(es) failed"), and classifying refusals that arrive as SDK error
results rather than result text (that path already fails loud, just with a
less precise message).

Found this while preparing a hands-on review of deepsec for my
security-engineering YouTube channel
([@vtcibersecurity](https://www.youtube.com/@vtcibersecurity), dev/appsec
audience) — happy to adjust anything here, and to take on the
summary-category follow-up if you want it.
