### PR TITLE
Tolerate host mounts where a create is not immediately visible to lookup

### DIFF
--- a/packages/core/src/__tests__/fs-settle.test.ts
+++ b/packages/core/src/__tests__/fs-settle.test.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { existsSettled, mkdirSettled, settleBudgetMs, settleFs } from "../fs-settle.js";
+
+/**
+ * Docker Desktop / virtiofs bind mounts of a macOS host return from a create
+ * syscall before the new entry is visible to path lookup — measured at 1-2ms,
+ * and 100% reproducible inside that window. These tests fake that lag, since
+ * a real non-coherent mount is not available in CI.
+ */
+function enoent(target: string): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error(
+    `ENOENT: no such file or directory, mkdir '${target}'`,
+  );
+  error.code = "ENOENT";
+  return error;
+}
+
+const NO_WAIT = { DEEPSEC_FS_SETTLE_MS: "0" };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fs-settle", () => {
+  // The failure that broke `deepsec init` on a mounted host filesystem:
+  // recursive mkdir creates the parent, then cannot see it when it looks up
+  // the child, and reports `ENOENT: mkdir 'data/<projectId>'` for a path
+  // whose parent it just created.
+  it("mkdirSettled retries a recursive mkdir that fails on its own fresh parent", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "settle-"));
+    const target = path.join(root, "data", "my-project");
+    let calls = 0;
+    const real = fs.mkdirSync;
+    vi.spyOn(fs, "mkdirSync").mockImplementation(((p: string, opts: never) => {
+      calls += 1;
+      if (calls === 1) throw enoent(p);
+      return real(p, opts);
+    }) as typeof fs.mkdirSync);
+    mkdirSettled(target, NO_WAIT);
+    expect(calls).toBe(2);
+    expect(fs.existsSync(target)).toBe(true);
+  });
+
+  it("mkdirSettled creates the directory when nothing lags", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "settle-"));
+    const target = path.join(root, "data", "my-project");
+    mkdirSettled(target, NO_WAIT);
+    expect(fs.existsSync(target)).toBe(true);
+  });
+
+  // A permission error is not a timing problem — retrying just doubles the
+  // wait before reporting the same failure.
+  it("mkdirSettled rethrows a non-ENOENT error without retrying", () => {
+    let calls = 0;
+    vi.spyOn(fs, "mkdirSync").mockImplementation((() => {
+      calls += 1;
+      const error: NodeJS.ErrnoException = new Error("EACCES: permission denied, mkdir '/nope'");
+      error.code = "EACCES";
+      throw error;
+    }) as typeof fs.mkdirSync);
+    expect(() => mkdirSettled("/nope/deeper", NO_WAIT)).toThrow(/EACCES/);
+    expect(calls).toBe(1);
+  });
+
+  it("mkdirSettled surfaces ENOENT when the retry also fails", () => {
+    vi.spyOn(fs, "mkdirSync").mockImplementation(((p: string) => {
+      throw enoent(p);
+    }) as unknown as typeof fs.mkdirSync);
+    expect(() => mkdirSettled("/nope/deeper", NO_WAIT)).toThrow(/ENOENT/);
+  });
+
+  it("existsSettled re-checks a lagging lookup once", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "settle-"));
+    let calls = 0;
+    const real = fs.existsSync;
+    vi.spyOn(fs, "existsSync").mockImplementation((target) => {
+      calls += 1;
+      return calls === 1 ? false : real(target);
+    });
+    expect(existsSettled(dir, NO_WAIT)).toBe(true);
+    expect(calls).toBe(2);
+  });
+
+  it("existsSettled costs one call when the path is already visible", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "settle-"));
+    const spy = vi.spyOn(fs, "existsSync");
+    expect(existsSettled(dir, NO_WAIT)).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("existsSettled reports a genuinely missing path as missing", () => {
+    expect(existsSettled(path.join(os.tmpdir(), "settle-does-not-exist-42"), NO_WAIT)).toBe(false);
+  });
+
+  describe("settleFs", () => {
+    it("waits the configured time", () => {
+      const started = Date.now();
+      settleFs({ DEEPSEC_FS_SETTLE_MS: "40" });
+      expect(Date.now() - started).toBeGreaterThanOrEqual(35);
+    });
+
+    it("returns immediately when the wait is disabled", () => {
+      const started = Date.now();
+      settleFs(NO_WAIT);
+      expect(Date.now() - started).toBeLessThan(20);
+    });
+  });
+
+  describe("settleBudgetMs", () => {
+    it("defaults to 100ms", () => {
+      expect(settleBudgetMs({})).toBe(100);
+    });
+
+    it("honors DEEPSEC_FS_SETTLE_MS for slower sync backends", () => {
+      expect(settleBudgetMs({ DEEPSEC_FS_SETTLE_MS: "500" })).toBe(500);
+    });
+
+    it("allows opting out entirely", () => {
+      expect(settleBudgetMs(NO_WAIT)).toBe(0);
+    });
+
+    it("rejects a nonsense value", () => {
+      expect(() => settleBudgetMs({ DEEPSEC_FS_SETTLE_MS: "soon" })).toThrow(/non-negative number/);
+    });
+  });
+});

--- a/packages/core/src/__tests__/run.test.ts
+++ b/packages/core/src/__tests__/run.test.ts
@@ -202,6 +202,47 @@ describe("ensureProject", () => {
     }
   });
 
+  // Regression: on a Docker/virtiofs bind mount of a macOS host, recursive
+  // mkdir creates `data/`, then cannot see it when it looks up the child, and
+  // reports `ENOENT: mkdir 'data/<projectId>'`. ensureProject must survive it.
+  it("creates the project data dir on a filesystem with a lagging lookup", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-lagging-fs-"));
+    const oldDataRoot = process.env.DEEPSEC_DATA_ROOT;
+    process.env.DEEPSEC_DATA_ROOT = path.join(tmp, "data");
+    const root = path.join(tmp, "project");
+    fs.mkdirSync(root);
+
+    let mkdirCalls = 0;
+    const realMkdir = fs.mkdirSync;
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync").mockImplementation(((
+      target: string,
+      options: never,
+    ) => {
+      mkdirCalls += 1;
+      if (mkdirCalls === 1) {
+        const error: NodeJS.ErrnoException = new Error(
+          `ENOENT: no such file or directory, mkdir '${target}'`,
+        );
+        error.code = "ENOENT";
+        throw error;
+      }
+      return realMkdir(target, options);
+    }) as typeof fs.mkdirSync);
+
+    try {
+      const project = ensureProject("test-project", root);
+      expect(project.projectId).toBe("test-project");
+      expect(mkdirCalls).toBeGreaterThan(1);
+      mkdirSpy.mockRestore();
+      expect(fs.existsSync(path.join(process.env.DEEPSEC_DATA_ROOT, "test-project"))).toBe(true);
+    } finally {
+      mkdirSpy.mockRestore();
+      if (oldDataRoot === undefined) delete process.env.DEEPSEC_DATA_ROOT;
+      else process.env.DEEPSEC_DATA_ROOT = oldDataRoot;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("does not print git errors for non-git roots", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-ensure-project-"));
     const oldDataRoot = process.env.DEEPSEC_DATA_ROOT;

--- a/packages/core/src/fs-settle.ts
+++ b/packages/core/src/fs-settle.ts
@@ -1,0 +1,86 @@
+// Helpers for filesystems where a create syscall returns before the new
+// entry is visible to path lookup.
+//
+// Observed on Docker Desktop / virtiofs bind mounts of a macOS host (the
+// shape most agent sandboxes use): `mkdir`, `writeFile`, and `symlink`
+// return success, but `lstat`/`realpath`/`existsSync` on the path they just
+// created report ENOENT for the next 1-2ms. `open`/`read`/`write` against
+// the same path work immediately — it is the lookup path that lags, not the
+// data. Measured visibility: 0/10 at 0ms, 9/10 at 1ms, 10/10 at 2ms.
+//
+// POSIX says a create is durable when the syscall returns, so code that
+// creates a directory and then stats it is correct and still breaks here.
+// The fix is to wait out the lag.
+//
+// Use these ONLY right after this process created the path. Everywhere else
+// the wait is pure cost: an absent path stays absent no matter how long you
+// wait for it.
+
+import fs from "node:fs";
+
+// 100ms is ~50x the observed virtiofs window. Deliberately a flat wait
+// rather than a poll-until-visible loop: it is a handful of call sites on
+// one code path (workspace scaffolding), and the simplicity is worth more
+// than the milliseconds.
+const DEFAULT_BUDGET_MS = 100;
+
+/**
+ * How long to wait for a create to become visible. Mutagen-based file
+ * sharing (Docker Desktop's "Synchronized file shares") can lag far longer
+ * than virtiofs, so the wait is tunable via `DEEPSEC_FS_SETTLE_MS`. Set it
+ * to 0 on a filesystem you know is coherent.
+ */
+export function settleBudgetMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.DEEPSEC_FS_SETTLE_MS;
+  if (raw === undefined) return DEFAULT_BUDGET_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`DEEPSEC_FS_SETTLE_MS must be a non-negative number, got "${raw}"`);
+  }
+  return parsed;
+}
+
+/**
+ * Wait out the mount's create-to-lookup lag.
+ *
+ * Every caller here is synchronous (`ensureProject`, workspace
+ * scaffolding), so a timer is not an option; `Atomics.wait` on an
+ * uncontended buffer parks the thread instead of spinning the CPU.
+ */
+export function settleFs(env?: NodeJS.ProcessEnv): void {
+  const ms = settleBudgetMs(env);
+  if (ms <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * `fs.existsSync` for a path another process just created — a "false" is
+ * re-checked once after settling.
+ */
+export function existsSettled(target: string, env?: NodeJS.ProcessEnv): boolean {
+  if (fs.existsSync(target)) return true;
+  settleFs(env);
+  return fs.existsSync(target);
+}
+
+/**
+ * Recursive `mkdir` that leaves the directory visible to path lookup when
+ * it returns.
+ *
+ * Node's recursive mkdir walks the path creating each missing component,
+ * and on a lagging mount the freshly created parent can still be invisible
+ * when it looks up the child — which surfaces as
+ * `ENOENT: mkdir '<parent>/<child>'` for a path whose parent was just
+ * created successfully. So ENOENT here means "too early", not "missing":
+ * settle and try once more.
+ */
+export function mkdirSettled(target: string, env?: NodeJS.ProcessEnv): void {
+  try {
+    fs.mkdirSync(target, { recursive: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    settleFs(env);
+    fs.mkdirSync(target, { recursive: true });
+  }
+  settleFs(env);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./config.js";
 export * from "./finding-id.js";
+export * from "./fs-settle.js";
 export * from "./paths.js";
 export * from "./plugin.js";
 export * from "./run.js";

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { ensureFindingIds } from "./finding-id.js";
+import { mkdirSettled } from "./fs-settle.js";
 import {
   dataDir,
   fileRecordPath,
@@ -85,7 +86,7 @@ export function ensureProject(projectId: string, rootPath: string): ProjectConfi
     createdAt: new Date().toISOString(),
     githubUrl: detectGithubUrl(path.resolve(rootPath)),
   };
-  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  mkdirSettled(path.dirname(configPath));
   writeProjectConfig(configPath, config);
   return config;
 }

--- a/packages/deepsec/src/__tests__/setup-install.test.ts
+++ b/packages/deepsec/src/__tests__/setup-install.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
-import { selectPackageManager } from "../setup/install.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { probeWorkspaceInstall, selectPackageManager } from "../setup/install.js";
 
 describe("setup package-manager selection", () => {
   it("falls back to npm when a preferred pnpm is unavailable", () => {
@@ -19,5 +19,54 @@ describe("setup package-manager selection", () => {
     expect(() => selectPackageManager(workspace, "pnpm", () => false)).toThrow(
       "Requested package manager pnpm is not available on PATH",
     );
+  });
+});
+
+describe("post-install workspace probe", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function installedWorkspace(): string {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-install-"));
+    const installed = path.join(workspace, "node_modules", "deepsec", "dist");
+    fs.mkdirSync(installed, { recursive: true });
+    fs.writeFileSync(
+      path.join(workspace, "node_modules", "deepsec", "package.json"),
+      JSON.stringify({ version: "1.2.3" }),
+    );
+    fs.writeFileSync(path.join(installed, "cli.mjs"), "");
+    fs.writeFileSync(path.join(installed, "config.mjs"), "");
+    return workspace;
+  }
+
+  // The installer is a child process that just wrote node_modules, so on a
+  // non-coherent mount the probe that follows it can still see nothing there
+  // and report "workspace is unusable" for a perfectly good install.
+  function lagFirstLookup(): void {
+    let calls = 0;
+    const real = fs.existsSync;
+    vi.spyOn(fs, "existsSync").mockImplementation((target) => {
+      calls += 1;
+      return calls === 1 ? false : real(target);
+    });
+  }
+
+  it("tolerates a lagging lookup right after the installer exits", () => {
+    const workspace = installedWorkspace();
+    vi.stubEnv("DEEPSEC_FS_SETTLE_MS", "0");
+    lagFirstLookup();
+    expect(probeWorkspaceInstall(workspace, { settle: true })).toEqual({
+      ok: true,
+      version: "1.2.3",
+    });
+  });
+
+  it("does not wait out a genuinely missing install", () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-install-"));
+    expect(probeWorkspaceInstall(workspace)).toEqual({
+      ok: false,
+      reason: "node_modules/deepsec is missing",
+    });
   });
 });

--- a/packages/deepsec/src/commands/init-project.ts
+++ b/packages/deepsec/src/commands/init-project.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { dataDir, ensureProject } from "@deepsec/core";
+import { dataDir, ensureProject, mkdirSettled } from "@deepsec/core";
 import { BOLD, CYAN, DIM, GREEN, RESET, YELLOW } from "../formatters.js";
 import { requireExistingDir } from "../require-dir.js";
 import { validateProjectId } from "../resolve-project-id.js";
@@ -90,7 +90,7 @@ export function registerProject(opts: {
     process.chdir(workspaceDir);
     ensureProject(id, targetAbs);
     const projectDir = dataDir(id);
-    fs.mkdirSync(projectDir, { recursive: true });
+    mkdirSettled(projectDir);
     const infoMdPath = path.join(projectDir, "INFO.md");
     if (!fs.existsSync(infoMdPath) || opts.force) {
       fs.writeFileSync(infoMdPath, infoMdTemplate(id));

--- a/packages/deepsec/src/commands/init.ts
+++ b/packages/deepsec/src/commands/init.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { ensureProject } from "@deepsec/core";
+import { ensureProject, mkdirSettled } from "@deepsec/core";
 import {
   type ModelProfile,
   parseModelProfile,
@@ -158,7 +158,7 @@ export async function initCommand(opts: InitOpts) {
   }
 
   // Workspace skeleton: empty config (with marker), README, AGENTS, env.
-  fs.mkdirSync(workspaceDir, { recursive: true });
+  mkdirSettled(workspaceDir);
   writeFile(
     workspaceDir,
     "package.json",

--- a/packages/deepsec/src/setup/coordinator.ts
+++ b/packages/deepsec/src/setup/coordinator.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   dataDir,
+  existsSettled,
   type FileRecord,
   getRegistry,
   loadAllFileRecords,
@@ -406,8 +407,10 @@ export async function runSetupWorkflow(
     const installInput = installFingerprint(workspaceDir);
     let installResult: Awaited<ReturnType<typeof ensureWorkspaceInstall>>;
     if (
+      // The installer is a child process that just finished writing this
+      // tree, so a lagging mount can still report it missing.
       !isCheckpointCurrent(state, "install", installInput, () =>
-        fs.existsSync("node_modules/deepsec"),
+        existsSettled("node_modules/deepsec"),
       )
     ) {
       installResult = await runPhase(state, reporter, "install", installInput, () =>

--- a/packages/deepsec/src/setup/install.ts
+++ b/packages/deepsec/src/setup/install.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { existsSettled } from "@deepsec/core";
 import { createTerminalLineDecoder, packageInstallProgress } from "./output.js";
 
 export type SupportedPackageManager = "pnpm" | "npm";
@@ -42,17 +43,26 @@ export function selectPackageManager(
   throw new Error("Deepsec requires pnpm or npm, but neither command is available on PATH");
 }
 
-export function probeWorkspaceInstall(workspaceDir: string): {
+export function probeWorkspaceInstall(
+  workspaceDir: string,
+  // Set when the installer child just wrote this tree: a lagging mount can
+  // report the files it created as missing for another millisecond or two, so
+  // a miss is re-checked after settling instead of failing the install. Left
+  // off for the pre-install probe, where an absent node_modules is the normal
+  // case and waiting on it is pure cost.
+  options: { settle?: boolean } = {},
+): {
   ok: boolean;
   version?: string;
   reason?: string;
 } {
+  const exists = options.settle ? existsSettled : fs.existsSync;
   const packageFile = path.join(workspaceDir, "node_modules", "deepsec", "package.json");
-  if (!fs.existsSync(packageFile)) return { ok: false, reason: "node_modules/deepsec is missing" };
+  if (!exists(packageFile)) return { ok: false, reason: "node_modules/deepsec is missing" };
   try {
     const pkg = JSON.parse(fs.readFileSync(packageFile, "utf8"));
     for (const relative of ["dist/cli.mjs", "dist/config.mjs"]) {
-      if (!fs.existsSync(path.join(workspaceDir, "node_modules", "deepsec", relative))) {
+      if (!exists(path.join(workspaceDir, "node_modules", "deepsec", relative))) {
         return { ok: false, reason: `deepsec/${relative} is missing` };
       }
     }
@@ -125,7 +135,7 @@ export async function ensureWorkspaceInstall(params: {
       `${packageManager} install failed with exit ${result.status ?? "unknown"}; see the setup log for package-manager output`,
     );
   }
-  const after = probeWorkspaceInstall(workspaceDir);
+  const after = probeWorkspaceInstall(workspaceDir, { settle: true });
   if (!after.ok) throw new Error(`Install completed but workspace is unusable: ${after.reason}`);
   params.onProgress?.({ message: `Installed deepsec ${after.version}` });
   return { packageManager, version: after.version!, installed: true };


### PR DESCRIPTION
On a Docker Desktop / virtiofs bind mount of a macOS host, mkdir,
writeFile, and symlink return success but lstat/realpath/existsSync on
the path they just created report ENOENT for the next 1-2ms. open, read,
and write on that path work immediately -- the lookup path lags, not the
data. Measured visibility after mkdir: 0/10 at 0ms, 9/10 at 1ms, 10/10 at
2ms. Sandboxed agent environments commonly mount the workspace this way.

deepsec assumed POSIX durability-on-return in a few places, so init
failed with "ENOENT: no such file or directory, mkdir 'data/<projectId>'"
-- recursive mkdir creates data/, then cannot see it when it looks up the
child.

Adds settleFs, existsSettled, and mkdirSettled: a flat 100ms wait after
creating a path, tunable via DEEPSEC_FS_SETTLE_MS (0 opts out). Not a
poll-until-visible loop -- this is a handful of call sites on one code
path, and the simplicity is worth more than the milliseconds. mkdirSettled
retries the mkdir once on ENOENT, since that is where the failure
surfaces; any other errno is a real error and is rethrown untouched.

Used only where this process just created the path: ensureProject's data
dir, the init workspace dir, init-project's data dir, and the post-install
node_modules probe. Resume detection, atomic-file temp cleanup, and the
mkdir lock primitive are left alone -- those paths were created by an
earlier process or are legitimately absent most of the time, where
waiting is pure cost.

Refs #159

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
