### PR TITLE
Add tls-verification-disabled matcher

### DIFF
--- a/packages/scanner/src/__tests__/tls-verification-disabled.test.ts
+++ b/packages/scanner/src/__tests__/tls-verification-disabled.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { tlsVerificationDisabledMatcher } from "../matchers/tls-verification-disabled.js";
+
+const m = tlsVerificationDisabledMatcher;
+
+describe("tls-verification-disabled matcher", () => {
+  it("reports each idiom in a file with several distinct disables", () => {
+    const src = `
+const agent = new https.Agent({ rejectUnauthorized: false });
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+const url = "postgres://user:pass@db:5432/app?sslmode=disable";
+`;
+    const matches = m.match(src, "src/client.ts");
+    const labels = matches.map((x) => x.matchedPattern);
+    expect(labels).toContain("rejectUnauthorized: false");
+    expect(labels.join(" ")).toContain("NODE_TLS_REJECT_UNAUTHORIZED");
+    expect(labels.join(" ")).toContain("sslmode=disable");
+    expect(matches.length).toBe(3);
+  });
+
+  it("matches spacing and assignment variants", () => {
+    expect(m.match(`opts = { rejectUnauthorized:false }`, "src/a.js").length).toBe(1);
+    expect(m.match(`resp = session.get(url, verify = False)`, "src/a.py").length).toBe(1);
+    expect(m.match(`https.globalAgent.options.rejectUnauthorized = false`, "src/a.js").length).toBe(
+      1,
+    );
+  });
+
+  it("does not flag verification-enabled configurations", () => {
+    const src = `
+const agent = new https.Agent({ rejectUnauthorized: true });
+conf := &tls.Config{InsecureSkipVerify: false}
+resp = requests.get(url, verify=True)
+DATABASE_URL=postgres://user:pass@db:5432/app?sslmode=require
+`;
+    expect(m.match(src, "src/client.ts")).toEqual([]);
+  });
+
+  it("skips test files across ecosystems", () => {
+    const bad = `const agent = new https.Agent({ rejectUnauthorized: false });`;
+    expect(m.match(bad, "src/client.test.ts")).toEqual([]);
+    expect(m.match(`conf := &tls.Config{InsecureSkipVerify: true}`, "pkg/client_test.go")).toEqual(
+      [],
+    );
+    expect(m.match(`resp = requests.get(url, verify=False)`, "app/test_client.py")).toEqual([]);
+    expect(m.match(`resp = requests.get(url, verify=False)`, "app/client_test.py")).toEqual([]);
+    expect(m.match(`http.verify_mode = OpenSSL::SSL::VERIFY_NONE`, "lib/client_spec.rb")).toEqual(
+      [],
+    );
+    expect(m.match(bad, "spec/support/helper.rb")).toEqual([]);
+    expect(m.match(`resp = requests.get(url, verify=False)`, "tests/conftest.py")).toEqual([]);
+  });
+
+  it("does not flag curl without insecure flags or unrelated -k-like tokens", () => {
+    expect(m.match(`RUN curl -fsSL https://example.com/install.sh | sh`, "Dockerfile")).toEqual([]);
+    expect(m.match(`curl -s -o /tmp/kubeconfig https://example.com`, "deploy.sh")).toEqual([]);
+  });
+});

--- a/packages/scanner/src/__tests__/tls-verification-disabled.test.ts
+++ b/packages/scanner/src/__tests__/tls-verification-disabled.test.ts
@@ -26,6 +26,14 @@ const url = "postgres://user:pass@db:5432/app?sslmode=disable";
     );
   });
 
+  it("does not fire verify=False on non-HTTP kwargs", () => {
+    expect(m.match(`claims = jwt.decode(encoded, verify=False)`, "src/auth.py")).toEqual([]);
+    expect(m.match(`t = ctx.findroot(f, ab, solver='illinois', verify=False)`, "src/m.py")).toEqual(
+      [],
+    );
+    expect(m.match(`@array_function_dispatch(_dispatcher, verify=False)`, "src/np.py")).toEqual([]);
+  });
+
   it("does not flag verification-enabled configurations", () => {
     const src = `
 const agent = new https.Agent({ rejectUnauthorized: true });

--- a/packages/scanner/src/matchers/index.ts
+++ b/packages/scanner/src/matchers/index.ts
@@ -202,6 +202,7 @@ import { tfIamWildcardMatcher } from "./tf-iam-wildcard.js";
 import { tfModuleUnpinnedMatcher } from "./tf-module-unpinned.js";
 import { tfPublicIngressMatcher } from "./tf-public-ingress.js";
 import { tfSecretInDataMatcher } from "./tf-secret-in-data.js";
+import { tlsVerificationDisabledMatcher } from "./tls-verification-disabled.js";
 import { trpcPublicProcedureMatcher } from "./trpc-public-procedure.js";
 import { unixSocketListenerMatcher } from "./unix-socket-listener.js";
 import { unsafeDeserializationMatcher } from "./unsafe-deserialization.js";
@@ -312,6 +313,7 @@ export function createDefaultRegistry(): MatcherRegistry {
   registry.register(dockerfileCurlPipeUnverifiedMatcher);
   registry.register(dockerfileRunAsRootMatcher);
   registry.register(cryptoUsageMatcher);
+  registry.register(tlsVerificationDisabledMatcher);
 
   // Secrets management
   registry.register(secretsPlaintextExposureMatcher);

--- a/packages/scanner/src/matchers/tls-verification-disabled.ts
+++ b/packages/scanner/src/matchers/tls-verification-disabled.ts
@@ -19,8 +19,14 @@ const PATTERNS: { regex: RegExp; label: string }[] = [
   { regex: /strictSSL\s*[:=]\s*false/, label: "strictSSL: false" },
   // Go
   { regex: /InsecureSkipVerify\s*:\s*true/, label: "tls.Config InsecureSkipVerify: true" },
-  // Python
-  { regex: /\bverify\s*=\s*False\b/, label: "requests verify=False" },
+  // Python — anchor verify=False to an HTTP-call context so it does not
+  // fire on unrelated `verify=False` kwargs (jwt.decode, numpy dispatch,
+  // mpmath.findroot, etc.).
+  {
+    regex:
+      /(?:\b(?:requests|httpx|session|client|aiohttp)\b|\.(?:get|post|put|patch|delete|head|options|request|Session|Client)\s*\()[^\n]*\bverify\s*=\s*False\b/,
+    label: "requests/httpx verify=False",
+  },
   { regex: /ssl\._create_unverified_context/, label: "ssl._create_unverified_context" },
   { regex: /\bcheck_hostname\s*=\s*False\b/, label: "SSLContext check_hostname = False" },
   // Ruby
@@ -90,6 +96,7 @@ export const tlsVerificationDisabledMatcher: MatcherPlugin = {
     `const client = request.defaults({ strictSSL: false });`,
     `conf := &tls.Config{InsecureSkipVerify: true}`,
     `resp = requests.get(url, verify=False)`,
+    `resp = httpx.get(url, verify=False)`,
     `ctx = ssl._create_unverified_context()`,
     `ctx.check_hostname = False`,
     `http.verify_mode = OpenSSL::SSL::VERIFY_NONE`,

--- a/packages/scanner/src/matchers/tls-verification-disabled.ts
+++ b/packages/scanner/src/matchers/tls-verification-disabled.ts
@@ -33,7 +33,8 @@ const PATTERNS: { regex: RegExp; label: string }[] = [
   { regex: /\bVERIFY_NONE\b/, label: "OpenSSL VERIFY_NONE" },
   // JVM (Apache HttpClient / HttpsURLConnection idioms)
   {
-    regex: /\b(?:NoopHostnameVerifier|AllowAllHostnameVerifier|ALLOW_ALL_HOSTNAME_VERIFIER|TrustAllStrategy)\b/,
+    regex:
+      /\b(?:NoopHostnameVerifier|AllowAllHostnameVerifier|ALLOW_ALL_HOSTNAME_VERIFIER|TrustAllStrategy)\b/,
     label: "permissive JVM hostname verifier / trust strategy",
   },
   // PHP

--- a/packages/scanner/src/matchers/tls-verification-disabled.ts
+++ b/packages/scanner/src/matchers/tls-verification-disabled.ts
@@ -1,0 +1,121 @@
+import type { MatcherPlugin } from "../types.js";
+import { regexMatcher } from "./utils.js";
+
+/**
+ * Disabled TLS certificate or hostname verification (CWE-295). Each pattern
+ * anchors to the explicit disable form (`false` / `0` / `disable` /
+ * `skip-verify`) so verification-enabled configurations never match. Skips
+ * test files across ecosystems — disabling verification against local
+ * self-signed fixtures is a common, mostly-legitimate test idiom, and the
+ * scan-level ignore list only pre-excludes JS-style test paths.
+ */
+const PATTERNS: { regex: RegExp; label: string }[] = [
+  // Node / JS
+  { regex: /rejectUnauthorized\s*[:=]\s*false/, label: "rejectUnauthorized: false" },
+  {
+    regex: /\bNODE_TLS_REJECT_UNAUTHORIZED\b\s*[=:]\s*['"]?0\b/,
+    label: "NODE_TLS_REJECT_UNAUTHORIZED=0 (process-wide TLS bypass)",
+  },
+  { regex: /strictSSL\s*[:=]\s*false/, label: "strictSSL: false" },
+  // Go
+  { regex: /InsecureSkipVerify\s*:\s*true/, label: "tls.Config InsecureSkipVerify: true" },
+  // Python
+  { regex: /\bverify\s*=\s*False\b/, label: "requests verify=False" },
+  { regex: /ssl\._create_unverified_context/, label: "ssl._create_unverified_context" },
+  { regex: /\bcheck_hostname\s*=\s*False\b/, label: "SSLContext check_hostname = False" },
+  // Ruby
+  { regex: /\bVERIFY_NONE\b/, label: "OpenSSL VERIFY_NONE" },
+  // JVM (Apache HttpClient / HttpsURLConnection idioms)
+  {
+    regex: /\b(?:NoopHostnameVerifier|AllowAllHostnameVerifier|ALLOW_ALL_HOSTNAME_VERIFIER|TrustAllStrategy)\b/,
+    label: "permissive JVM hostname verifier / trust strategy",
+  },
+  // PHP
+  {
+    regex: /CURLOPT_SSL_VERIFY(?:PEER|HOST)\s*(?:=>|,)\s*(?:false|0)\b/,
+    label: "PHP curl SSL verification disabled",
+  },
+  // .NET
+  {
+    regex:
+      /DangerousAcceptAnyServerCertificateValidator|ServerCertificate(?:Custom)?ValidationCallback\s*\+?=[^\n]*(?:=>|return)\s*true/,
+    label: ".NET certificate validation callback bypassed",
+  },
+  // CLI tools (shell, Dockerfile, CI)
+  {
+    regex: /\bcurl\b[^|\n]*\s(?:--insecure\b|-[A-Za-z]*k\b)/,
+    label: "curl --insecure / -k",
+  },
+  { regex: /\bwget\b[^\n]*--no-check-certificate/, label: "wget --no-check-certificate" },
+  { regex: /http\.sslVerify\b[^\n]*\bfalse\b/i, label: "git http.sslVerify false" },
+  {
+    regex: /\bGIT_SSL_NO_VERIFY\b\s*=\s*['"]?(?:1|true)\b/i,
+    label: "GIT_SSL_NO_VERIFY",
+  },
+  // Connection strings / infra config
+  { regex: /\bsslmode=disable\b/, label: "connection string sslmode=disable" },
+  { regex: /\btls=skip-verify\b/, label: "MySQL DSN tls=skip-verify" },
+  {
+    regex: /--insecure-skip-tls-verify\b|\binsecure-skip-tls-verify\s*:\s*true\b/,
+    label: "kubectl/kubeconfig insecure-skip-tls-verify",
+  },
+];
+
+export const tlsVerificationDisabledMatcher: MatcherPlugin = {
+  noiseTier: "precise" as const,
+  slug: "tls-verification-disabled",
+  description:
+    "TLS certificate or hostname verification explicitly disabled (rejectUnauthorized:false, InsecureSkipVerify, verify=False, VERIFY_NONE, curl -k, sslmode=disable)",
+  filePatterns: [
+    "**/*.{ts,tsx,js,jsx,mjs,cjs}",
+    "**/*.go",
+    "**/*.py",
+    "**/*.rb",
+    "**/*.{java,kt,scala,groovy}",
+    "**/*.php",
+    "**/*.cs",
+    "**/*.{sh,bash}",
+    "**/*.{yml,yaml}",
+    ".github/workflows/**/*.{yml,yaml}",
+    "**/.env",
+    "**/.env.*",
+    "**/Dockerfile",
+    "**/Dockerfile.*",
+    "**/*.Dockerfile",
+  ],
+  examples: [
+    `const agent = new https.Agent({ rejectUnauthorized: false });`,
+    `process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";`,
+    `NODE_TLS_REJECT_UNAUTHORIZED=0`,
+    `const client = request.defaults({ strictSSL: false });`,
+    `conf := &tls.Config{InsecureSkipVerify: true}`,
+    `resp = requests.get(url, verify=False)`,
+    `ctx = ssl._create_unverified_context()`,
+    `ctx.check_hostname = False`,
+    `http.verify_mode = OpenSSL::SSL::VERIFY_NONE`,
+    `.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)`,
+    `curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);`,
+    `handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;`,
+    `RUN curl -k https://internal.example.com/install.sh -o install.sh`,
+    `curl --insecure https://internal.example.com/health`,
+    `wget --no-check-certificate https://example.com/pkg.tar.gz`,
+    `git config --global http.sslVerify false`,
+    `GIT_SSL_NO_VERIFY=1 git clone https://git.internal/repo.git`,
+    `DATABASE_URL=postgres://user:pass@db:5432/app?sslmode=disable`,
+    `dsn := "user:pass@tcp(db:3306)/app?tls=skip-verify"`,
+    `insecure-skip-tls-verify: true`,
+    `kubectl --insecure-skip-tls-verify get pods`,
+  ],
+  match(content, filePath) {
+    if (/_test\.go$/.test(filePath)) return [];
+    if (/\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(filePath)) return [];
+    if (/(?:^|\/)__tests__\//.test(filePath)) return [];
+    if (/(?:^|\/)(?:test_[^/]*|[^/]+_test)\.py$/.test(filePath)) return [];
+    if (/(?:^|\/)conftest\.py$/.test(filePath)) return [];
+    if (/_spec\.rb$/.test(filePath)) return [];
+    if (/(?:^|\/)spec\//.test(filePath)) return [];
+    if (/\.d\.ts$/.test(filePath)) return [];
+
+    return regexMatcher("tls-verification-disabled", PATTERNS, content);
+  },
+};


### PR DESCRIPTION
## What changed

Adds a new built-in matcher, `tls-verification-disabled`, that flags code which explicitly disables TLS certificate or hostname verification (CWE-295) across the ecosystems deepsec already scans.

## Why

There was no built-in coverage for disabled TLS verification — no matcher referenced `rejectUnauthorized`, `InsecureSkipVerify`, `verify=False`, `VERIFY_NONE`, `sslmode=disable`, or `curl -k`. It's a high-signal, cross-language weakness class, so a single ungated matcher fills the gap in one place. Every pattern anchors to the explicit disable form (`false` / `0` / `disable` / `skip-verify`), so verification-*enabled* configurations never match.

Covered idioms: Node (`rejectUnauthorized: false`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, `strictSSL: false`), Go (`InsecureSkipVerify: true`), Python (requests/httpx `verify=False`, `ssl._create_unverified_context`, `check_hostname = False`), Ruby (`VERIFY_NONE`), JVM (permissive hostname verifiers / trust-all strategy), PHP (`CURLOPT_SSL_VERIFY*` off), .NET (validation-callback bypass), curl/wget/git CLI flags, and connection strings (`sslmode=disable`, `tls=skip-verify`, `insecure-skip-tls-verify`).

## Verification

- [x] `pnpm test` passes (2390 unit tests, including the auto-discovered `matcher-examples` suite — every one of the matcher's sub-patterns is exercised by an inline example)
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [x] `pnpm -r build` passes
- [x] `pnpm test:bundle` passes (28 tests) — a registered matcher compiles into `dist/config.mjs` via `createDefaultRegistry`, so it's part of the publish surface
- [x] Ran it against real repositories and confirmed the candidate count is sane

**Real-repo candidate counts** (`pnpm deepsec scan --matchers tls-verification-disabled`):

- App codebase A: 5 candidates, all true positives (production Postgres SSL config with `rejectUnauthorized: false`).
- App codebase B: 5 app-code candidates, all true positives (`check_hostname = False` in DB/index scripts, a Node `rejectUnauthorized: false`, a `curl -k` in a shell script). A further 14 candidates were inside vendored `venv/site-packages/` (urllib3/httpx internals) — genuine matches, filtered by ordinary project ignore config rather than by the matcher.

## Notes for reviewer

- **Noise tier `precise`** — the matched syntax is itself a strong signal. During validation, the initial `verify=False` pattern over-fired on unrelated kwargs (`jwt.decode(..., verify=False)`, `numpy` dispatch, `mpmath.findroot`), so it's now anchored to a `requests`/`httpx`/`session`/HTTP-verb call context on the same line. That's the one deliberate precision/recall trade: a `verify=False` split across lines from its request call won't match.
- **Test-file exclusion is cross-language.** `insecure-crypto` excludes only JS-style `.test.`/`.spec.` paths; this matcher also excludes `_test.go`, `test_*.py`/`*_test.py`, `conftest.py`, `_spec.rb`, and `spec/` dirs, since the scan-level `IGNORE_DIRS` only pre-excludes the JS conventions and this matcher is deliberately multi-language.
- **`filePatterns` names dot-path targets explicitly** (`.github/workflows/`, `**/.env`, `**/Dockerfile`) because the scan glob doesn't traverse dot-paths by default — mirroring `github-workflow-security`, `env-exposure`, and the `dockerfile-*` matchers.
- **Overlap with `crypto-usage`:** Go `tls.Config{...}` lines are also picked up by `crypto-usage`'s wide-net "Go TLS op" pattern. Different tiers and purposes (wide-net-for-AI vs. precise disable signal), so this is additive, not a conflict — flagging in case you'd prefer a note or de-dup.
- Happy to add a positive fixture under `fixtures/vulnerable-app` if you'd like the matcher exercised by the fixture-based tests too — left it out to keep the diff to matcher + unit tests.
