### PR TITLE
docs: reduce AI-writing tells in getting-started, models, vercel-setup

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ npx deepsec init
 ```
 
 Deepsec remembers how far it got. Finished steps are skipped and the run
-continues where it left off — this is also how you resume after hitting a
+continues where it left off. This is also how you resume after hitting a
 cost limit, losing your connection, or pressing Ctrl-C.
 
 ## Limiting time and cost
@@ -87,7 +87,7 @@ pnpm deepsec revalidate   # re-check findings; cuts false positives
 pnpm deepsec export --format md-dir --out ./findings
 ```
 
-`scan` costs nothing — it's local pattern matching. `process` is the
+`scan` costs nothing (it's local pattern matching). `process` is the
 expensive AI stage. All of these resume cleanly if interrupted, and
 re-running them only looks at work that isn't done yet.
 
@@ -105,8 +105,8 @@ MY_OPENAI_KEY=... npx deepsec init \
 ```
 
 For Anthropic, use `--agent claude --ai-provider anthropic`. Deepsec
-stores only the *name* of the environment variable, never the key itself —
-export the variable again for later commands, or put it in
+stores only the *name* of the environment variable, never the key itself.
+Export the variable again for later commands, or put it in
 `.deepsec/.env.local`. See [vercel-setup](vercel-setup.md) for other
 providers and the full credential reference.
 
@@ -135,7 +135,7 @@ account, since the sandboxes run on Vercel):
 pnpm deepsec sandbox process --project-id my-app --sandboxes 10 --concurrency 4
 ```
 
-Sandboxes never see your real model credentials — the host machine keeps
+Sandboxes never see your real model credentials. The host machine keeps
 them and injects them only at the model provider's servers.
 
 ## Running from CI or an agent

--- a/docs/models.md
+++ b/docs/models.md
@@ -88,7 +88,7 @@ pnpm deepsec process --project-id my-app --thinking-level high
 ```
 
 Accepted values: `minimal`, `low`, `medium`, `high`, `xhigh`. The
-default is `xhigh` — deepsec optimizes for finding hard bugs, not for
+default is `xhigh`. Deepsec optimizes for finding hard bugs, not for
 cost. Dial down for cheaper reinvestigation waves or quick smoke runs
 over large repos.
 
@@ -121,7 +121,7 @@ themselves in lower FP rate, even at higher per-call cost. Opus is the
 strongest of the Claude family at this kind of code reasoning.
 
 If cost matters more than precision (a 10k-file repo, a quick triaged
-starter list), drop to `claude-sonnet-4-6` — same prompt, ~3× cheaper,
+starter list), drop to `claude-sonnet-4-6`. Same prompt, ~3× cheaper,
 ~10–20% higher FP rate.
 
 ### `gpt-5.5` for the Codex backend
@@ -166,8 +166,8 @@ repeatable `--ai-header name=value` remain available as Pi runtime overrides.
 
 ### `claude-sonnet-4-6` for `triage`
 
-Triage buckets findings into P0/P1/P2/skip without re-reading the code
-— it just looks at the finding text. That's a cheap task; Opus is
+Triage buckets findings into P0/P1/P2/skip without re-reading the code.
+It just looks at the finding text. That's a cheap task; Opus is
 overkill. Sonnet keeps `triage` at ~1¢/finding.
 
 ## Refusals

--- a/docs/vercel-setup.md
+++ b/docs/vercel-setup.md
@@ -13,10 +13,10 @@ Vercel project. That single link supplies the platform identity used for:
 
 There is no separate Sandbox onboarding step. Setup verifies that the exact
 workspace link has an OIDC or access-token credential usable by Sandbox, but
-does not create a billable Sandbox. Distributed execution remains optional;
-the first `sandbox` command performs the authoritative service operation.
+does not create a billable Sandbox. Distributed execution remains optional.
+The first `sandbox` command performs the authoritative service operation.
 
-The link lives at `.deepsec/.vercel/project.json`; credentials live in
+The link lives at `.deepsec/.vercel/project.json`. Credentials live in
 `.deepsec/.env.local` or the calling process. Both paths are gitignored.
 Because `vercel env pull` reads the linked project's development environment,
 a dedicated empty Deepsec project is the safest choice.
@@ -100,7 +100,7 @@ ai: { mode: "gateway", provider: "vercel" }
 ```
 
 Deepsec maps the Gateway credential to the environment expected by Codex,
-Claude, or Pi. Sandbox workers receive only a placeholder; the real bearer
+Claude, or Pi. Sandbox workers receive only a placeholder. The real bearer
 token is injected at the allowed Gateway host by the host-side broker.
 
 ### Your own OpenAI or Anthropic credential


### PR DESCRIPTION
Copy-editing only. An AI-written-text detector reviewed every page on the docs site plus the homepage; three pages came back with elevated stylistic tells. This PR sands those down.

The edits are **punctuation and cadence only**. No meaning, technical detail, command, flag, code block, table, frontmatter field, or link changed — the diff is 13 lines, each swapping a connector for a sentence boundary (plus the resulting capitalization).

## What was flagged, and what changed

**`docs/getting-started.md`** — em-dash appositive density was elevated (the "claim — clarifying aside" shape recurring). Four mid-sentence splices became separate sentences or a parenthetical:

- ``scan`` costs nothing → parenthetical
- resuming after a stop → two sentences
- credentials never reaching sandboxes → two sentences
- storing only the env var *name* → two sentences

**`docs/models.md`** — the same "claim — aside" cadence, roughly once per paragraph. Three reworked into plain sentences, with numbers and mechanism identical:

- the `claude-sonnet-4-6` cost/FP tradeoff
- the `xhigh` thinking-level default
- what triage reads

**`docs/vercel-setup.md`** — semicolon-coupled two-clause cadence was running well above baseline (the balanced "clause; mirrored clause" join). Three of those splits into separate sentences:

- distributed execution being optional
- where the link vs. the credentials live
- placeholder vs. real bearer token in sandbox workers

One note for reviewers: splitting the `xhigh` sentence in `models.md` put the product name at a sentence boundary, so it reads `Deepsec` there. That file already uses both casings at sentence start; capitalized matches the neighboring paragraph.

## Pages reviewed

Reviewed: `getting-started`, `models`, `vercel-setup` (edited here), plus `architecture`, `configuration`, `data-layout`, `faq`, `plugins`, `reviewing-changes`, `supported-tech`, `writing-matchers`.

The other 8 docs pages passed the review and read as human-written. They are unchanged, deliberately — no sweep was applied to them.