### PR TITLE
fix(cli): round token metrics to prevent table layout breakage

### DIFF
--- a/packages/deepsec/src/__tests__/metrics.test.ts
+++ b/packages/deepsec/src/__tests__/metrics.test.ts
@@ -33,6 +33,11 @@ describe("formatTokens", () => {
     expect(formatTokens(950)).toBe("950");
   });
 
+  it("rounds floats under 1K to whole numbers", () => {
+    expect(formatTokens(12.7)).toBe("13");
+    expect(formatTokens(12.3)).toBe("12");
+  });
+
   it("uses K/M/B suffixes", () => {
     expect(formatTokens(1500)).toBe("1.5K");
     expect(formatTokens(2_500_000)).toBe("2.5M");

--- a/packages/deepsec/src/commands/metrics.ts
+++ b/packages/deepsec/src/commands/metrics.ts
@@ -160,7 +160,7 @@ export function formatCost(n: number): string {
 
 export function formatTokens(n: number): string {
   if (n === 0) return "0";
-  if (n < 1000) return String(n);
+  if (n < 1000) return String(Math.round(n));
   if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;
   if (n < 1_000_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   return `${(n / 1_000_000_000).toFixed(1)}B`;
@@ -409,8 +409,8 @@ export function metricsCommand(opts: { projectId?: string; minSeverity?: string 
             m.projectId,
             String(m.analysisCount),
             formatCost(m.cost),
-            formatTokens(m.tokens.input),
-            formatTokens(m.tokens.output),
+              formatTokens(Math.round(m.tokens.input)),
+              formatTokens(Math.round(m.tokens.output)),
             cacheHit,
             formatCost(perAnalysis),
           ],
@@ -430,8 +430,8 @@ export function metricsCommand(opts: { projectId?: string; minSeverity?: string 
             `${BOLD}TOTAL${RESET}`,
             `${BOLD}${totals.analysisCount}${RESET}`,
             `${BOLD}${formatCost(totals.cost)}${RESET}`,
-            `${BOLD}${formatTokens(totals.tokens.input)}${RESET}`,
-            `${BOLD}${formatTokens(totals.tokens.output)}${RESET}`,
+              `${BOLD}${formatTokens(Math.round(totals.tokens.input))}${RESET}`,
+              `${BOLD}${formatTokens(Math.round(totals.tokens.output))}${RESET}`,
             `${BOLD}${cacheHit}${RESET}`,
             `${BOLD}${formatCost(perAnalysis)}${RESET}`,
           ],


### PR DESCRIPTION
## What changed

rounded token values before rendering the metrics table and updated `formatTokens()` to render numbers under 1K as whole integers
added a unit test to assert float to integer behavior

## Why

some projects produced fractional token counts (e.g. 12.7) which became string values in table cells and broke the fixed-width table borders. rounding ensures token counts are whole numbers and preserves table layout

## Verification

- [x] `pnpm test` passes
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [x] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane

## Notes for reviewer

nothing worth mentioning!
