### PR TITLE
Don't let workspace OIDC override a local-subscription model route

### DIFF
--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -24,6 +24,7 @@ import {
   applyConfiguredModelRoute,
   assertAgentCredential,
   assertSandboxCredential,
+  revertAiGatewayDefaultsForLocalRoute,
 } from "../preflight.js";
 
 describe("applyConfiguredModelRoute", () => {
@@ -355,5 +356,82 @@ describe("applyAiGatewayDefaults", () => {
     expect(process.env.AI_GATEWAY_API_KEY).toBe("gw-key");
     expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("gw-key");
     expect(process.env.OPENAI_API_KEY).toBe("gw-key");
+  });
+});
+
+describe("revertAiGatewayDefaultsForLocalRoute", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {
+      AI_GATEWAY_API_KEY: process.env.AI_GATEWAY_API_KEY,
+      VERCEL_OIDC_TOKEN: process.env.VERCEL_OIDC_TOKEN,
+      ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+      OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+    };
+    for (const k of Object.keys(saved)) delete process.env[k];
+  });
+  afterEach(() => {
+    setLoadedConfig({ projects: [] });
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  // Setup writes VERCEL_OIDC_TOKEN into the workspace .env.local, dotenv
+  // loads it on the next command, and without the revert every request
+  // 402/403s at the Gateway instead of using the machine-wide claude login.
+  it("removes the OIDC-derived gateway vars for a local route", async () => {
+    process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
+    const injected = await applyAiGatewayDefaults();
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://ai-gateway.vercel.sh");
+
+    setLoadedConfig({ projects: [], ai: { mode: "local", provider: "local" } });
+    revertAiGatewayDefaultsForLocalRoute(injected);
+
+    expect(process.env.AI_GATEWAY_API_KEY).toBeUndefined();
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+    // `sandbox` still needs the token itself.
+    expect(process.env.VERCEL_OIDC_TOKEN).toBe("oidc-tok");
+  });
+
+  it("keeps values the user set explicitly", async () => {
+    process.env.AI_GATEWAY_API_KEY = "gw-key";
+    process.env.ANTHROPIC_AUTH_TOKEN = "explicit-anthropic";
+    const injected = await applyAiGatewayDefaults();
+
+    setLoadedConfig({ projects: [], ai: { mode: "local", provider: "local" } });
+    revertAiGatewayDefaultsForLocalRoute(injected);
+
+    expect(process.env.AI_GATEWAY_API_KEY).toBe("gw-key");
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("explicit-anthropic");
+    expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it("leaves a gateway route untouched", async () => {
+    process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
+    const injected = await applyAiGatewayDefaults();
+
+    setLoadedConfig({ projects: [], ai: { mode: "gateway", provider: "vercel" } });
+    revertAiGatewayDefaultsForLocalRoute(injected);
+
+    expect(process.env.AI_GATEWAY_API_KEY).toBe("oidc-tok");
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://ai-gateway.vercel.sh");
+  });
+
+  it("leaves a workspace with no configured route untouched", async () => {
+    process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
+    const injected = await applyAiGatewayDefaults();
+
+    setLoadedConfig({ projects: [] });
+    revertAiGatewayDefaultsForLocalRoute(injected);
+
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://ai-gateway.vercel.sh");
   });
 });

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -23,7 +23,7 @@ import { statusCommand } from "./commands/status.js";
 import { triageCommand } from "./commands/triage.js";
 import { loadConfig } from "./load-config.js";
 import { installSandboxOutputCap } from "./output-cap.js";
-import { applyAiGatewayDefaults } from "./preflight.js";
+import { applyAiGatewayDefaults, revertAiGatewayDefaultsForLocalRoute } from "./preflight.js";
 import { modelRouteFromCli } from "./setup/options.js";
 import {
   formatSetupDocumentationHuman,
@@ -583,8 +583,11 @@ async function main() {
   // the per-SDK env vars before any command handler instantiates an agent.
   // Must run before loadConfig in case the user's deepsec.config.ts reads
   // these vars at module load.
-  await applyAiGatewayDefaults();
+  const gatewayDefaults = await applyAiGatewayDefaults();
   await loadConfig();
+  // A local-subscription route delegates model auth to the machine-wide
+  // claude/codex/pi login, so take the gateway vars back out.
+  revertAiGatewayDefaultsForLocalRoute(gatewayDefaults);
   // Plugins may register their own subcommands.
   for (const register of getRegistry().commands) {
     register(program);

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -62,14 +62,17 @@ const OIDC_EXPIRATION_BUFFER_MS = 60 * 60 * 1000;
  * for direct-to-provider access doesn't get silently rerouted.
  *
  * Call this once at CLI startup (after dotenv loads .env.local), before
- * any module reads these vars.
+ * any module reads these vars. Returns the names it set, which is what
+ * `revertAiGatewayDefaultsForLocalRoute` undoes once the route is known.
  */
-export async function applyAiGatewayDefaults(): Promise<void> {
+export async function applyAiGatewayDefaults(): Promise<string[]> {
+  const injected: string[] = [];
   if (!process.env.AI_GATEWAY_API_KEY && process.env.VERCEL_OIDC_TOKEN) {
     try {
       process.env.AI_GATEWAY_API_KEY = await getVercelOidcToken({
         expirationBufferMs: OIDC_EXPIRATION_BUFFER_MS,
       });
+      injected.push("AI_GATEWAY_API_KEY");
     } catch {
       // Refresh failed (token unparseable, network, or the linked project
       // it would refresh against is gone). Fall through — assertAgentCredential
@@ -78,11 +81,40 @@ export async function applyAiGatewayDefaults(): Promise<void> {
     }
   }
   const key = process.env.AI_GATEWAY_API_KEY;
-  if (!key) return;
-  if (!process.env.ANTHROPIC_AUTH_TOKEN) process.env.ANTHROPIC_AUTH_TOKEN = key;
-  if (!process.env.OPENAI_API_KEY) process.env.OPENAI_API_KEY = key;
-  if (!process.env.ANTHROPIC_BASE_URL) process.env.ANTHROPIC_BASE_URL = GATEWAY_ANTHROPIC_BASE_URL;
-  if (!process.env.OPENAI_BASE_URL) process.env.OPENAI_BASE_URL = GATEWAY_OPENAI_BASE_URL;
+  if (!key) return injected;
+  const fill = (name: string, value: string) => {
+    if (process.env[name]) return;
+    process.env[name] = value;
+    injected.push(name);
+  };
+  fill("ANTHROPIC_AUTH_TOKEN", key);
+  fill("OPENAI_API_KEY", key);
+  fill("ANTHROPIC_BASE_URL", GATEWAY_ANTHROPIC_BASE_URL);
+  fill("OPENAI_BASE_URL", GATEWAY_OPENAI_BASE_URL);
+  return injected;
+}
+
+/**
+ * Undo the gateway defaults when the loaded config selects the
+ * local-subscription route.
+ *
+ * The defaults have to be applied before `loadConfig`, so by the time the
+ * route is known the gateway vars are already in env — and the agent SDKs
+ * read `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` straight from there,
+ * routing past the machine-wide login the user selected. Setup writes
+ * `VERCEL_OIDC_TOKEN` into the workspace `.env.local`, so from the second
+ * command onward that happens on every run.
+ *
+ * Only what we injected is removed; values the user set survive.
+ */
+export function revertAiGatewayDefaultsForLocalRoute(
+  injected: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (injected.length === 0) return;
+  const route = getConfig()?.ai as ModelRoute | undefined;
+  if (route?.mode !== "local") return;
+  for (const name of injected) delete env[name];
 }
 
 /**


### PR DESCRIPTION
## What changed

`applyAiGatewayDefaults` now returns the env vars it injected, and `main()` deletes exactly those once the loaded config turns out to select the local-subscription model route.

## Why

`--model-auth local` works exactly once: during the setup run that creates the workspace. Every command after that authenticates against the AI Gateway instead of the local `claude` login, and 403s if the account has no card on file.

Setup ran fine on a Claude Code subscription and finished with `Analysis: claude-opus-4-8 · $40.9925`. The next command, same workspace, nothing changed in between:

```
$ pnpm deepsec revalidate --project-id middleware
  SDK error: Claude Code returned an error result: Failed to authenticate.
  API Error: 403 AI Gateway requires a valid credit card on file to service requests.
  ...
Revalidation complete: 0/81 findings — TP: 0, FP: 0, Fixed: 0, Uncertain: 0, Dupe: 0, 81 UNRESOLVED
```

The config still said what setup had written into it:

```ts
defaultAgent: "claude-agent-sdk", // <deepsec:default-agent>
ai: {"mode":"local","provider":"local"}, // <deepsec:model-route>
```

`main()` calls `applyAiGatewayDefaults()` before `loadConfig()`, on purpose, because a user's `deepsec.config.ts` may read the gateway vars at module load. So the OIDC expansion happens before anything knows which route the workspace selected. Under `mode: "local"` it sets `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN`, the Claude Agent SDK reads those straight out of the environment, and the machine-wide login never gets a look in. `applyConfiguredModelRoute` does handle a local route, but it handles it by returning early, and returning early leaves the injected vars sitting in `process.env`.

What makes it deterministic is the workspace `.env.local`. Setup writes `VERCEL_OIDC_TOKEN` into it, `cli.ts` loads that file with dotenv at module scope, and from then on the OIDC branch fires on every invocation. The first setup run only escapes because the file does not exist yet when the process starts.

Same failure mode as #54, which #56 fixed by gating the OIDC refresh on the env var being present. #139 later started writing that env var into the workspace, which reopened it for the route added in #154.

## Verification

- [x] `pnpm test` passes (2406 passed, 1 skipped, includes the bundle e2e since `cli.ts` is bundled into the publish surface)
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [ ] If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane (n/a, no matcher here)
- [x] `pnpm -r build` passes

Four new tests in `preflight.test.ts`: the revert under a local route, user-set values surviving it, a gateway route left alone, a workspace with no configured route left alone.

The bug itself was reproduced on a real workspace, and confirmed by moving `.deepsec/.env.local` out of the way, after which `revalidate` runs on the local subscription again. The patched behaviour is covered by the unit tests rather than a second live run, since reproducing it end to end means paying for another analysis pass.

## Notes for reviewer

Values the user set themselves never get recorded as injected, so they never get removed. An explicit `ANTHROPIC_AUTH_TOKEN` survives, so does a direct-to-provider `ANTHROPIC_BASE_URL`, and so does `VERCEL_OIDC_TOKEN` itself.

Nothing under `packages/deepsec/src/sandbox/` is touched and `VERCEL_OIDC_TOKEN` is deliberately left in place, so the sandbox credential-brokering path should be unaffected. I did not run the live-sandbox e2e for that reason.

Two things I left alone because they felt like separate PRs. There is no log line saying which credential path got picked, which is most of why this took a while to track down. And a run where every batch failed still prints `Revalidation complete` with a full summary table before the unresolved list, which reads like success at a glance.
