### PR TITLE
Add Atlas Cloud provider preset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ ANTHROPIC_BASE_URL=https://ai-gateway.vercel.sh
 # unset and Codex will fall back to ANTHROPIC_AUTH_TOKEN.
 OPENAI_API_KEY=
 OPENAI_BASE_URL=https://ai-gateway.vercel.sh/v1
+
+# Atlas Cloud (--agent pi --ai-provider atlas)
+ATLASCLOUD_API_KEY=

--- a/docs/models.md
+++ b/docs/models.md
@@ -115,6 +115,17 @@ pnpm deepsec process --project-id my-app --agent pi
 If `.env.local` has `VERCEL_OIDC_TOKEN` from `vercel env pull`, deepsec
 uses that as the gateway credential automatically.
 
+Atlas Cloud is available as a first-class OpenAI-compatible Pi provider:
+
+```bash
+ATLASCLOUD_API_KEY=...
+pnpm deepsec process --project-id my-app --agent pi --ai-provider atlas
+```
+
+This defaults to `https://api.atlascloud.ai/v1` and
+`atlas/deepseek-ai/deepseek-v4-pro`. Use `--model`, `--ai-base-url`, or
+`--ai-api-key-env` to override any preset value.
+
 For OpenAI/Anthropic-compatible gateways such as Martian, point an
 existing Pi provider at the gateway with command-line flags:
 

--- a/packages/deepsec/src/__tests__/agent-config.test.ts
+++ b/packages/deepsec/src/__tests__/agent-config.test.ts
@@ -62,4 +62,31 @@ describe("buildAgentConfig", () => {
       aiHeaders: { "x-test": "one", "x-other": "two" },
     });
   });
+
+  it("applies Atlas Cloud defaults for the atlas provider", () => {
+    expect(
+      buildAgentConfig({
+        model: "atlas/deepseek-ai/deepseek-v4-pro",
+        aiProvider: "atlas",
+      }),
+    ).toMatchObject({
+      aiProvider: "atlas",
+      aiBaseUrl: "https://api.atlascloud.ai/v1",
+      aiApiKeyEnv: "ATLASCLOUD_API_KEY",
+    });
+  });
+
+  it("preserves explicit Atlas Cloud provider overrides", () => {
+    expect(
+      buildAgentConfig({
+        model: "atlas/custom-model",
+        aiProvider: "atlas",
+        aiBaseUrl: "https://atlas.example/v1",
+        aiApiKeyEnv: "CUSTOM_ATLAS_KEY",
+      }),
+    ).toMatchObject({
+      aiBaseUrl: "https://atlas.example/v1",
+      aiApiKeyEnv: "CUSTOM_ATLAS_KEY",
+    });
+  });
 });

--- a/packages/deepsec/src/__tests__/agent-defaults.test.ts
+++ b/packages/deepsec/src/__tests__/agent-defaults.test.ts
@@ -5,6 +5,7 @@ describe("defaultModelForAgent", () => {
   it("returns the backend-specific default models", () => {
     expect(defaultModelForAgent("codex")).toBe("gpt-5.5");
     expect(defaultModelForAgent("pi")).toBe("zai/glm-5.2");
+    expect(defaultModelForAgent("pi", "atlas")).toBe("atlas/deepseek-ai/deepseek-v4-pro");
     expect(defaultModelForAgent("claude-agent-sdk")).toBe("claude-opus-4-8");
   });
 });

--- a/packages/deepsec/src/agent-config.ts
+++ b/packages/deepsec/src/agent-config.ts
@@ -1,3 +1,5 @@
+import { ATLAS_API_KEY_ENV, ATLAS_BASE_URL, ATLAS_PROVIDER } from "./atlas-provider.js";
+
 const THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh"] as const;
 
 interface AgentRuntimeOpts {
@@ -62,8 +64,14 @@ export function buildAgentConfig(opts: AgentRuntimeOpts): Record<string, unknown
     config.reasoningEffort = opts.thinkingLevel;
   }
   if (opts.aiProvider || hasProviderOverride) config.aiProvider = effectiveProvider;
-  if (opts.aiBaseUrl) config.aiBaseUrl = opts.aiBaseUrl;
-  if (opts.aiApiKeyEnv) config.aiApiKeyEnv = opts.aiApiKeyEnv;
+  if (effectiveProvider === ATLAS_PROVIDER) {
+    config.aiProvider = ATLAS_PROVIDER;
+    config.aiBaseUrl = opts.aiBaseUrl ?? ATLAS_BASE_URL;
+    config.aiApiKeyEnv = opts.aiApiKeyEnv ?? ATLAS_API_KEY_ENV;
+  } else {
+    if (opts.aiBaseUrl) config.aiBaseUrl = opts.aiBaseUrl;
+    if (opts.aiApiKeyEnv) config.aiApiKeyEnv = opts.aiApiKeyEnv;
+  }
   if (aiHeaders) config.aiHeaders = aiHeaders;
   return config;
 }

--- a/packages/deepsec/src/agent-defaults.ts
+++ b/packages/deepsec/src/agent-defaults.ts
@@ -1,13 +1,15 @@
+import { ATLAS_DEFAULT_MODEL, ATLAS_PROVIDER } from "./atlas-provider.js";
+
 /**
  * Per-backend default models. Used when --model is not explicitly set.
  * Keep in sync with the DEFAULT_MODEL constants in each agent plugin.
  */
-export function defaultModelForAgent(agentType: string): string {
+export function defaultModelForAgent(agentType: string, aiProvider?: string): string {
   switch (agentType) {
     case "codex":
       return "gpt-5.5";
     case "pi":
-      return "zai/glm-5.2";
+      return aiProvider === ATLAS_PROVIDER ? ATLAS_DEFAULT_MODEL : "zai/glm-5.2";
     default:
       return "claude-opus-4-8";
   }

--- a/packages/deepsec/src/atlas-provider.ts
+++ b/packages/deepsec/src/atlas-provider.ts
@@ -1,0 +1,4 @@
+export const ATLAS_PROVIDER = "atlas";
+export const ATLAS_BASE_URL = "https://api.atlascloud.ai/v1";
+export const ATLAS_API_KEY_ENV = "ATLASCLOUD_API_KEY";
+export const ATLAS_DEFAULT_MODEL = "atlas/deepseek-ai/deepseek-v4-pro";

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -142,10 +142,7 @@ program
     "--model <model>",
     "Model to use (default: claude-opus-4-8 for claude, gpt-5.5 for codex, zai/glm-5.2 for pi)",
   )
-  .option(
-    "--ai-provider <provider>",
-    "Pi: provider to override for --ai-base-url / --ai-api-key-env (e.g. openai)",
-  )
+  .option("--ai-provider <provider>", "Pi: provider preset or override target (e.g. atlas, openai)")
   .option(
     "--ai-base-url <url>",
     "Pi: provider base URL override (e.g. a Martian/OpenAI-compatible gateway)",
@@ -221,10 +218,7 @@ program
     "--model <model>",
     "Model to use (default: claude-opus-4-8 for claude, gpt-5.5 for codex, zai/glm-5.2 for pi)",
   )
-  .option(
-    "--ai-provider <provider>",
-    "Pi: provider to override for --ai-base-url / --ai-api-key-env (e.g. openai)",
-  )
+  .option("--ai-provider <provider>", "Pi: provider preset or override target (e.g. atlas, openai)")
   .option(
     "--ai-base-url <url>",
     "Pi: provider base URL override (e.g. a Martian/OpenAI-compatible gateway)",

--- a/packages/deepsec/src/commands/process.ts
+++ b/packages/deepsec/src/commands/process.ts
@@ -126,10 +126,12 @@ async function processStandardMode(opts: Parameters<typeof processCommand>[0]) {
   const project = readProjectConfig(projectId);
   const effectiveRoot = opts.root ?? project.rootPath;
   const agentType = resolveAgentType(opts.agent);
-  const model = opts.model ?? defaultModelForAgent(agentType);
+  const model = opts.model ?? defaultModelForAgent(agentType, opts.aiProvider);
   const agentConfig = buildAgentConfig({ ...opts, model });
 
-  assertAgentCredential(agentType, { aiApiKeyEnv: opts.aiApiKeyEnv });
+  assertAgentCredential(agentType, {
+    aiApiKeyEnv: agentConfig.aiApiKeyEnv as string | undefined,
+  });
 
   // --reinvestigate  → true (re-investigate all)
   // --reinvestigate 2 → number (only files with < 2 analyses)
@@ -273,9 +275,11 @@ async function processDirectMode(opts: Parameters<typeof processCommand>[0]) {
   ensureProject(projectId, rootPath);
 
   const agentType = resolveAgentType(opts.agent);
-  const model = opts.model ?? defaultModelForAgent(agentType);
+  const model = opts.model ?? defaultModelForAgent(agentType, opts.aiProvider);
   const agentConfig = buildAgentConfig({ ...opts, model });
-  assertAgentCredential(agentType, { aiApiKeyEnv: opts.aiApiKeyEnv });
+  assertAgentCredential(agentType, {
+    aiApiKeyEnv: agentConfig.aiApiKeyEnv as string | undefined,
+  });
 
   // Resolve the file list.
   const resolved = resolveFiles({

--- a/packages/deepsec/src/commands/revalidate.ts
+++ b/packages/deepsec/src/commands/revalidate.ts
@@ -83,13 +83,15 @@ export async function revalidateCommand(opts: {
   const projectId = resolveProjectId(opts.projectId);
   const _project = readProjectConfig(projectId);
   const agentType = resolveAgentType(opts.agent);
-  const model = opts.model ?? defaultModelForAgent(agentType);
+  const model = opts.model ?? defaultModelForAgent(agentType, opts.aiProvider);
   const agentConfig = buildAgentConfig({ ...opts, model });
   const minSeverity = opts.minSeverity as Severity | undefined;
   const onlySlugs = parseCsv(opts.onlySlugs);
   const skipSlugs = parseCsv(opts.skipSlugs);
 
-  assertAgentCredential(agentType, { aiApiKeyEnv: opts.aiApiKeyEnv });
+  assertAgentCredential(agentType, {
+    aiApiKeyEnv: agentConfig.aiApiKeyEnv as string | undefined,
+  });
 
   console.log(`${BOLD}Revalidating${RESET} findings for project ${BOLD}${projectId}${RESET}`);
   console.log(`  Agent: ${agentType} (${model})`);

--- a/packages/deepsec/src/commands/sandbox-all.ts
+++ b/packages/deepsec/src/commands/sandbox-all.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { getDataRoot, readProjectConfig } from "@deepsec/core";
+import { buildAgentConfig } from "../agent-config.js";
 import { defaultModelForAgent } from "../agent-defaults.js";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "../formatters.js";
 import { assertAgentCredential, assertSandboxCredential } from "../preflight.js";
@@ -89,12 +90,20 @@ export async function sandboxAllCommand(
   const vcpus = opts.vcpus ?? Math.min(Math.ceil(concurrency / 2) * 2, 8);
   const timeout = opts.timeout ?? 5 * 60 * 60 * 1000;
   const agentType = resolveAgentType(extractFlag(passthrough, "--agent"));
+  const aiProvider = extractFlag(passthrough, "--ai-provider");
+  const model = extractFlag(passthrough, "--model") ?? defaultModelForAgent(agentType, aiProvider);
+  const agentConfig = buildAgentConfig({
+    model,
+    aiProvider,
+    aiApiKeyEnv: extractFlag(passthrough, "--ai-api-key-env"),
+    aiBaseUrl: extractFlag(passthrough, "--ai-base-url"),
+  });
 
   // Same preflight as sandbox-process — fail fast before fanning out.
   assertSandboxCredential();
   assertAgentCredential(agentType, {
     inSandbox: true,
-    aiApiKeyEnv: extractFlag(passthrough, "--ai-api-key-env"),
+    aiApiKeyEnv: agentConfig.aiApiKeyEnv as string | undefined,
   });
 
   console.log(`${BOLD}Sandbox All${RESET} — ${CYAN}${command}${RESET}`);
@@ -204,9 +213,9 @@ export async function sandboxAllCommand(
       concurrency,
       batchSize: parseInt(extractFlag(passthrough, "--batch-size") ?? "5", 10) || 5,
       agentType,
-      aiApiKeyEnv: extractFlag(passthrough, "--ai-api-key-env"),
-      aiBaseUrl: extractFlag(passthrough, "--ai-base-url"),
-      model: extractFlag(passthrough, "--model") ?? defaultModelForAgent(agentType),
+      aiApiKeyEnv: agentConfig.aiApiKeyEnv as string | undefined,
+      aiBaseUrl: agentConfig.aiBaseUrl as string | undefined,
+      model,
       snapshotId: undefined,
       saveSnapshot: false,
       keepAlive: false,

--- a/packages/deepsec/src/commands/sandbox-process.ts
+++ b/packages/deepsec/src/commands/sandbox-process.ts
@@ -1,3 +1,4 @@
+import { buildAgentConfig } from "../agent-config.js";
 import { defaultModelForAgent } from "../agent-defaults.js";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET } from "../formatters.js";
 import { assertAgentCredential, assertSandboxCredential } from "../preflight.js";
@@ -64,6 +65,14 @@ function buildConfig(
   // Auto-derive vCPUs from concurrency if not explicitly set (max 8, must be even)
   const vcpus = opts.vcpus ?? Math.min(Math.ceil(concurrency / 2) * 2, 8);
   const agentType = resolveAgentType(extractFlag(args, "--agent"));
+  const aiProvider = extractFlag(args, "--ai-provider");
+  const model = extractFlag(args, "--model") ?? defaultModelForAgent(agentType, aiProvider);
+  const agentConfig = buildAgentConfig({
+    model,
+    aiProvider,
+    aiApiKeyEnv: extractFlag(args, "--ai-api-key-env"),
+    aiBaseUrl: extractFlag(args, "--ai-base-url"),
+  });
   return {
     projectId,
     command: subcommand,
@@ -74,9 +83,9 @@ function buildConfig(
     concurrency,
     batchSize: parseInt(extractFlag(args, "--batch-size") ?? "5", 10) || 5,
     agentType,
-    aiApiKeyEnv: extractFlag(args, "--ai-api-key-env"),
-    aiBaseUrl: extractFlag(args, "--ai-base-url"),
-    model: extractFlag(args, "--model") ?? defaultModelForAgent(agentType),
+    aiApiKeyEnv: agentConfig.aiApiKeyEnv as string | undefined,
+    aiBaseUrl: agentConfig.aiBaseUrl as string | undefined,
+    model,
     snapshotId: opts.snapshotId,
     saveSnapshot: opts.saveSnapshot ?? false,
     keepAlive: opts.keepAlive ?? false,

--- a/packages/processor/src/__tests__/pi-sdk-tools.test.ts
+++ b/packages/processor/src/__tests__/pi-sdk-tools.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  configurePiProviders,
   createPiReadOnlyToolDefinitions,
   resolvePiModelWithDynamicGateway,
 } from "../agents/pi-sdk.js";
@@ -70,6 +71,7 @@ describe("Pi model resolution", () => {
     "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_BASE_URL",
+    "ATLASCLOUD_API_KEY",
   ] as const;
   const originalEnv = Object.fromEntries(KEYS.map((key) => [key, process.env[key]]));
   const originalFetch = globalThis.fetch;
@@ -167,5 +169,27 @@ describe("Pi model resolution", () => {
       }),
     ).rejects.toThrow(/Pi model not found: acme\/nonexistent-model-1/);
     expect(called).toBe(false);
+  });
+
+  it("registers and resolves the Atlas Cloud default model", async () => {
+    process.env.ATLASCLOUD_API_KEY = "atlas_test";
+    const registry = await freshRegistry();
+    configurePiProviders(registry, {
+      model: "atlas/deepseek-ai/deepseek-v4-pro",
+      aiProvider: "atlas",
+      aiApiKeyEnv: "ATLASCLOUD_API_KEY",
+    });
+
+    const model = await resolvePiModelWithDynamicGateway(
+      registry,
+      "atlas/deepseek-ai/deepseek-v4-pro",
+      { aiProvider: "atlas" },
+    );
+
+    expect(model.provider).toBe("atlas");
+    expect(model.id).toBe("deepseek-ai/deepseek-v4-pro");
+    expect(model.api).toBe("openai-completions");
+    expect(model.contextWindow).toBe(1_048_576);
+    expect(model.maxTokens).toBe(393_216);
   });
 });

--- a/packages/processor/src/agents/pi-sdk.ts
+++ b/packages/processor/src/agents/pi-sdk.ts
@@ -56,6 +56,9 @@ const DEFAULT_MODEL = "zai/glm-5.2";
 const DEFAULT_THINKING_LEVEL = "xhigh";
 const DEFAULT_TOOLS = ["read", "grep", "find", "ls"];
 const GATEWAY_PROVIDER = "vercel-ai-gateway";
+const ATLAS_PROVIDER = "atlas";
+const ATLAS_BASE_URL = "https://api.atlascloud.ai/v1";
+const ATLAS_MODEL_ID = "deepseek-ai/deepseek-v4-pro";
 // pi's built-in gateway provider speaks the gateway's Anthropic Messages
 // endpoint (since pi 0.81) — NOT the OpenAI-compat one. This matters for
 // Gemini 3.x: the Anthropic wire format round-trips thinking signatures,
@@ -342,7 +345,7 @@ async function configureRuntimeAuth(runtime: ModelRuntime, cfg: PiAgentConfig): 
   }
 }
 
-function configureProviderOverrides(registry: ModelRegistry, cfg: PiAgentConfig): void {
+export function configurePiProviders(registry: ModelRegistry, cfg: PiAgentConfig): void {
   if (process.env.ANTHROPIC_BASE_URL) {
     registry.registerProvider("anthropic", { baseUrl: process.env.ANTHROPIC_BASE_URL });
   }
@@ -353,6 +356,32 @@ function configureProviderOverrides(registry: ModelRegistry, cfg: PiAgentConfig)
   const provider = cfg.aiProvider ?? modelProviderFromName(cfg.model);
   if (!provider) return;
   const override: Parameters<ModelRegistry["registerProvider"]>[1] = {};
+  if (provider === ATLAS_PROVIDER) {
+    const existingModels = registry
+      .getAll()
+      .filter((model) => model.provider === ATLAS_PROVIDER)
+      .map(piModelToProviderModelConfig);
+    override.baseUrl = cfg.aiBaseUrl ?? ATLAS_BASE_URL;
+    override.api = "openai-completions";
+    override.models = dedupeProviderModels([
+      ...existingModels,
+      {
+        id: ATLAS_MODEL_ID,
+        name: "DeepSeek V4 Pro",
+        api: "openai-completions",
+        reasoning: true,
+        input: ["text"],
+        cost: {
+          input: 1.68,
+          output: 3.38,
+          cacheRead: 0.13,
+          cacheWrite: 0,
+        },
+        contextWindow: 1_048_576,
+        maxTokens: 393_216,
+      },
+    ]);
+  }
   if (cfg.aiBaseUrl) override.baseUrl = cfg.aiBaseUrl;
   if (cfg.aiHeaders && Object.keys(cfg.aiHeaders).length > 0) override.headers = cfg.aiHeaders;
   if (Object.keys(override).length > 0) {
@@ -511,7 +540,7 @@ async function createPiSession(projectRoot: string, cfg: PiAgentConfig): Promise
   // Sync facade over the runtime — keeps our resolution helpers (and
   // their tests) on the same ModelRegistry API as before.
   const modelRegistry = new ModelRegistry(runtime);
-  configureProviderOverrides(modelRegistry, cfg);
+  configurePiProviders(modelRegistry, cfg);
 
   const modelName = cfg.model ?? DEFAULT_MODEL;
   const model = await resolvePiModelWithDynamicGateway(modelRegistry, modelName, cfg);


### PR DESCRIPTION
## What

- add an `atlas` Pi provider preset with the Atlas Cloud OpenAI-compatible endpoint, `ATLASCLOUD_API_KEY`, and `deepseek-ai/deepseek-v4-pro`
- register the Atlas model in Pi's `ModelRegistry` while preserving explicit model, endpoint, API key env, and header overrides
- carry the resolved provider settings through local process/revalidate preflight and sandbox credential brokering
- document the minimal CLI setup and add focused configuration/model-resolution coverage

## Why

Deepsec already supports generic Pi provider overrides, but Atlas Cloud currently requires users to coordinate the provider name, endpoint, credential environment variable, and model manually. This preset makes the supported configuration explicit while keeping the generic override path unchanged.

## Verification

- `pnpm -r build`
- `pnpm lint`
- `pnpm knip`
- focused Vitest: 17/17 passed
- full unit suite: 2212/2213 passed; the unchanged timing-sensitive `core` shutdown signal test failed under the parallel suite and passed 3/3 in isolation
- publish bundle built successfully; bundle E2E 23/23 passed
- isolated `.deepsec` TypeScript check passed
- live `ModelRuntime` request through Atlas Cloud returned the required `verify_atlas({ status: "ATLAS_OK" })` tool call

No dependency or lockfile changes.
