### PR TITLE
Add optional vulnerability report fields

### DIFF
--- a/packages/core/src/__tests__/schemas.test.ts
+++ b/packages/core/src/__tests__/schemas.test.ts
@@ -59,6 +59,40 @@ describe("fileRecordSchema", () => {
     expect(() => fileRecordSchema.parse(valid)).not.toThrow();
   });
 
+  it("preserves optional report fields", () => {
+    const valid = {
+      filePath: "src/db/query.ts",
+      projectId: "test",
+      candidates: [],
+      lastScannedAt: "2026-04-01T14:30:52.000Z",
+      lastScannedRunId: "run1",
+      fileHash: "abc",
+      findings: [
+        {
+          severity: "HIGH",
+          vulnSlug: "sql-injection",
+          title: "SQL injection in user lookup",
+          description: "User input reaches a raw SQL query.",
+          lineNumbers: [10],
+          recommendation: "Use a parameterized query.",
+          confidence: "high",
+          impact: "An attacker can read or modify database records.",
+          stepsToReproduce: "Trace the request id into the raw query.",
+          cvssScore: 8.1,
+          cvssVector: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
+          cweId: "CWE-89",
+          limitations: ["Static analysis did not execute the query."],
+        },
+      ],
+      analysisHistory: [],
+      status: "analyzed",
+    };
+
+    const parsed = fileRecordSchema.parse(valid);
+
+    expect(parsed.findings[0]).toMatchObject(valid.findings[0]);
+  });
+
   it("rejects invalid status", () => {
     const invalid = {
       filePath: "test.ts",

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -45,6 +45,12 @@ export const findingSchema = z.object({
   lineNumbers: z.array(z.number()),
   recommendation: z.string(),
   confidence: z.enum(["high", "medium", "low"]),
+  impact: z.string().optional(),
+  stepsToReproduce: z.string().optional(),
+  cvssScore: z.number().min(0).max(10).optional(),
+  cvssVector: z.string().optional(),
+  cweId: z.string().optional(),
+  limitations: z.array(z.string()).optional(),
   triage: z
     .object({
       priority: z.enum(["P0", "P1", "P2", "skip"]),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -226,6 +226,12 @@ export interface Finding {
   lineNumbers: number[];
   recommendation: string;
   confidence: Confidence;
+  impact?: string;
+  stepsToReproduce?: string;
+  cvssScore?: number;
+  cvssVector?: string;
+  cweId?: string;
+  limitations?: string[];
   triage?: Triage;
   revalidation?: Revalidation;
   /**

--- a/packages/processor/src/__tests__/shared.test.ts
+++ b/packages/processor/src/__tests__/shared.test.ts
@@ -324,6 +324,10 @@ describe("JSON repair prompts", () => {
     expect(prompt).toContain("- apps/web/a.ts");
     expect(prompt).toContain("- lib/b.ts");
     expect(prompt).toContain('"findings"');
+    expect(prompt).toContain('"impact"');
+    expect(prompt).toContain('"stepsToReproduce"');
+    expect(prompt).toContain('"cvssScore"');
+    expect(prompt).toContain('"cweId"');
   });
 
   it("asks revalidation agents to re-output only JSON verdicts", () => {
@@ -369,6 +373,22 @@ describe("parseInvestigateResults", () => {
     expect(out.results.find((r) => r.filePath === "a.ts")?.findings.length).toBe(1);
     expect(out.results.find((r) => r.filePath === "b.ts")?.findings).toEqual([]);
     expect(out.invalid).toEqual([]);
+  });
+
+  it("preserves optional report fields", () => {
+    const finding = validFinding({
+      impact: "An attacker can read arbitrary rows.",
+      stepsToReproduce: "Trace req.query.id into db.raw().",
+      cvssScore: 8.1,
+      cvssVector: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
+      cweId: "CWE-89",
+      limitations: ["Static analysis only."],
+    });
+    const text = JSON.stringify([{ filePath: "a.ts", findings: [finding] }]);
+
+    const out = parseInvestigateResults(text, batch);
+
+    expect(out.results[0].findings[0]).toMatchObject(finding);
   });
 
   it("repairs common malformed model JSON before parsing findings", () => {
@@ -448,6 +468,8 @@ describe("buildInvestigateFieldRepairPrompt", () => {
     expect(prompt).toContain('"severity": "INFO"');
     expect(prompt).toContain("Do not redo the investigation");
     expect(prompt).toContain("do not repeat findings that were already accepted");
+    expect(prompt).toContain('"impact"');
+    expect(prompt).toContain('"stepsToReproduce"');
   });
 });
 

--- a/packages/processor/src/agents/shared.ts
+++ b/packages/processor/src/agents/shared.ts
@@ -425,10 +425,16 @@ After your investigation, output a JSON block with your findings for EACH file. 
         "severity": "CRITICAL|HIGH|MEDIUM|HIGH_BUG|BUG",
         "vulnSlug": "the-vuln-slug-or-other",
         "title": "Brief title of the issue",
-        "description": "Detailed description of the vulnerability, the attack scenario, and evidence from the code",
+        "description": "Detailed description of the vulnerability, attack scenario, source evidence, and security boundary failure",
         "lineNumbers": [10, 15],
-        "recommendation": "How to fix this vulnerability",
-        "confidence": "high|medium|low"
+        "recommendation": "Concrete code changes and regression checks",
+        "confidence": "high|medium|low",
+        "impact": "Optional concrete technical and business impact",
+        "stepsToReproduce": "Optional source-level procedure that explains how the vulnerable path is reached; do not execute it",
+        "cvssScore": 8.1,
+        "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
+        "cweId": "CWE-89",
+        "limitations": ["Optional evidence limits or assumptions"]
       }
     ]
   }
@@ -441,6 +447,8 @@ After your investigation, output a JSON block with your findings for EACH file. 
 - **BUG** — notable non-security bugs (logic errors, race conditions, resource leaks) that don't rise to HIGH_BUG
 
 **vulnSlug** can be any of the known categories OR a custom slug for issues not covered by the scanner. Use \`"other"\` as the slug prefix for novel findings (e.g., \`"other-race-condition"\`, \`"other-logic-bug"\`, \`"other-info-disclosure"\`).
+
+The report fields after **confidence** are optional. Populate each one only when the source evidence supports it. Do not invent impact, reproduction details, CVSS data, CWE classifications, or limitations.
 
 If a file has no real vulnerabilities after thorough investigation, include it with an empty findings array.`;
 }
@@ -516,7 +524,13 @@ Use this exact schema:
         "description": "Detailed description of the vulnerability, the attack scenario, and evidence from the code",
         "lineNumbers": [10, 15],
         "recommendation": "How to fix this vulnerability",
-        "confidence": "high"
+        "confidence": "high",
+        "impact": "Optional concrete impact",
+        "stepsToReproduce": "Optional source-level reproduction procedure",
+        "cvssScore": 8.1,
+        "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
+        "cweId": "CWE-89",
+        "limitations": ["Optional evidence limit"]
       }
     ]
   }
@@ -884,7 +898,13 @@ Return ONLY a JSON array in this exact shape, containing one entry per filePath 
         "description": "Detailed description",
         "lineNumbers": [10, 15],
         "recommendation": "How to fix this vulnerability",
-        "confidence": "high"
+        "confidence": "high",
+        "impact": "Optional concrete impact",
+        "stepsToReproduce": "Optional source-level reproduction procedure",
+        "cvssScore": 8.1,
+        "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
+        "cweId": "CWE-89",
+        "limitations": ["Optional evidence limit"]
       }
     ]
   }


### PR DESCRIPTION
Adds optional impact, source-level reproduction, CVSS, CWE, and limitation fields to findings.

Updates the investigation and repair prompts to request these fields only when source evidence supports them. Missing fields remain valid and do not fail a run.

Verified:
- core and processor TypeScript builds
- core schema tests
- processor shared-agent tests
- Biome checks