### PR TITLE
Record truncated revalidations as incomplete runs

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -282,6 +282,10 @@ export const runMetaSchema = z.object({
     fixed: z.number().optional(),
     uncertain: z.number().optional(),
     duplicates: z.number().optional(),
+    findingsRequested: z.number().optional(),
+    findingsUnresolved: z.number().optional(),
+    batchesTotal: z.number().optional(),
+    batchesCompleted: z.number().optional(),
   }),
 });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -74,6 +74,15 @@ export interface RunMeta {
     fixed?: number;
     uncertain?: number;
     duplicates?: number;
+    /**
+     * Coverage of the run rather than its verdicts. A truncated run still
+     * writes the counts above, so these four are the only fields that
+     * distinguish a full sweep from a partial one.
+     */
+    findingsRequested?: number;
+    findingsUnresolved?: number;
+    batchesTotal?: number;
+    batchesCompleted?: number;
   };
 }
 

--- a/packages/processor/src/__tests__/process-revalidate.test.ts
+++ b/packages/processor/src/__tests__/process-revalidate.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { defineConfig, type FileRecord, setLoadedConfig } from "@deepsec/core";
+import { defineConfig, type FileRecord, readRunMeta, setLoadedConfig } from "@deepsec/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { QuotaExhaustedError } from "../agents/shared.js";
 import { process as processProject, revalidate } from "../index.js";
@@ -1754,5 +1754,93 @@ describe("revalidate() reconciliation, repair, and adaptive splitting", () => {
     const after = fx.readRecord("app.ts");
     expect(after.findings[0].revalidation?.verdict).toBe("accepted-risk");
     expect(after.findings[0].revalidation?.reasoning).toBe("team decision");
+  });
+});
+
+describe("run record fidelity for truncated revalidations", () => {
+  let prevDataRoot: string | undefined;
+
+  beforeEach(() => {
+    prevDataRoot = process.env.DEEPSEC_DATA_ROOT;
+  });
+
+  afterEach(() => {
+    if (prevDataRoot === undefined) delete process.env.DEEPSEC_DATA_ROOT;
+    else process.env.DEEPSEC_DATA_ROOT = prevDataRoot;
+    setLoadedConfig(defineConfig({ projects: [] }));
+  });
+
+  it("does not record a quota-truncated revalidation as a completed run", async () => {
+    const fx = setupProject({ files: ["one/a.ts", "two/b.ts"] });
+    for (const f of ["one/a.ts", "two/b.ts"]) {
+      const r = pendingRecord(fx.projectId, f);
+      r.status = "analyzed";
+      r.findings = [
+        {
+          severity: "HIGH",
+          vulnSlug: "auth-bypass",
+          title: `bug in ${f}`,
+          description: "x",
+          lineNumbers: [1],
+          recommendation: "x",
+          confidence: "high",
+        },
+      ];
+      r.analysisHistory = [
+        {
+          runId: "earlier",
+          investigatedAt: new Date().toISOString(),
+          durationMs: 1,
+          agentType: "stub",
+          model: "stub",
+          modelConfig: {},
+          findingCount: 1,
+          phase: "process",
+        },
+      ];
+      fx.writeRecord(r);
+    }
+
+    let calls = 0;
+    const stub = new StubAgent({
+      async *revalidateImpl() {
+        calls++;
+        throw new QuotaExhaustedError("openai-quota", "insufficient_quota");
+      },
+    });
+    setLoadedConfig(
+      defineConfig({
+        projects: [{ id: fx.projectId, root: fx.targetRoot }],
+        plugins: [{ name: "stub", agents: [stub] }],
+      }),
+    );
+
+    // batchSize 1 over two files gives two batches, so the abort has a
+    // batch left to abandon.
+    const result = await revalidate({
+      projectId: fx.projectId,
+      agentType: "stub",
+      concurrency: 1,
+      batchSize: 1,
+    });
+
+    // In memory the truncation is fully known.
+    expect(calls).toBe(1);
+    expect(result.quotaExhausted?.source).toBe("openai-quota");
+    expect(result.revalidated).toBe(0);
+    // Only the batch that ran is counted, so the returned denominator
+    // cannot reveal the abandoned batch either.
+    expect(result.requested).toBe(1);
+
+    // The run record is what outlives the terminal, and it must not
+    // present a truncated run as a finished one.
+    const meta = readRunMeta(fx.projectId, result.runId);
+    expect(meta.phase).not.toBe("done");
+    // Coverage, not verdicts: one batch of two was attempted, and the
+    // finding it claimed went back unresolved.
+    expect(meta.stats.batchesTotal).toBe(2);
+    expect(meta.stats.batchesCompleted).toBe(1);
+    expect(meta.stats.findingsRequested).toBe(1);
+    expect(meta.stats.findingsUnresolved).toBe(1);
   });
 });

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -1582,7 +1582,11 @@ export async function revalidate(params: {
       );
     }
 
-    completeRun(projectId, runId, "done", {
+    // Abandoned batches mean the sweep never covered its scope, so the run
+    // is not "done". Reusing "error" rather than adding a phase keeps lock
+    // reclaim working — it treats exactly "done" | "error" as finished.
+    const batchesAbandoned = batches.length - batchesCompleted;
+    completeRun(projectId, runId, batchesAbandoned > 0 ? "error" : "done", {
       findingsRevalidated: totalRevalidated,
       truePositives: totalTP,
       falsePositives: totalFP,
@@ -1590,6 +1594,10 @@ export async function revalidate(params: {
       uncertain: totalUncertain,
       duplicates: totalDuplicate,
       totalCostUsd,
+      findingsRequested: totalRequested,
+      findingsUnresolved: totalUnresolved.length,
+      batchesTotal: batches.length,
+      batchesCompleted,
     });
 
     const totalDupeRejected = dupeRejectedIds.size;


### PR DESCRIPTION
## What changed

`revalidate` now completes as `phase: "error"` when a quota abort left batches unstarted, and persists four coverage stats (`findingsRequested`, `findingsUnresolved`, `batchesTotal`, `batchesCompleted`) alongside the existing verdict counts.

## Why

A truncated run was recorded as `phase: "done"` with a success-shaped `stats` block. The truncation reached `emitProgress` and the return value, but nothing on disk — so once the process was detached from its terminal the run record was indistinguishable from a full sweep.

We hit this on a 532-finding revalidation: it recorded `phase: done, findingsRevalidated: 326`, while on disk 0 of 2 CRITICAL and 4 of 17 HIGH findings had verdicts. `deepsec status` reported a completed run, and there was no way to learn otherwise.

The abandoned work was invisible in the return value too. `totalRequested` accumulates per batch, so the denominator truncates with the run — two planned batches with an abort after the first reports `requested: 1`, not 2. And batches never started are not appended to `totalUnresolved` either (only the batch that threw is), so that work appears in no output at all.

Phase flips only on **abandoned** batches, not on failures: a run that attempted its whole scope but had a batch fail stays `"done"` and reports the loss via `findingsUnresolved`. Keying on batch coverage rather than on `quotaExhausted` also covers the `params.signal` abort path, which truncates identically.

Reusing `"error"` avoids widening `RunMeta["phase"]`; lock reclaim treats exactly `"done" | "error"` as finished, so a third value would strand the run's files for `STALE_LOCK_MS`.

## Verification

- [x] `pnpm test` passes — 2411 passed, 1 skipped, 63 files
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [x] `pnpm -r build` passes
- [x] `pnpm test:bundle` passes (`RunMeta` is on the `deepsec/config` surface)
- [x] `pnpm typecheck:deepsec` passes
- [ ] N/A — no matcher added

## Notes for reviewer

The new test asserts the **persisted** run meta. The existing coverage at `process-revalidate.test.ts:929` asserts `result.quotaExhausted` — the in-memory return — which is why this went unnoticed.

`process()` has the identical shape (abort at `:781`, bail at `:803`/`:811`, unconditional `completeRun(…, "done", …)` at `:833`) and wants the same treatment. Left out to keep this single-purpose; happy to follow up or fold it in, whichever you prefer.

The four stats fields are optional and additive, so existing run records parse unchanged.
