### PR TITLE
Fix broad crypto and handler matcher candidates

### DIFF
--- a/packages/scanner/src/__tests__/matchers.test.ts
+++ b/packages/scanner/src/__tests__/matchers.test.ts
@@ -49,6 +49,22 @@ describe("missing-auth matcher", () => {
     const matches = missingAuthMatcher.match(content, "src/lib/db.ts");
     expect(matches.length).toBe(0);
   });
+
+  it("flags default exports with request and response parameters", () => {
+    const content = `export default async function handler(req: Request, res: Response) {
+  return res.json({ ok: true });
+}`;
+    const matches = missingAuthMatcher.match(content, "src/handler.ts");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedPattern).toContain("default export handler");
+  });
+
+  it("does not flag ordinary default-exported functions", () => {
+    const content = `export default function formatDescription(value: string) {
+  return value.trim();
+}`;
+    expect(missingAuthMatcher.match(content, "src/format.ts")).toEqual([]);
+  });
 });
 
 describe("xss matcher", () => {
@@ -111,6 +127,17 @@ describe("insecure-crypto matcher", () => {
     const patterns = matches.map((m) => m.matchedPattern);
     expect(patterns.some((p) => p.includes("MD5"))).toBe(true);
     expect(patterns.some((p) => p.includes("Math.random"))).toBe(true);
+  });
+
+  it("requires weak cipher names to be standalone words", () => {
+    const ordinaryCode = `
+      const description = "desktop notification";
+      const desiredWidth = 120;
+    `;
+    expect(insecureCryptoMatcher.match(ordinaryCode, "src/layout.ts")).toEqual([]);
+
+    const weakCipher = `const algorithm = "DES";`;
+    expect(insecureCryptoMatcher.match(weakCipher, "src/crypto.ts")).toHaveLength(1);
   });
 });
 

--- a/packages/scanner/src/matchers/insecure-crypto.ts
+++ b/packages/scanner/src/matchers/insecure-crypto.ts
@@ -28,7 +28,7 @@ export const insecureCryptoMatcher: MatcherPlugin = {
         { regex: /createHash\s*\(\s*['"]md5['"]/, label: "MD5 hash" },
         { regex: /createHash\s*\(\s*['"]sha1['"]/, label: "SHA1 hash" },
         { regex: /createCipher\s*\(/, label: "deprecated createCipher (use createCipheriv)" },
-        { regex: /DES|RC4|Blowfish/i, label: "weak cipher algorithm" },
+        { regex: /\b(?:DES|RC4|Blowfish)\b/i, label: "weak cipher algorithm" },
         { regex: /\bmd5\s*\(/, label: "MD5 function call" },
         {
           regex: /===?\s*.{0,40}\bhmac\b|\bhmac\b.{0,40}===?/,

--- a/packages/scanner/src/matchers/missing-auth.ts
+++ b/packages/scanner/src/matchers/missing-auth.ts
@@ -56,7 +56,8 @@ export const missingAuthMatcher: MatcherPlugin = {
       },
       // Next.js Pages API routes
       {
-        regex: /export\s+default\s+(async\s+)?function/,
+        regex:
+          /export\s+default\s+(async\s+)?function(?:\s+\w+)?\s*\(\s*_?(req|request)\b[^,]*,\s*_?(res|response)\b/,
         label: "default export handler",
       },
       // Express / Fastify / Hono style


### PR DESCRIPTION
## Change
- require DES, RC4, and Blowfish to be standalone cipher names
- require generic default-export handlers to accept request and response parameters
- add regressions for ordinary description/desktop identifiers and ordinary default exports

## Evidence
Deepsec 2.2.9 scanned Alkonos-SAST-Benchmark/notion-next and created 32,712 candidate files / 7,383 process batches. The insecure-crypto matcher alone marked 26,955 files because `/DES|RC4|Blowfish/i` matched `des` inside words such as `description`, `desired`, and `desktop`; 21,204 files had no other candidate. The missing-auth matcher also treated any default-exported function as an HTTP handler.

## Verification
- `npx --yes pnpm@8.15.9 test -- packages/scanner/src/__tests__/matchers.test.ts` (15 passed)
- `git diff --check`