### PR TITLE
Add "local subscriptions" model route + document --scaffold-only

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,8 +18,11 @@ creates the project threat model, checks scan coverage, generates safe
 project-specific matchers when needed, and processes candidates. Re-run it
 to resume, or use `pnpm deepsec setup` from inside `.deepsec/`.
 
-Use `npx deepsec init --scaffold-only` if you only want the files, and
-`--model-auth direct` with `--ai-api-key-env` to use your own model key.
+Use `npx deepsec init --scaffold-only` if you only want the files,
+`--model-auth direct` with `--ai-api-key-env` to use your own model key,
+or `--model-auth local` to rely on machine-wide `claude`/`codex` logins
+without any API key. See
+[getting-started](getting-started.md) for details on both.
 
 `.deepsec/` has its own `package.json` and `node_modules/` — separate
 from the parent repo's lockfile and tooling. The parent repo only

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -110,6 +110,50 @@ Export the variable again for later commands, or put it in
 `.deepsec/.env.local`. See [vercel-setup](vercel-setup.md) for other
 providers and the full credential reference.
 
+## Using local subscriptions
+
+If the `claude` or `codex` CLI is already logged in on your machine, you
+can skip model credentials entirely. Pick **Use local subscriptions** at
+the interactive model-access prompt, or pass the flag directly:
+
+```bash
+npx deepsec init --model-auth local
+```
+
+Deepsec then configures nothing for model access: no API key, no gateway
+token, no environment variables. Later commands (`process`,
+`revalidate`, `triage`) skip their credential checks and rely on the
+machine-wide login — if it's missing, the agent SDK itself reports a
+clear error on first use.
+
+Two caveats: the login must exist for the harness you actually run
+(`claude` for `--agent claude`, a logged-in `codex` for `--agent codex`),
+and `sandbox` commands still need a real API token
+(`AI_GATEWAY_API_KEY`), because a machine-local login can't be brokered
+into an isolated sandbox.
+
+## Scaffold only
+
+To create the workspace files without running any of the setup:
+
+```bash
+npx deepsec init --scaffold-only
+```
+
+This writes the `.deepsec/` skeleton — `deepsec.config.ts`,
+`package.json`, `README.md`, `AGENTS.md`, `.gitignore`, and
+`data/<project>/{INFO.md,SETUP.md,project.json}` for the first project —
+and stops. It does not install dependencies, log in to Vercel, pick a
+model, scan, or start AI processing.
+
+Use it when you want to review or commit the scaffold before anything
+runs, drive the remaining setup from a coding agent, or do the steps by
+hand. The command prints the manual path: `pnpm install` inside
+`.deepsec/`, an agent prompt for filling in `INFO.md`, then
+`pnpm deepsec scan` and `pnpm deepsec process`. You can also run
+`pnpm deepsec setup` (or re-run `npx deepsec init`) later to complete
+the normal automated flow from where the scaffold left off.
+
 ## Two files worth a look
 
 Setup writes two things you may want to review:

--- a/docs/models.md
+++ b/docs/models.md
@@ -48,6 +48,13 @@ Vercel/Sandbox project link and is persisted as non-secret `ai` config. Direct
 OpenAI/Anthropic and custom Pi routes are documented in
 [vercel-setup](vercel-setup.md).
 
+There is also a `local` route (`--model-auth local`, or "Use local
+subscriptions" in the interactive prompt) for machines where the `claude` or
+`codex` CLI is already logged in. It configures no credential at all and
+disables the env-var preflight checks — the machine-wide login is used
+directly. Sandbox commands are the exception: they must broker a real token,
+so they still require `AI_GATEWAY_API_KEY` (or an equivalent key).
+
 ## CLI selection
 
 ```bash

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -35,7 +35,7 @@ export interface DeepsecConfig {
   defaultThinkingLevel?: string;
   /** Non-secret default model credential route. Secret values stay in env/.env.local. */
   ai?: {
-    mode: "gateway" | "direct" | "custom";
+    mode: "gateway" | "direct" | "custom" | "local";
     provider: string;
     apiKeyEnv?: string;
     baseUrl?: string;

--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/src/__tests__/ensure-connected-workspace.test.ts
+++ b/packages/deepsec/src/__tests__/ensure-connected-workspace.test.ts
@@ -74,4 +74,35 @@ describe("ensureConnectedWorkspace", () => {
     expect(verifyModelRoute).not.toHaveBeenCalled();
     expect(result.sandboxReady).toBe(true);
   });
+
+  it("skips credential resolution and verification for a local-subscription route", async () => {
+    const resolveRoute = vi.fn(async () => resolved());
+    const verifyModelRoute = vi.fn(async () => undefined);
+    const localRoute = { mode: "local", provider: "local" } as const;
+    const env = { VERCEL_TOKEN: "v", VERCEL_TEAM_ID: "team", VERCEL_PROJECT_ID: "project" };
+    const result = await ensureConnectedWorkspace({
+      workspaceDir: "/workspace",
+      interactive: false,
+      modelRoute: localRoute,
+      agentTypes: ["claude-agent-sdk"],
+      env,
+      dependencies: {
+        ensureLink: async () => ({
+          method: "access-token-triple",
+          project: { teamId: "team", projectId: "project" },
+          link: { orgId: "team", projectId: "project" },
+        }),
+        resolveRoute,
+        verifyModelRoute,
+        now: () => new Date("2026-01-01T00:00:00Z"),
+      },
+    });
+    expect(resolveRoute).not.toHaveBeenCalled();
+    expect(verifyModelRoute).not.toHaveBeenCalled();
+    expect(result.modelAuth).toEqual(localRoute);
+    expect(result.modelRouteVerified).toBe(false);
+    expect(result.verification.route).toEqual(localRoute);
+    // No model credential env vars were injected.
+    expect(env).toEqual({ VERCEL_TOKEN: "v", VERCEL_TEAM_ID: "team", VERCEL_PROJECT_ID: "project" });
+  });
 });

--- a/packages/deepsec/src/__tests__/ensure-connected-workspace.test.ts
+++ b/packages/deepsec/src/__tests__/ensure-connected-workspace.test.ts
@@ -103,6 +103,10 @@ describe("ensureConnectedWorkspace", () => {
     expect(result.modelRouteVerified).toBe(false);
     expect(result.verification.route).toEqual(localRoute);
     // No model credential env vars were injected.
-    expect(env).toEqual({ VERCEL_TOKEN: "v", VERCEL_TEAM_ID: "team", VERCEL_PROJECT_ID: "project" });
+    expect(env).toEqual({
+      VERCEL_TOKEN: "v",
+      VERCEL_TEAM_ID: "team",
+      VERCEL_PROJECT_ID: "project",
+    });
   });
 });

--- a/packages/deepsec/src/__tests__/model-route.test.ts
+++ b/packages/deepsec/src/__tests__/model-route.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import { applyResolvedModelRoute, resolveModelRoute } from "../auth/model-route.js";
 
 describe("resolveModelRoute", () => {
+  it("refuses to resolve a local-subscription route to a brokered credential", async () => {
+    await expect(
+      resolveModelRoute({ mode: "local", provider: "local" }, { agentType: "codex", env: {} }),
+    ).rejects.toThrow(/machine-wide agent logins/);
+  });
+
   it("still rejects an explicitly selected route that is incompatible with the harness", async () => {
     await expect(
       resolveModelRoute(

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -192,9 +192,7 @@ describe("assertAgentCredential", () => {
 
   it("still requires a brokered token in sandbox mode despite a local route", () => {
     setLoadedConfig({ projects: [], ai: { mode: "local", provider: "local" } });
-    expect(() => assertAgentCredential("codex", { inSandbox: true })).toThrow(
-      /AI_GATEWAY_API_KEY/,
-    );
+    expect(() => assertAgentCredential("codex", { inSandbox: true })).toThrow(/AI_GATEWAY_API_KEY/);
     // An ambient gateway key still unlocks sandbox runs.
     process.env.AI_GATEWAY_API_KEY = "vck_gateway";
     process.env.OPENAI_API_KEY = "vck_gateway";

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -50,6 +50,14 @@ describe("applyConfiguredModelRoute", () => {
     expect(env).toEqual({});
   });
 
+  it("leaves a local-subscription route entirely to machine-wide agent logins", async () => {
+    setLoadedConfig({ projects: [], ai: { mode: "local", provider: "local" } });
+    const env = {};
+    await expect(applyConfiguredModelRoute("codex", env)).resolves.toBeUndefined();
+    await expect(applyConfiguredModelRoute("claude-agent-sdk", env)).resolves.toBeUndefined();
+    expect(env).toEqual({});
+  });
+
   it("ignores a persisted route that is incompatible with the requested harness", async () => {
     setLoadedConfig({
       projects: [],
@@ -104,6 +112,7 @@ describe("assertAgentCredential", () => {
     rmSync(emptyClaudeHome, { recursive: true, force: true });
     rmSync(emptyCodexHome, { recursive: true, force: true });
     rmSync(emptyPathDir, { recursive: true, force: true });
+    setLoadedConfig({ projects: [] });
   });
 
   it("passes for claude-agent-sdk when ANTHROPIC_AUTH_TOKEN is set", () => {
@@ -171,6 +180,25 @@ describe("assertAgentCredential", () => {
     // require fake ANTHROPIC_AUTH_TOKEN env vars.
     expect(() => assertAgentCredential("stub")).not.toThrow();
     expect(() => assertAgentCredential("anything-else")).not.toThrow();
+  });
+
+  it("skips all env-var checks when the configured route is local subscriptions", () => {
+    setLoadedConfig({ projects: [], ai: { mode: "local", provider: "local" } });
+    // Nothing set anywhere — no env vars, no CLI on PATH, no auth.json.
+    expect(() => assertAgentCredential("claude-agent-sdk")).not.toThrow();
+    expect(() => assertAgentCredential("codex")).not.toThrow();
+    expect(() => assertAgentCredential("pi")).not.toThrow();
+  });
+
+  it("still requires a brokered token in sandbox mode despite a local route", () => {
+    setLoadedConfig({ projects: [], ai: { mode: "local", provider: "local" } });
+    expect(() => assertAgentCredential("codex", { inSandbox: true })).toThrow(
+      /AI_GATEWAY_API_KEY/,
+    );
+    // An ambient gateway key still unlocks sandbox runs.
+    process.env.AI_GATEWAY_API_KEY = "vck_gateway";
+    process.env.OPENAI_API_KEY = "vck_gateway";
+    expect(() => assertAgentCredential("codex", { inSandbox: true })).not.toThrow();
   });
 
   it("passes for pi when AI_GATEWAY_API_KEY is set", () => {

--- a/packages/deepsec/src/__tests__/setup-options.test.ts
+++ b/packages/deepsec/src/__tests__/setup-options.test.ts
@@ -6,6 +6,10 @@ describe("modelRouteFromCli", () => {
     expect(modelRouteFromCli({})).toEqual({ mode: "gateway", provider: "vercel" });
   });
 
+  it("supports local subscriptions with no credential wiring", () => {
+    expect(modelRouteFromCli({ modelAuth: "local" })).toEqual({ mode: "local", provider: "local" });
+  });
+
   it("supports a direct user-owned key", () => {
     expect(
       modelRouteFromCli({

--- a/packages/deepsec/src/auth/ensure-connected-workspace.ts
+++ b/packages/deepsec/src/auth/ensure-connected-workspace.ts
@@ -130,6 +130,29 @@ export async function ensureConnectedWorkspace(
 
   // Link success is not enough: the credential must still be available now.
   assertSandboxCredential({ env });
+
+  if (options.modelRoute.mode === "local") {
+    // Local subscriptions delegate model auth to the machine-wide
+    // claude/codex/pi logins. There is no credential to resolve, apply to
+    // env, or verify — the agent SDK errors clearly at first call if the
+    // machine login is actually missing.
+    const verification: ConnectionVerificationCheckpoint = {
+      project: platform.project,
+      route: options.modelRoute,
+      agentTypes: [...options.agentTypes],
+      modelVerifiedAt: now.toISOString(),
+    };
+    return {
+      platformAuth: { method: platform.method },
+      project: platform.project,
+      modelAuth: options.modelRoute,
+      agentTypes: [...options.agentTypes],
+      modelRouteVerified: false,
+      sandboxReady: true,
+      verification,
+    };
+  }
+
   const resolvedRoutes: ResolvedModelRoute[] = [];
   for (const agentType of options.agentTypes) {
     const resolved = await (deps.resolveRoute ?? resolveModelRoute)(options.modelRoute, {

--- a/packages/deepsec/src/auth/model-route-prompt.ts
+++ b/packages/deepsec/src/auth/model-route-prompt.ts
@@ -13,8 +13,10 @@ export async function promptForModelRoute(): Promise<InteractiveModelChoice> {
     console.log("  1. Vercel AI Gateway using the linked project's identity (recommended)");
     console.log("  2. My OpenAI API key");
     console.log("  3. My Anthropic API key");
+    console.log("  4. Use local subscriptions (claude/codex already logged in on this machine)");
     const answer = (await prompt.question("\nModel access [1]: ")).trim() || "1";
     if (answer === "1") return { route: { mode: "gateway", provider: "vercel" } };
+    if (answer === "4") return { route: { mode: "local", provider: "local" } };
     if (answer !== "2" && answer !== "3") throw new Error("Invalid model access selection");
     const openai = answer === "2";
     const defaultEnv = openai ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";

--- a/packages/deepsec/src/auth/model-route.ts
+++ b/packages/deepsec/src/auth/model-route.ts
@@ -1,6 +1,6 @@
 import { getVercelOidcToken } from "@vercel/oidc";
 
-export type ModelAuthMode = "gateway" | "direct" | "custom";
+export type ModelAuthMode = "gateway" | "direct" | "custom" | "local";
 export type CredentialHeaderScheme = "bearer" | "raw";
 
 export interface ModelRoute {
@@ -97,6 +97,15 @@ export async function resolveModelRoute(
 ): Promise<ResolvedModelRoute> {
   const env = options.env ?? process.env;
   assertCompatible(route, options.agentType);
+
+  if (route.mode === "local") {
+    // Local subscriptions delegate auth to the machine-wide claude/codex/pi
+    // login. There is no env var to read and no header to broker, so this
+    // route can never be resolved — callers must short-circuit before here.
+    throw new Error(
+      "Local-subscription model routes rely on machine-wide agent logins and have no brokered credential",
+    );
+  }
 
   if (route.mode === "gateway") {
     if (route.provider !== "vercel") {

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -96,7 +96,7 @@ program
   .option("--model <model>", "Model for repository analysis and processing")
   .option("--model-profile <profile>", "Benchmark profile: best, value, or budget")
   .option("--thinking-level <level>", "Reasoning effort: minimal, low, medium, high, or xhigh")
-  .option("--model-auth <mode>", "Credential route: gateway, direct, or custom")
+  .option("--model-auth <mode>", "Credential route: gateway, direct, custom, or local")
   .option("--ai-provider <provider>", "Provider for direct/custom credentials")
   .option("--ai-api-key-env <name>", "Environment variable containing a direct/custom API key")
   .option("--ai-base-url <url>", "Direct/custom provider base URL")
@@ -141,6 +141,7 @@ Examples:
   $ npx deepsec init --scaffold-only          # files only; manual legacy flow
   $ npx deepsec init --package-manager npm    # use npm in the isolated workspace
   $ MY_KEY=... npx deepsec init --agent codex --model-auth direct --ai-provider openai --ai-api-key-env MY_KEY
+  $ npx deepsec init --model-auth local       # machine-wide claude/codex logins; no API key
   $ npx deepsec init audits ../my-app         # custom workspace + target
   $ npx deepsec init .deepsec . --id my-app   # override the auto-derived id`,
   )
@@ -190,7 +191,7 @@ program
   .option("--model <model>", "Model for repository analysis and processing")
   .option("--model-profile <profile>", "Benchmark profile: best, value, or budget")
   .option("--thinking-level <level>", "Reasoning effort: minimal, low, medium, high, or xhigh")
-  .option("--model-auth <mode>", "Credential route: gateway, direct, or custom")
+  .option("--model-auth <mode>", "Credential route: gateway, direct, custom, or local")
   .option("--ai-provider <provider>", "Provider for direct/custom credentials")
   .option("--ai-api-key-env <name>", "Environment variable containing a direct/custom API key")
   .option("--ai-base-url <url>", "Direct/custom provider base URL")

--- a/packages/deepsec/src/commands/init.ts
+++ b/packages/deepsec/src/commands/init.ts
@@ -523,7 +523,9 @@ skip completed work. The linked Vercel project is always in Sandbox scope.
 
 Use \`--model-auth direct --ai-provider <provider>
 --ai-api-key-env <ENV_NAME>\` to use a user-owned model credential; secret
-values remain in the environment or \`.env.local\`.
+values remain in the environment or \`.env.local\`. Use \`--model-auth local\`
+to rely on a machine-wide \`claude\`/\`codex\` login instead — no API key or
+env vars needed.
 
 ## Daily commands
 

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -110,6 +110,9 @@ export async function applyConfiguredModelRoute(
   // Preserve the pre-onboarding behavior for cross-agent invocations by
   // falling back to that harness's normal credential discovery.
   if (modelRouteCompatibilityError(route, agentType)) return undefined;
+  // A local-subscription route is an explicit "do nothing": model auth comes
+  // from the machine-wide claude/codex/pi login, so leave env untouched.
+  if (route.mode === "local") return undefined;
   // Older scaffold-only workspaces persisted Gateway as a default even when
   // the user intended to rely on a logged-in Codex/Claude/Pi subscription.
   // With no explicit Gateway credential, leave env untouched and let the
@@ -214,6 +217,15 @@ export function assertAgentCredential(
 ): void {
   if (agentType !== undefined && !KNOWN_BACKENDS.has(agentType)) return;
 
+  // A local-subscription route is the user saying "claude/codex are set up
+  // machine-wide" — skip the env-var checks entirely and let the agent SDK
+  // error clearly at first call if the login is actually missing. Sandboxes
+  // are the exception: they must broker a real token through the firewall,
+  // so fall through to the normal checks (an ambient AI_GATEWAY_API_KEY
+  // still works there, and the standard actionable error fires otherwise).
+  const selectedRoute = options.modelRoute ?? (getConfig()?.ai as ModelRoute | undefined);
+  if (selectedRoute?.mode === "local" && !options.inSandbox) return;
+
   const gateway = process.env.AI_GATEWAY_API_KEY;
   const anthropic = process.env.ANTHROPIC_AUTH_TOKEN;
   const anthropicApi = process.env.ANTHROPIC_API_KEY;
@@ -223,7 +235,7 @@ export function assertAgentCredential(
   // A selected route has already made precedence explicit. In particular,
   // direct Anthropic uses ANTHROPIC_API_KEY and its x-api-key broker contract;
   // ambient Gateway/OIDC must not be considered as a fallback.
-  if (options.modelRoute) {
+  if (options.modelRoute && options.modelRoute.mode !== "local") {
     const keyEnv =
       options.modelRoute.apiKeyEnv ??
       (options.modelRoute.mode === "gateway"

--- a/packages/deepsec/src/setup/options.ts
+++ b/packages/deepsec/src/setup/options.ts
@@ -1,7 +1,7 @@
 import { defaultCredentialHeaderScheme, type ModelRoute } from "../auth/model-route.js";
 
 export interface ModelRouteCliOptions {
-  modelAuth?: "gateway" | "direct" | "custom";
+  modelAuth?: "gateway" | "direct" | "custom" | "local";
   aiProvider?: string;
   aiApiKeyEnv?: string;
   aiBaseUrl?: string;
@@ -11,10 +11,11 @@ export interface ModelRouteCliOptions {
 
 export function modelRouteFromCli(options: ModelRouteCliOptions): ModelRoute {
   const mode = options.modelAuth ?? "gateway";
-  if (mode !== "gateway" && mode !== "direct" && mode !== "custom") {
-    throw new Error("--model-auth must be gateway, direct, or custom");
+  if (mode !== "gateway" && mode !== "direct" && mode !== "custom" && mode !== "local") {
+    throw new Error("--model-auth must be gateway, direct, custom, or local");
   }
   if (mode === "gateway") return { mode, provider: "vercel" };
+  if (mode === "local") return { mode, provider: "local" };
   const provider =
     options.aiProvider ??
     (options.agent === "claude" || options.agent === "claude-agent-sdk"


### PR DESCRIPTION
## What

- **New `local` model route** (`--model-auth local`, or "Use local subscriptions" as option 4 in the interactive model-access prompt). For machines where the `claude`/`codex` CLI is already logged in: setup configures no model credential (nothing resolved, injected, or verified), and runtime preflight (`process`/`revalidate`/`triage`) skips the env-var checks entirely, deferring to the machine-wide login. Sandbox commands are the exception — they must broker a real token through the firewall, so they still require `AI_GATEWAY_API_KEY` (an ambient key works; otherwise the standard actionable error fires). `resolveModelRoute` explicitly refuses a local route so no broker path can reach it by accident.
- **Documents `--scaffold-only`** in `docs/getting-started.md` (what it writes, what it skips, how to resume the automated flow later), plus a "Using local subscriptions" section, models.md/FAQ/CLI-help mentions, and the scaffolded workspace README.

## Tests

- `modelRouteFromCli("local")`, connect-phase short-circuit, resolver refusal, and preflight coverage (route rehydration no-op, env-check skip for all three harnesses, sandbox fall-through with/without ambient key).
- `pnpm -r build` and full `pnpm test:unit` (2368 tests) pass.

Fixes #153
