### PR TITLE
[website] Redirect DeepSec homepage to the OSS lander

### DIFF
--- a/packages/website/next.config.ts
+++ b/packages/website/next.config.ts
@@ -14,6 +14,17 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: repoRoot,
   },
+  async redirects() {
+    return [
+      {
+        // The marketing homepage now lives on vercel.com; DeepSec's docs
+        // remain on deepsec.sh. Keep this temporary during the launch soak.
+        source: "/",
+        destination: "https://vercel.com/oss/deepsec",
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default withMDX(nextConfig);

--- a/packages/website/next.config.ts
+++ b/packages/website/next.config.ts
@@ -20,6 +20,7 @@ const nextConfig: NextConfig = {
         // The marketing homepage now lives on vercel.com; DeepSec's docs
         // remain on deepsec.sh. Keep this temporary during the launch soak.
         source: "/",
+        has: [{ type: "host", value: "deepsec.sh" }],
         destination: "https://vercel.com/oss/deepsec",
         permanent: false,
       },


### PR DESCRIPTION
Redirects only `deepsec.sh/` to the new Vercel OSS lander. The docs and every non-root route stay on `deepsec.sh`.

## Details

- Adds a temporary 307 from `/` to `https://vercel.com/oss/deepsec` only when the request host is `deepsec.sh`.
- Leaves PR previews, local development, and direct deployment URLs usable at `/`.
- Matches the SWR launch pattern; switch to a permanent 308 after the redirect has soaked.
- Confirmed the destination and `/docs/getting-started` currently return 200.
- `git diff --check` passes. The preview deployment will exercise the Next.js build.
