### PR TITLE
Ensure local agent configuration is respected on #157

### DIFF
--- a/packages/deepsec/src/__tests__/ensure-connected-workspace.test.ts
+++ b/packages/deepsec/src/__tests__/ensure-connected-workspace.test.ts
@@ -75,9 +75,14 @@ describe("ensureConnectedWorkspace", () => {
     expect(result.sandboxReady).toBe(true);
   });
 
-  it("skips credential resolution and verification for a local-subscription route", async () => {
+  it("skips the platform link, credential resolution and verification for a local route", async () => {
     const resolveRoute = vi.fn(async () => resolved());
     const verifyModelRoute = vi.fn(async () => undefined);
+    const ensureLink = vi.fn(async () => ({
+      method: "access-token-triple" as const,
+      project: { teamId: "team", projectId: "project" },
+      link: { orgId: "team", projectId: "project" },
+    }));
     const localRoute = { mode: "local", provider: "local" } as const;
     const env = { VERCEL_TOKEN: "v", VERCEL_TEAM_ID: "team", VERCEL_PROJECT_ID: "project" };
     const result = await ensureConnectedWorkspace({
@@ -87,16 +92,14 @@ describe("ensureConnectedWorkspace", () => {
       agentTypes: ["claude-agent-sdk"],
       env,
       dependencies: {
-        ensureLink: async () => ({
-          method: "access-token-triple",
-          project: { teamId: "team", projectId: "project" },
-          link: { orgId: "team", projectId: "project" },
-        }),
+        ensureLink,
         resolveRoute,
         verifyModelRoute,
         now: () => new Date("2026-01-01T00:00:00Z"),
       },
     });
+    expect(ensureLink).not.toHaveBeenCalled();
+    expect(result.project).toBeUndefined();
     expect(resolveRoute).not.toHaveBeenCalled();
     expect(verifyModelRoute).not.toHaveBeenCalled();
     expect(result.modelAuth).toEqual(localRoute);

--- a/packages/deepsec/src/__tests__/setup-persisted-route.test.ts
+++ b/packages/deepsec/src/__tests__/setup-persisted-route.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { persistedModelRoute, recordInitialModelRoute } from "../setup/persisted-route.js";
+import {
+  persistWorkspaceConfigRoute,
+  readWorkspaceConfigRoute,
+} from "../setup/workspace-config.js";
+
+const LOCAL = { mode: "local" as const, provider: "local" };
+
+function workspace(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-route-"));
+  fs.writeFileSync(
+    path.join(dir, "deepsec.config.ts"),
+    "export default defineConfig({\n  projects: [],\n});\n",
+  );
+  return dir;
+}
+
+function writeConnectionCheckpoint(dir: string, projectId: string, route: unknown): void {
+  const setupDir = path.join(dir, "data", projectId, "setup");
+  fs.mkdirSync(setupDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(setupDir, "setup-state.json"),
+    JSON.stringify({
+      version: 1,
+      projectId,
+      targetRoot: dir,
+      phases: {},
+      matcherAttempts: [],
+      agent: { type: "claude-agent-sdk", model: "claude-opus-5" },
+      connection: { route },
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+}
+
+describe("recordInitialModelRoute", () => {
+  it("records a flag-supplied route, so an interrupt before install cannot lose it", () => {
+    // `--model-auth local` is not repeated on resume, and setup writes its own
+    // checkpoint only after login. Without this write, resuming an interrupted
+    // run falls back to the gateway default.
+    const dir = workspace();
+    recordInitialModelRoute(dir, LOCAL);
+
+    expect(persistedModelRoute(dir, "app")).toEqual(LOCAL);
+  });
+
+  it("leaves the recorded route alone for a resumed run, which carries none", () => {
+    const dir = workspace();
+    recordInitialModelRoute(dir, LOCAL);
+    recordInitialModelRoute(dir, undefined);
+
+    expect(readWorkspaceConfigRoute(dir)).toEqual(LOCAL);
+  });
+});
+
+describe("persistedModelRoute", () => {
+  it("reuses a local route persisted before the login checkpoint", () => {
+    // Setup interrupted after the route prompt but before login: there is no
+    // connection checkpoint, so init must not fall back to prompting for the
+    // Vercel link or to the gateway route.
+    const dir = workspace();
+    persistWorkspaceConfigRoute(dir, LOCAL);
+
+    expect(readWorkspaceConfigRoute(dir)).toEqual(LOCAL);
+    expect(persistedModelRoute(dir, "app")).toEqual(LOCAL);
+  });
+
+  it("prefers the login checkpoint over the config route", () => {
+    const dir = workspace();
+    persistWorkspaceConfigRoute(dir, LOCAL);
+    writeConnectionCheckpoint(dir, "app", { mode: "gateway", provider: "vercel" });
+
+    expect(persistedModelRoute(dir, "app")).toEqual({ mode: "gateway", provider: "vercel" });
+  });
+
+  it("returns undefined when no route was recorded", () => {
+    const dir = workspace();
+
+    expect(readWorkspaceConfigRoute(dir)).toBeUndefined();
+    expect(persistedModelRoute(dir, "app")).toBeUndefined();
+    expect(persistedModelRoute(path.join(dir, "missing"), "app")).toBeUndefined();
+  });
+
+  it("ignores an unparseable route line", () => {
+    const dir = workspace();
+    persistWorkspaceConfigRoute(dir, LOCAL);
+    const file = path.join(dir, "deepsec.config.ts");
+    fs.writeFileSync(
+      file,
+      fs
+        .readFileSync(file, "utf8")
+        .replace(/ai: .*<deepsec:model-route>/, "ai: local, // <deepsec:model-route>"),
+    );
+
+    expect(readWorkspaceConfigRoute(dir)).toBeUndefined();
+  });
+
+  it("keeps a single route line when setup later reconciles the config", () => {
+    const dir = workspace();
+    persistWorkspaceConfigRoute(dir, LOCAL);
+    persistWorkspaceConfigRoute(dir, LOCAL);
+
+    const source = fs.readFileSync(path.join(dir, "deepsec.config.ts"), "utf8");
+    expect(source.match(/<deepsec:model-route>/g)).toHaveLength(1);
+  });
+});

--- a/packages/deepsec/src/auth/ensure-connected-workspace.ts
+++ b/packages/deepsec/src/auth/ensure-connected-workspace.ts
@@ -17,7 +17,8 @@ import {
 } from "./vercel-link.js";
 
 export interface ConnectionVerificationCheckpoint {
-  project: { teamId: string; projectId: string };
+  /** Absent for local-subscription routes, which never link a project. */
+  project?: { teamId: string; projectId: string };
   route: ModelRoute;
   agentTypes: string[];
   modelVerifiedAt: string;
@@ -28,10 +29,11 @@ export interface ConnectionVerificationCheckpoint {
 }
 
 export interface LoginResult {
-  platformAuth: {
+  /** Absent for local-subscription routes, which never link a project. */
+  platformAuth?: {
     method: "existing-link" | "vercel-cli" | "access-token-triple";
   };
-  project: { teamId: string; projectId: string };
+  project?: { teamId: string; projectId: string };
   modelAuth: ModelRoute;
   agentTypes: string[];
   modelRouteVerified: boolean;
@@ -85,8 +87,8 @@ function canReuseModel(
 ): boolean {
   return Boolean(
     previous &&
-      previous.project.teamId === platform.project.teamId &&
-      previous.project.projectId === platform.project.projectId &&
+      previous.project?.teamId === platform.project.teamId &&
+      previous.project?.projectId === platform.project.projectId &&
       sameRoute(previous.route, route) &&
       JSON.stringify(previous.agentTypes) === JSON.stringify(agents) &&
       fresh(previous.modelVerifiedAt, now, ttl),
@@ -102,6 +104,29 @@ export async function ensureConnectedWorkspace(
   const deps = options.dependencies ?? {};
   const now = (deps.now ?? (() => new Date()))();
   const ttl = options.verificationTtlMs ?? 24 * 60 * 60 * 1000;
+
+  if (options.modelRoute.mode === "local") {
+    // Local subscriptions delegate model auth to the machine-wide
+    // claude/codex/pi logins, and nothing else in host-side setup needs the
+    // platform. Linking anyway would prompt for the Vercel login the user
+    // just declined and leave a VERCEL_OIDC_TOKEN in .env.local that every
+    // later run expands into ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN,
+    // routing past the login they chose. Sandbox commands do need the
+    // platform and assert their own credential when they run.
+    const verification: ConnectionVerificationCheckpoint = {
+      route: options.modelRoute,
+      agentTypes: [...options.agentTypes],
+      modelVerifiedAt: now.toISOString(),
+    };
+    return {
+      modelAuth: options.modelRoute,
+      agentTypes: [...options.agentTypes],
+      modelRouteVerified: false,
+      sandboxReady: false,
+      verification,
+    };
+  }
+
   const platform = await (deps.ensureLink ?? ensureVercelLink)({
     workspaceDir: options.workspaceDir,
     interactive: options.interactive,
@@ -130,28 +155,6 @@ export async function ensureConnectedWorkspace(
 
   // Link success is not enough: the credential must still be available now.
   assertSandboxCredential({ env });
-
-  if (options.modelRoute.mode === "local") {
-    // Local subscriptions delegate model auth to the machine-wide
-    // claude/codex/pi logins. There is no credential to resolve, apply to
-    // env, or verify — the agent SDK errors clearly at first call if the
-    // machine login is actually missing.
-    const verification: ConnectionVerificationCheckpoint = {
-      project: platform.project,
-      route: options.modelRoute,
-      agentTypes: [...options.agentTypes],
-      modelVerifiedAt: now.toISOString(),
-    };
-    return {
-      platformAuth: { method: platform.method },
-      project: platform.project,
-      modelAuth: options.modelRoute,
-      agentTypes: [...options.agentTypes],
-      modelRouteVerified: false,
-      sandboxReady: true,
-      verification,
-    };
-  }
 
   const resolvedRoutes: ResolvedModelRoute[] = [];
   for (const agentType of options.agentTypes) {

--- a/packages/deepsec/src/commands/init.ts
+++ b/packages/deepsec/src/commands/init.ts
@@ -17,6 +17,7 @@ import { runSetupWorkflow, type SetupThrough } from "../setup/coordinator.js";
 import type { SupportedPackageManager } from "../setup/install.js";
 import { shouldUseHeadlessMode } from "../setup/interaction.js";
 import { acquireSetupLock } from "../setup/lock.js";
+import { persistedModelRoute, recordInitialModelRoute } from "../setup/persisted-route.js";
 import { buildSetupPlan } from "../setup/plan.js";
 import { deterministicVercelProjectName } from "../setup/project-name.js";
 import {
@@ -215,6 +216,7 @@ export async function initCommand(opts: InitOpts) {
       modelRoute = choice.route;
       agent ??= choice.defaultAgent;
     }
+    recordInitialModelRoute(workspaceDir, modelRoute);
     if (!model && !resuming && !headless && process.stdin.isTTY && process.stdout.isTTY) {
       const choice = await promptForModelSelection({
         route: modelRoute ?? { mode: "gateway", provider: "vercel" },
@@ -263,7 +265,14 @@ export async function initCommand(opts: InitOpts) {
     // Complete interactive project selection before Ink ever takes ownership
     // of the terminal. Besides producing a cleaner onboarding sequence, this
     // avoids transferring stdin between two independent prompt runtimes.
+    //
+    // A local-subscription route needs no platform link, so skip it rather
+    // than prompt for the Vercel login the user just declined. On resume the
+    // route comes from the login checkpoint, or from the generated config when
+    // setup was interrupted before login; the prompt above is first-run only.
+    const linkRoute = modelRoute ?? persistedModelRoute(workspaceDir, registered.id);
     if (
+      linkRoute?.mode !== "local" &&
       !headless &&
       process.stdin.isTTY &&
       process.stdout.isTTY &&

--- a/packages/deepsec/src/setup/persisted-route.ts
+++ b/packages/deepsec/src/setup/persisted-route.ts
@@ -1,0 +1,43 @@
+import type { ModelRoute } from "../auth/model-route.js";
+import { readSetupState } from "./state.js";
+import { persistWorkspaceConfigRoute, readWorkspaceConfigRoute } from "./workspace-config.js";
+
+/**
+ * Record the route a run starts with before install, the first interruptible
+ * phase. Setup writes its own checkpoint only after login succeeds, and
+ * neither the route prompt nor a one-off `--model-auth` flag is repeated on
+ * resume, so an interrupt in between would otherwise resume onto the gateway
+ * default. A resumed run carries no route of its own and leaves the recorded
+ * one alone.
+ */
+export function recordInitialModelRoute(workspaceDir: string, route?: ModelRoute): void {
+  if (!route) return;
+  persistWorkspaceConfigRoute(workspaceDir, route);
+}
+
+/**
+ * Route a resumed run must reuse. The login checkpoint is authoritative once
+ * setup got that far; before it, the only record is the route line the first
+ * run wrote into the generated config. Init prompts for a route on a first run
+ * only, so a resume with neither would silently fall back to the gateway.
+ */
+export function persistedModelRoute(
+  workspaceDir: string,
+  projectId: string,
+): ModelRoute | undefined {
+  return checkpointRoute(workspaceDir, projectId) ?? readWorkspaceConfigRoute(workspaceDir);
+}
+
+/** Setup state paths resolve against the data root, which is relative to cwd. */
+function checkpointRoute(workspaceDir: string, projectId: string): ModelRoute | undefined {
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(workspaceDir);
+    const connection = readSetupState(projectId)?.connection as { route?: ModelRoute } | undefined;
+    return connection?.route;
+  } catch {
+    return undefined;
+  } finally {
+    process.chdir(originalCwd);
+  }
+}

--- a/packages/deepsec/src/setup/workspace-config.ts
+++ b/packages/deepsec/src/setup/workspace-config.ts
@@ -23,6 +23,45 @@ function upsertConfigLine(
   return source.replace(/defineConfig\(\{\s*/, (match) => `${match}${line}\n  `);
 }
 
+function upsertRouteLine(source: string, route: ModelRoute): string {
+  const line = `ai: ${JSON.stringify(route)}, ${ROUTE_MARKER}`;
+  if (source.includes(ROUTE_MARKER)) {
+    return source.replace(/^\s*ai:.*<deepsec:model-route>.*$/m, `  ${line}`);
+  }
+  return source.replace(/defineConfig\(\{\s*/, (match) => `${match}${line}\n  `);
+}
+
+/**
+ * Record the selected route in the generated config before any interruptible
+ * setup work runs. Setup only records its own checkpoint once login succeeds,
+ * and init only prompts for a route on a first run, so without this an
+ * interrupt in between loses the choice.
+ */
+export function persistWorkspaceConfigRoute(workspaceDir: string, route: ModelRoute): void {
+  const file = path.join(workspaceDir, "deepsec.config.ts");
+  fs.writeFileSync(file, upsertRouteLine(fs.readFileSync(file, "utf8"), route));
+}
+
+/** Route recorded by {@link persistWorkspaceConfigRoute} or a previous setup run. */
+export function readWorkspaceConfigRoute(workspaceDir: string): ModelRoute | undefined {
+  let source: string;
+  try {
+    source = fs.readFileSync(path.join(workspaceDir, "deepsec.config.ts"), "utf8");
+  } catch {
+    return undefined;
+  }
+  const match = source.match(/^\s*ai:\s*(.*),\s*\/\/ <deepsec:model-route>/m);
+  if (!match) return undefined;
+  try {
+    const route = JSON.parse(match[1]) as ModelRoute;
+    if (typeof route?.mode !== "string" || typeof route.provider !== "string") return undefined;
+    return route;
+  } catch {
+    // A hand-edited route line is not authoritative; fall back to prompting.
+    return undefined;
+  }
+}
+
 /** Idempotently migrate older generated workspaces to the one-shot config hooks. */
 export function reconcileWorkspaceConfig(
   workspaceDir: string,
@@ -46,12 +85,7 @@ export function reconcileWorkspaceConfig(
     }
   }
 
-  const routeLine = `ai: ${JSON.stringify(route)}, ${ROUTE_MARKER}`;
-  if (source.includes(ROUTE_MARKER)) {
-    source = source.replace(/^\s*ai:.*<deepsec:model-route>.*$/m, `  ${routeLine}`);
-  } else {
-    source = source.replace(/defineConfig\(\{\s*/, (match) => `${match}${routeLine}\n  `);
-  }
+  source = upsertRouteLine(source, route);
 
   const agentLine = `defaultAgent: ${JSON.stringify(agentType)}, ${AGENT_MARKER}`;
   if (source.includes(AGENT_MARKER)) {


### PR DESCRIPTION
- **Don't let workspace OIDC override a local-subscription model route**
- **Skip the Vercel link entirely for local-subscription routes**
