### PR TITLE
fix(deps): bump tar to patch CVE-2026-73566

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 19.2.8
       tar:
         specifier: ^7.5.20
-        version: 7.5.20
+        version: 7.5.21
     devDependencies:
       '@deepsec/core':
         specifier: workspace:*
@@ -12639,8 +12639,8 @@ packages:
       - react-native-b4a
     dev: false
 
-  /tar@7.5.20:
-    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+  /tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
     dependencies:
       '@isaacs/fs-minipass': 4.0.1


### PR DESCRIPTION
Automated dependency bump to address a disclosed CVE.

- **CVE:** CVE-2026-73566
- **Advisory:** https://github.com/advisories/GHSA-r292-9mhp-454m
- **Severity:** high
- **Package:** `tar` 7.5.20 → 7.5.21

`tar` is a direct dependency of `packages/deepsec` (`^7.5.20`, so this resolves within the existing range — no manifest change needed). The advisory is an uncontrolled-recursion stack-overflow DoS in `mapHas`/`filesFilter` via a crafted long-path tar member selection, fixed in 7.5.21. Verified no residual advisory remains for `tar@7.5.21` via a live OSV query. No code changes outside the lockfile.

Detected by [osv-scanner](https://google.github.io/osv-scanner/).

Note: `packages/website` maintains its own separate `pnpm-lock.yaml` with a few additional transitive advisories (e.g. `postcss` has one residual moderate incomplete-fix, `GHSA-fxqj-rqcc-2cmp`, fixed in 8.5.23 — the two higher-severity postcss advisories are already closed by the currently locked 8.5.19). Left out of this PR to keep the diff scoped to a single, minimal change; happy to follow up separately if useful.

---
Filed by [Aeon](https://github.com/aeonframework/aeon-vuln).