### PR TITLE
Honor local subscription routes with workspace OIDC

### DIFF
--- a/packages/deepsec/package.json
+++ b/packages/deepsec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepsec",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "AI-powered vulnerability scanner for any codebase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/deepsec/src/__tests__/preflight.test.ts
+++ b/packages/deepsec/src/__tests__/preflight.test.ts
@@ -24,6 +24,7 @@ import {
   applyConfiguredModelRoute,
   assertAgentCredential,
   assertSandboxCredential,
+  reconcileAiGatewayDefaultsForRoute,
 } from "../preflight.js";
 
 describe("applyConfiguredModelRoute", () => {
@@ -284,6 +285,7 @@ describe("applyAiGatewayDefaults", () => {
       if (v === undefined) delete process.env[k];
       else process.env[k] = v;
     }
+    setLoadedConfig({ projects: [] });
   });
 
   it("does nothing when AI_GATEWAY_API_KEY is unset", async () => {
@@ -355,5 +357,61 @@ describe("applyAiGatewayDefaults", () => {
     expect(process.env.AI_GATEWAY_API_KEY).toBe("gw-key");
     expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("gw-key");
     expect(process.env.OPENAI_API_KEY).toBe("gw-key");
+  });
+
+  it("removes unchanged OIDC-derived defaults for a configured local route", async () => {
+    process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
+    await applyAiGatewayDefaults();
+    setLoadedConfig({ projects: [], ai: { mode: "local", provider: "local" } });
+
+    await applyConfiguredModelRoute("codex");
+
+    expect(process.env.VERCEL_OIDC_TOKEN).toBe("oidc-tok");
+    expect(process.env.AI_GATEWAY_API_KEY).toBeUndefined();
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it("preserves values changed after startup while reconciling a local route", async () => {
+    process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
+    await applyAiGatewayDefaults();
+    process.env.OPENAI_API_KEY = "user-openai-key";
+    process.env.ANTHROPIC_BASE_URL = "https://api.anthropic.com";
+
+    reconcileAiGatewayDefaultsForRoute({ mode: "local", provider: "local" });
+
+    expect(process.env.OPENAI_API_KEY).toBe("user-openai-key");
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://api.anthropic.com");
+    expect(process.env.AI_GATEWAY_API_KEY).toBeUndefined();
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+  });
+
+  it("keeps OIDC-derived defaults for Gateway and local-route sandbox runs", async () => {
+    process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
+    await applyAiGatewayDefaults();
+
+    reconcileAiGatewayDefaultsForRoute({ mode: "gateway", provider: "vercel" });
+    reconcileAiGatewayDefaultsForRoute({ mode: "local", provider: "local" }, { inSandbox: true });
+
+    expect(process.env.AI_GATEWAY_API_KEY).toBe("oidc-tok");
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe("oidc-tok");
+    expect(process.env.OPENAI_API_KEY).toBe("oidc-tok");
+    expect(process.env.ANTHROPIC_BASE_URL).toBe("https://ai-gateway.vercel.sh");
+    expect(process.env.OPENAI_BASE_URL).toBe("https://ai-gateway.vercel.sh/v1");
+  });
+
+  it("preserves OIDC-derived credentials when a configured local route runs in a sandbox", async () => {
+    process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
+    await applyAiGatewayDefaults();
+    setLoadedConfig({ projects: [], ai: { mode: "local", provider: "local" } });
+
+    await applyConfiguredModelRoute("codex", process.env, { inSandbox: true });
+
+    expect(process.env.AI_GATEWAY_API_KEY).toBe("oidc-tok");
+    expect(process.env.OPENAI_API_KEY).toBe("oidc-tok");
+    expect(() => assertAgentCredential("codex", { inSandbox: true })).not.toThrow();
   });
 });

--- a/packages/deepsec/src/__tests__/setup-coordinator.test.ts
+++ b/packages/deepsec/src/__tests__/setup-coordinator.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { defineConfig, type FileRecord, setLoadedConfig } from "@deepsec/core";
 import type { DeclarativeMatcherSpec } from "@deepsec/scanner";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyAiGatewayDefaults } from "../preflight.js";
 import { runSetupWorkflow, type SetupWorkflowOptions } from "../setup/coordinator.js";
 import { writeGeneratedMatchers } from "../setup/generated-matchers.js";
 import {
@@ -16,6 +17,75 @@ const originalCwd = process.cwd();
 afterEach(() => process.chdir(originalCwd));
 
 describe("one-shot setup coordinator", () => {
+  it("honors a local route selected during setup despite ambient workspace OIDC", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-local-route-"));
+    const workspace = path.join(root, ".deepsec");
+    const project = path.join(root, "app");
+    fs.mkdirSync(path.join(workspace, "data", "app"), { recursive: true });
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(path.join(workspace, "package.json"), '{"private":true}\n');
+    fs.writeFileSync(
+      path.join(workspace, "deepsec.config.ts"),
+      `const defineConfig = <T>(config: T): T => config;\nexport default defineConfig({ projects: [{ id: "app", root: "../app" }] });\n`,
+    );
+    fs.writeFileSync(
+      path.join(workspace, "generated-matchers.ts"),
+      `export const generatedMatchersPlugin = { name: "generated", matchers: [] };\n`,
+    );
+
+    const names = [
+      "VERCEL_OIDC_TOKEN",
+      "AI_GATEWAY_API_KEY",
+      "ANTHROPIC_AUTH_TOKEN",
+      "OPENAI_API_KEY",
+      "ANTHROPIC_BASE_URL",
+      "OPENAI_BASE_URL",
+    ];
+    const saved = Object.fromEntries(names.map((name) => [name, process.env[name]]));
+    for (const name of names) delete process.env[name];
+
+    try {
+      process.env.VERCEL_OIDC_TOKEN = "oidc-tok";
+      await applyAiGatewayDefaults();
+
+      await runSetupWorkflow({
+        workspaceDir: workspace,
+        projectId: "app",
+        projectRoot: project,
+        agent: "codex",
+        modelRoute: { mode: "local", provider: "local" },
+        through: "login",
+        services: {
+          install: async () => {
+            fs.mkdirSync(path.join(workspace, "node_modules", "deepsec"), { recursive: true });
+            return { packageManager: "npm", version: "test", installed: true };
+          },
+          connect: async () => {
+            expect(process.env.VERCEL_OIDC_TOKEN).toBe("oidc-tok");
+            expect(process.env.AI_GATEWAY_API_KEY).toBeUndefined();
+            expect(process.env.OPENAI_API_KEY).toBeUndefined();
+            expect(process.env.OPENAI_BASE_URL).toBeUndefined();
+            return {
+              verification: { route: { mode: "local", provider: "local" } },
+            };
+          },
+        },
+        onLog: () => undefined,
+      });
+
+      expect(fs.readFileSync(path.join(workspace, "deepsec.config.ts"), "utf8")).toContain(
+        'ai: {"mode":"local","provider":"local"}',
+      );
+    } finally {
+      for (const [name, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+      setLoadedConfig({ projects: [] });
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("short-circuits completed install, login, analysis, scan, and process phases", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-one-shot-"));
     const workspace = path.join(root, ".deepsec");

--- a/packages/deepsec/src/commands/sandbox-all.ts
+++ b/packages/deepsec/src/commands/sandbox-all.ts
@@ -97,7 +97,7 @@ export async function sandboxAllCommand(
   const explicitAiBaseUrl = extractFlag(passthrough, "--ai-base-url");
   const resolvedRoute =
     !explicitAiApiKeyEnv && !explicitAiBaseUrl
-      ? await applyConfiguredModelRoute(agentType)
+      ? await applyConfiguredModelRoute(agentType, process.env, { inSandbox: true })
       : undefined;
 
   // Same preflight as sandbox-process — fail fast before fanning out.

--- a/packages/deepsec/src/commands/sandbox-process.ts
+++ b/packages/deepsec/src/commands/sandbox-process.ts
@@ -149,7 +149,9 @@ export async function sandboxCommand(subcommand: string, opts: SandboxOpts) {
   const config = buildConfig(subcommand as SandboxSubcommand, projectId, opts);
 
   if (!config.aiApiKeyEnv && !config.aiBaseUrl) {
-    const resolved = await applyConfiguredModelRoute(config.agentType ?? "codex");
+    const resolved = await applyConfiguredModelRoute(config.agentType ?? "codex", process.env, {
+      inSandbox: true,
+    });
     config.brokeredModelCredential = resolved?.broker;
     config.aiBaseUrl = resolved?.route.baseUrl;
   }

--- a/packages/deepsec/src/preflight.ts
+++ b/packages/deepsec/src/preflight.ts
@@ -39,6 +39,17 @@ const GATEWAY_OPENAI_BASE_URL = "https://ai-gateway.vercel.sh/v1";
 // and the gateway will 401 the moment the JWT lapses.
 const OIDC_EXPIRATION_BUFFER_MS = 60 * 60 * 1000;
 
+// Keep provenance for values synthesized during CLI startup. A later local
+// subscription selection needs to undo only this ambient Gateway expansion,
+// never values the user supplied or changed themselves.
+const injectedAiGatewayDefaults = new Map<string, string>();
+
+function injectAiGatewayDefault(name: string, value: string): void {
+  if (process.env[name]) return;
+  process.env[name] = value;
+  injectedAiGatewayDefaults.set(name, value);
+}
+
 /**
  * If the user set `AI_GATEWAY_API_KEY`, expand it into the four env vars
  * the agent SDKs actually read. Lets a user run with a single token
@@ -65,11 +76,15 @@ const OIDC_EXPIRATION_BUFFER_MS = 60 * 60 * 1000;
  * any module reads these vars.
  */
 export async function applyAiGatewayDefaults(): Promise<void> {
+  for (const [name, injectedValue] of injectedAiGatewayDefaults) {
+    if (process.env[name] !== injectedValue) injectedAiGatewayDefaults.delete(name);
+  }
   if (!process.env.AI_GATEWAY_API_KEY && process.env.VERCEL_OIDC_TOKEN) {
     try {
-      process.env.AI_GATEWAY_API_KEY = await getVercelOidcToken({
+      const key = await getVercelOidcToken({
         expirationBufferMs: OIDC_EXPIRATION_BUFFER_MS,
       });
+      injectAiGatewayDefault("AI_GATEWAY_API_KEY", key);
     } catch {
       // Refresh failed (token unparseable, network, or the linked project
       // it would refresh against is gone). Fall through — assertAgentCredential
@@ -79,10 +94,27 @@ export async function applyAiGatewayDefaults(): Promise<void> {
   }
   const key = process.env.AI_GATEWAY_API_KEY;
   if (!key) return;
-  if (!process.env.ANTHROPIC_AUTH_TOKEN) process.env.ANTHROPIC_AUTH_TOKEN = key;
-  if (!process.env.OPENAI_API_KEY) process.env.OPENAI_API_KEY = key;
-  if (!process.env.ANTHROPIC_BASE_URL) process.env.ANTHROPIC_BASE_URL = GATEWAY_ANTHROPIC_BASE_URL;
-  if (!process.env.OPENAI_BASE_URL) process.env.OPENAI_BASE_URL = GATEWAY_OPENAI_BASE_URL;
+  injectAiGatewayDefault("ANTHROPIC_AUTH_TOKEN", key);
+  injectAiGatewayDefault("OPENAI_API_KEY", key);
+  injectAiGatewayDefault("ANTHROPIC_BASE_URL", GATEWAY_ANTHROPIC_BASE_URL);
+  injectAiGatewayDefault("OPENAI_BASE_URL", GATEWAY_OPENAI_BASE_URL);
+}
+
+/**
+ * Stop ambient OIDC from overriding an explicit local-subscription route.
+ * Sandbox commands are intentionally exempt: local machine credentials are
+ * unavailable in the worker, so the startup-expanded token must be brokered.
+ */
+export function reconcileAiGatewayDefaultsForRoute(
+  route: ModelRoute,
+  options: { env?: NodeJS.ProcessEnv; inSandbox?: boolean } = {},
+): void {
+  if (route.mode !== "local" || options.inSandbox) return;
+  const env = options.env ?? process.env;
+  for (const [name, injectedValue] of injectedAiGatewayDefaults) {
+    // A value changed since startup belongs to the user or selected route.
+    if (env[name] === injectedValue) delete env[name];
+  }
 }
 
 /**
@@ -103,6 +135,7 @@ export async function applySelectedModelRoute(
 export async function applyConfiguredModelRoute(
   agentType: string,
   env: NodeJS.ProcessEnv = process.env,
+  options: { inSandbox?: boolean } = {},
 ): Promise<ResolvedModelRoute | undefined> {
   const route = getConfig()?.ai as ModelRoute | undefined;
   if (!route) return undefined;
@@ -110,9 +143,13 @@ export async function applyConfiguredModelRoute(
   // Preserve the pre-onboarding behavior for cross-agent invocations by
   // falling back to that harness's normal credential discovery.
   if (modelRouteCompatibilityError(route, agentType)) return undefined;
-  // A local-subscription route is an explicit "do nothing": model auth comes
-  // from the machine-wide claude/codex/pi login, so leave env untouched.
-  if (route.mode === "local") return undefined;
+  // Local model auth comes from the machine-wide claude/codex/pi login. Undo
+  // ambient Gateway values synthesized from OIDC, except in sandboxes where
+  // the token still has to be brokered into the remote worker.
+  if (route.mode === "local") {
+    reconcileAiGatewayDefaultsForRoute(route, { env, inSandbox: options.inSandbox });
+    return undefined;
+  }
   // Older scaffold-only workspaces persisted Gateway as a default even when
   // the user intended to rely on a logged-in Codex/Claude/Pi subscription.
   // With no explicit Gateway credential, leave env untouched and let the

--- a/packages/deepsec/src/setup/coordinator.ts
+++ b/packages/deepsec/src/setup/coordinator.ts
@@ -28,6 +28,7 @@ import {
 } from "../auth/ensure-connected-workspace.js";
 import type { ModelRoute } from "../auth/model-route.js";
 import { loadConfig } from "../load-config.js";
+import { reconcileAiGatewayDefaultsForRoute } from "../preflight.js";
 import { resolveAgentType } from "../resolve-agent-type.js";
 import {
   type CoverageReport,
@@ -443,6 +444,7 @@ export async function runSetupWorkflow(
         mode: "gateway",
         provider: "vercel",
       };
+    reconcileAiGatewayDefaultsForRoute(route);
     const agentConfig = buildAgentConfig({ model, thinkingLevel, modelRoute: route });
     reconcileWorkspaceConfig(workspaceDir, route, agentType, model, thinkingLevel);
 


### PR DESCRIPTION
## Summary

- track the exact AI Gateway environment values synthesized from workspace OIDC at CLI startup
- remove only unchanged synthesized values when the effective model route is local, including a route selected during the current setup run
- preserve OIDC-expanded credentials for sandbox commands, where local machine logins are unavailable
- preserve explicit or subsequently changed user environment values

This is a separate implementation of the behavior discussed in #157. Reconciliation is route-aware instead of global, so local host execution cannot be redirected to AI Gateway while sandbox credential brokering continues to work.

## Tests

- pnpm --filter deepsec build
- biome check .
- vitest run --project cli (237 tests)
- pnpm bundle
- vitest run --project e2e e2e/bundle.test.ts (29 tests)