### PR TITLE
Validate severity flag values instead of silently changing what runs

### DIFF
--- a/e2e/bundle.test.ts
+++ b/e2e/bundle.test.ts
@@ -276,6 +276,27 @@ export default defineConfig({
     expect(result.stderr).toContain("Duration must look like 500ms, 30s, 10m, or 2h");
   });
 
+  it("rejects an unknown severity on every flag that takes one", () => {
+    // Each of these compares severities differently, so an unvalidated value
+    // fails differently too — silently widening one filter, emptying another.
+    const flags = [
+      ["revalidate", "--min-severity"],
+      ["enrich", "--min-severity"],
+      ["triage", "--severity"],
+      ["export", "--min-severity"],
+      ["export", "--only-severity"],
+      ["metrics", "--min-severity"],
+    ];
+
+    for (const [command, flag] of flags) {
+      const result = runBundle([command, flag, "CRTICAL"]);
+      expect(result.status, `${command} ${flag}`).toBe(1);
+      expect(result.stderr, `${command} ${flag}`).toContain(
+        "Allowed choices are CRITICAL, HIGH, MEDIUM, HIGH_BUG, BUG, LOW.",
+      );
+    }
+  });
+
   it("init --scaffold-only writes a workspace seeded with the first project", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "deepsec-init-"));
     const workspace = path.join(tmp, "audits");

--- a/packages/deepsec/src/cli.ts
+++ b/packages/deepsec/src/cli.ts
@@ -5,7 +5,7 @@ dotenvConfig(); // also load .env as fallback
 
 import { getRegistry } from "@deepsec/core";
 import { setAttributionVersion } from "@deepsec/processor";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { collectRepeatable } from "./agent-config.js";
 import { enrichCommand } from "./commands/enrich.js";
 import { exportCommand } from "./commands/export.js";
@@ -36,6 +36,8 @@ import {
 import { getDeepsecVersion } from "./version.js";
 
 installSandboxOutputCap();
+
+const SEVERITIES = ["CRITICAL", "HIGH", "MEDIUM", "HIGH_BUG", "BUG", "LOW"] as const;
 
 const program = new Command();
 
@@ -396,9 +398,11 @@ program
     "--thinking-level <level>",
     "Reasoning/thinking effort for the main agent run: minimal, low, medium, high, or xhigh (default: xhigh)",
   )
-  .option(
-    "--min-severity <sev>",
-    "Only revalidate findings at this severity or above (CRITICAL, HIGH, MEDIUM, HIGH_BUG, BUG)",
+  .addOption(
+    new Option(
+      "--min-severity <sev>",
+      "Only revalidate findings at this severity or above",
+    ).choices(SEVERITIES),
   )
   .option("--force", "Re-check already-validated findings")
   .option("--limit <n>", "Max files to revalidate", parseInt)
@@ -419,9 +423,11 @@ program
     "Project identifier (default: the only project in deepsec.config.ts; required if there are multiple)",
   )
   .option("--filter <prefix>", "Only enrich files matching path prefix")
-  .option(
-    "--min-severity <sev>",
-    "Only enrich files with a finding at this severity or above (CRITICAL, HIGH, MEDIUM, HIGH_BUG, BUG, LOW)",
+  .addOption(
+    new Option(
+      "--min-severity <sev>",
+      "Only enrich files with a finding at this severity or above",
+    ).choices(SEVERITIES),
   )
   .option("--force", "Re-enrich already-enriched files")
   .option("--concurrency <n>", "Parallel ownership oracle requests (default: cores - 1)", parseInt)
@@ -434,7 +440,9 @@ program
     "--project-id <id>",
     "Project identifier (default: the only project in deepsec.config.ts; required if there are multiple)",
   )
-  .option("--severity <sev>", "Severity to triage (default: MEDIUM)", "MEDIUM")
+  .addOption(
+    new Option("--severity <sev>", "Severity to triage").choices(SEVERITIES).default("MEDIUM"),
+  )
   .option("--model <model>", "Model to use (default: claude-sonnet-4-6 — cheaper)")
   .option("--force", "Re-triage already-triaged findings")
   .option("--limit <n>", "Max findings to triage", parseInt)
@@ -455,13 +463,15 @@ program
   .description("Export findings as JSON or as a directory of per-finding markdown files")
   .option("--format <kind>", "Output format: json (default) or md-dir", "json")
   .option("--project-id <csv>", "Comma-separated project IDs (omit for all)")
-  .option(
-    "--min-severity <sev>",
-    "Only export findings at this severity or above (CRITICAL, HIGH, MEDIUM, HIGH_BUG, BUG, LOW)",
+  .addOption(
+    new Option("--min-severity <sev>", "Only export findings at this severity or above").choices(
+      SEVERITIES,
+    ),
   )
-  .option(
-    "--only-severity <sev>",
-    "Only export findings at this exact severity (CRITICAL, HIGH, MEDIUM, HIGH_BUG, BUG, LOW)",
+  .addOption(
+    new Option("--only-severity <sev>", "Only export findings at this exact severity").choices(
+      SEVERITIES,
+    ),
   )
   .option("--discovered-today", "Only findings whose most recent analysis was today (local time)")
   .option(
@@ -498,7 +508,11 @@ program
   .command("metrics")
   .description("Report findings metrics across all projects (or one project)")
   .option("--project-id <id>", "Project identifier (omit for all projects)")
-  .option("--min-severity <sev>", "Minimum severity to include (default: LOW)")
+  .addOption(
+    new Option("--min-severity <sev>", "Minimum severity to include (default: LOW)").choices(
+      SEVERITIES,
+    ),
+  )
   .action(metricsCommand);
 
 const sandboxCmd = program

--- a/packages/deepsec/src/commands/export.ts
+++ b/packages/deepsec/src/commands/export.ts
@@ -351,9 +351,6 @@ export async function exportCommand(opts: {
 
   const minSeverity = opts.minSeverity as Severity | undefined;
   const onlySeverity = opts.onlySeverity as Severity | undefined;
-  if (onlySeverity && !(onlySeverity in SEVERITY_ORDER)) {
-    throw new Error(`--only-severity: not a valid severity: ${opts.onlySeverity}`);
-  }
 
   let sinceMs: number | undefined;
   let untilMs = Number.POSITIVE_INFINITY;


### PR DESCRIPTION
## What changed

The six options that take a severity — `--severity`, `--min-severity`, `--only-severity` — are now declared with `.addOption(new Option(...).choices(SEVERITIES))`, so Commander rejects an unrecognized value instead of passing it through to be cast to `Severity` and used as a filter key. `export --only-severity` already validated by hand, and that now-duplicated check is removed.

## Why

Only one of the six severity options validated its input. The other five cast the raw string straight to `Severity`, and because the value ends up as a lookup key or an equality operand, a typo doesn't fail — it quietly changes which findings the command operates on, then reports success and exits 0.

The failure is not even consistent, because each call site compares differently:

| flag | comparison | a bad value means |
|---|---|---|
| `triage --severity` | `finding.severity !== severity` | matches nothing — prints `Triage complete.`, exits 0, triages zero findings |
| `revalidate --min-severity` | `ORDER[f] > ORDER[bad]` | `n > undefined` is false, so the filter is disabled and *everything* is revalidated |
| `enrich --min-severity` | `ORDER[f] <= ORDER[bad]` | `n <= undefined` is false, so nothing qualifies and *nothing* is enriched |
| `export --min-severity` | `ORDER[f] > ORDER[bad]` | filter disabled — every severity is exported |
| `metrics --min-severity` | `ORDER[bad] ?? 2` | silently means `MEDIUM` |
| `export --only-severity` | validated at `export.ts:354` | correctly rejected |

So the same typo under-includes on two commands, over-includes on two others, and silently picks a tier on a fifth. What we hit in practice: `deepsec triage --severity CRTICAL` echoed the typo back three times, triaged nothing, printed a green `Triage complete.` and exited 0. Nothing in the run record showed it either — `toTriage.length === 0` returns before `createRunMeta`, so no run is written at all. Separately, `deepsec export --min-severity NONSENSE --only-true-positive` exported all 474 findings rather than erroring.

`--only-severity` proves the intent: unrecognized severities were always meant to be an error, and the check simply wasn't applied to its five siblings.

## Notes for reviewer

`.choices()` is Commander's own mechanism for this, so there is no hand-written parser to keep in step with the ladder. It also renders the allowed values into `--help`, which lets four descriptions drop the parenthetical list they were maintaining by hand — one of which had already drifted: `revalidate --min-severity` documented five of the six severities, omitting `LOW` even though it has always been accepted. Using `.choices()` means that list can no longer go stale.

`.choices()` requires `.addOption(new Option(...))` rather than `.option(...)`, which is a new shape in this file. It seemed worth it for six options that were all getting the same treatment; happy to switch to a shared `parseArg` function if you'd rather keep `.option()` throughout.

The error is Commander's standard one, naming the offending flag: `error: option '--min-severity <sev>' argument 'NONSENSE' is invalid. Allowed choices are CRITICAL, HIGH, MEDIUM, HIGH_BUG, BUG, LOW.`

`SEVERITIES` is declared in `cli.ts` rather than in `@deepsec/core`, to keep this a validation-only change. Hoisting a canonical ladder into core is #48's job, and it can't ride along here: the six local `SEVERITY_ORDER` maps have drifted (`packages/processor/src/enrich.ts:156` and `packages/deepsec/src/commands/export.ts:9` rank `HIGH_BUG` above `MEDIUM`; `packages/deepsec/src/sandbox/partitioner.ts:8` omits `LOW` entirely), so unifying them changes what `export --min-severity MEDIUM` returns. That is user-visible and belongs in its own PR.

Two small things came along because they are the same lines: `export.ts`'s hand-rolled check is now unreachable, since Commander rejects the value before `exportCommand` runs; and `triage --help` no longer prints its default twice (`Severity to triage (default: MEDIUM) (default: "MEDIUM")`), because the description no longer restates what Commander already renders.

The test is an e2e one rather than a unit test, since with `.choices()` there is no unit left to test — the regression worth guarding is the wiring. It exercises all six flags through the built bundle; reverting any single option to a bare `.option()` fails it with that flag named.

Not addressed here, and arguably the real ergonomic gap: `triage` takes only an exact tier, so covering the ladder means six sequential runs. Adding `--min-severity` to `triage` is a feature, not this bug, so it is left out.

## Verification

- [x] `pnpm test` passes — 2411 passed, 1 skipped, 63 files
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [x] `pnpm -r build` passes
- [x] `pnpm test:bundle` passes — 30 tests
- [x] `pnpm typecheck:deepsec` passes
- [ ] N/A — no matcher added
