### PR TITLE
Remove .md extensions on inline docs links

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ gitignored by the scaffold; `INFO.md` remains trackable. Each `FileRecord` is th
 for everything deepsec knows about a single source file: candidate
 matches, AI findings, analysis history, git committer info, ownership.
 Full schemas for every file under `data/` are documented in
-[data-layout.md](data-layout.md).
+[data-layout](data-layout.md).
 
 The merge model is additive: every stage adds to the FileRecord. A
 re-scan merges new candidates into the existing set; a re-process appends
@@ -177,7 +177,7 @@ from the active plugins, and stashes it on a module-level singleton
 (`getRegistry()`). All internal code consults the registry rather than
 hard-coding integrations.
 
-See [docs/plugins.md](plugins.md) for the full plugin authoring guide.
+See [plugins](plugins.md) for the full plugin authoring guide.
 
 ## Design decisions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ see [`samples/webapp/deepsec.config.ts`](https://github.com/vercel-labs/deepsec/
 | `projects` | `ProjectDeclaration[]` | The codebases deepsec knows about. |
 | `plugins` | `DeepsecPlugin[]` | Loaded in order; later plugins override single-slot capabilities. |
 | `matchers` | `{ only?: string[]; exclude?: string[] }` | Filter the matcher set used by `scan`. |
-| `defaultAgent` | `string` | Default `--agent` value (`codex`, `claude`, or `pi`). See [models.md](models.md). |
+| `defaultAgent` | `string` | Default `--agent` value (`codex`, `claude`, or `pi`). See [models](models.md). |
 | `defaultModel` | `string` | Default `--model` value selected during setup. |
 | `defaultThinkingLevel` | `string` | Default reasoning effort (`minimal` through `xhigh`) selected during setup. |
 | `ai` | `ModelRoute` | Non-secret model credential route selected and verified by setup. |
@@ -88,7 +88,7 @@ If `infoMarkdown` isn't set in the config, deepsec looks for
 context (what the codebase does, the auth shape, the threat model,
 known false-positive sources) is the right length. One-shot setup writes and
 validates this file automatically. See
-[getting-started.md](getting-started.md) for its required sections and resume
+[getting-started](getting-started.md) for its required sections and resume
 behavior.
 
 ## Generated matchers
@@ -100,7 +100,7 @@ breadth validation. Keep the import/plugin entry in config and commit the
 generated file after review.
 
 Hand-authored plugins remain additive and can live beside the generated
-plugin. See [writing-matchers.md](writing-matchers.md).
+plugin. See [writing-matchers](writing-matchers.md).
 
 ## Matcher filtering
 

--- a/docs/data-layout.md
+++ b/docs/data-layout.md
@@ -56,7 +56,7 @@ Optional. Read by `scan` and the AI agents.
 
 Free-form markdown injected into the AI prompt for `process`,
 `triage`, and `revalidate`. See
-[getting-started.md](getting-started.md) for the automatic repository-analysis
+[getting-started](getting-started.md) for the automatic repository-analysis
 phase and the manual scaffold fallback.
 
 ## `setup/setup-state.json` — SetupState
@@ -172,7 +172,7 @@ deleted.
 | `numTurns` | `number?` | Conversation turn count. |
 | `costUsd` | `number?` | Estimated USD cost. |
 | `usage` | `{ inputTokens, outputTokens, cacheReadInputTokens, cacheCreationInputTokens }?` | Token accounting. |
-| `refusal` | `RefusalReport?` | See [models.md](models.md#refusals-are-not-a-large-problem). |
+| `refusal` | `RefusalReport?` | See [models](models.md#refusals-are-not-a-large-problem). |
 | `codexStderr` | `string?` | Captured codex stderr when an investigation produced 0 output tokens (forensic only). |
 | `reinvestigateMarker` | `number?` | Wave marker from `--reinvestigate <N>`. |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -85,7 +85,7 @@ MY_ANTHROPIC_KEY=... npx deepsec init \
   --ai-provider anthropic --ai-api-key-env MY_ANTHROPIC_KEY
 ```
 
-See [vercel-setup.md](vercel-setup.md) for route persistence, headless
+See [vercel-setup](vercel-setup.md) for route persistence, headless
 project credentials, and host-side Sandbox credential brokering.
 
 ## How accurate is it? What's the FP rate?
@@ -170,7 +170,7 @@ what `--reinvestigate` (process) and `--force` (revalidate) are for.
 
 ## How do I add a matcher for my codebase?
 
-See [docs/writing-matchers.md](writing-matchers.md). Short version: hand
+See [writing-matchers](writing-matchers.md). Short version: hand
 your `.deepsec/data/` and the target repo to your coding agent with the
 prompt in that doc — it'll spot entry-point coverage gaps the default
 matchers miss and write matchers tailored to your codebase.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ MY_OPENAI_KEY=... npx deepsec init \
 For Anthropic, use `--agent claude --ai-provider anthropic`. Deepsec
 stores only the *name* of the environment variable, never the key itself —
 export the variable again for later commands, or put it in
-`.deepsec/.env.local`. See [vercel-setup.md](vercel-setup.md) for other
+`.deepsec/.env.local`. See [vercel-setup](vercel-setup.md) for other
 providers and the full credential reference.
 
 ## Two files worth a look
@@ -120,14 +120,14 @@ Setup writes two things you may want to review:
   findings.
 - `.deepsec/generated-matchers.ts` — extra scan patterns deepsec generated
   to cover gaps in your codebase. Review and commit this file. To go
-  further, see [writing-matchers.md](writing-matchers.md).
+  further, see [writing-matchers](writing-matchers.md).
 
 ## A note on trust
 
 Treat deepsec like a coding agent: during setup it reads your source code
 with an AI agent that authenticates to your model provider. Only run it on
 code you trust at that level. For scanning untrusted pull requests, use
-the guarded CI patterns in [reviewing-changes.md](reviewing-changes.md),
+the guarded CI patterns in [reviewing-changes](reviewing-changes.md),
 or run the work in isolated cloud sandboxes (this part does use a Vercel
 account, since the sandboxes run on Vercel):
 
@@ -185,10 +185,10 @@ everyday commands.
 
 ## Next
 
-- [configuration.md](configuration.md) — project, model route, and
+- [configuration](configuration.md) — project, model route, and
   environment configuration.
-- [writing-matchers.md](writing-matchers.md) — improving scan coverage
+- [writing-matchers](writing-matchers.md) — improving scan coverage
   with your own matchers.
-- [vercel-setup.md](vercel-setup.md) — credentials, CI setups, and
+- [vercel-setup](vercel-setup.md) — credentials, CI setups, and
   troubleshooting the Vercel connection.
-- [architecture.md](architecture.md) — how the pipeline works internally.
+- [architecture](architecture.md) — how the pipeline works internally.

--- a/docs/models.md
+++ b/docs/models.md
@@ -46,7 +46,7 @@ The built-in backends work with Vercel AI Gateway through the linked
 workspace's OIDC credential. The model credential route is independent of the
 Vercel/Sandbox project link and is persisted as non-secret `ai` config. Direct
 OpenAI/Anthropic and custom Pi routes are documented in
-[vercel-setup.md](vercel-setup.md).
+[vercel-setup](vercel-setup.md).
 
 ## CLI selection
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -55,7 +55,7 @@ e.g. `@my-org/plugin-internal-services`.
 ## Slot 1: matchers
 
 Most common. Same shape as a built-in matcher; see
-[writing-matchers.md](writing-matchers.md) for how to write one.
+[writing-matchers](writing-matchers.md) for how to write one.
 
 ```ts
 // my-plugin/src/matchers/internal-rpc.ts


### PR DESCRIPTION
## What changed

Removal of `.md` extension on inline docs links

## Why

Docs links dont need the `.md` extension on the link text, only on the destination

**Before**: [vercel-setup.md](vercel-setup.md)
**Before**: [vercel-setup](vercel-setup.md)

## Verification

- [ ] `pnpm test` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->
