### PR TITLE
feat(prompt): scope promptAppend entries to declared paths

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,8 +77,75 @@ instead of hand-editing it.
 | `root` | `string` | yes | Absolute or relative path to the codebase. |
 | `githubUrl` | `string` | no | `https://github.com/owner/repo/blob/branch` — used in exports for clickable links. Auto-detected from `git remote` when omitted. |
 | `infoMarkdown` | `string` | no | Repo context injected into AI prompts. Overrides `data/<id>/INFO.md` if both are present. |
-| `promptAppend` | `string` | no | Free-form text appended to the system prompt for this project. |
+| `promptAppend` | `string \| PromptAppendRule[]` | no | Free-form text appended to the system prompt. A string applies to every batch. An array scopes each entry to the paths it declares. See [promptAppend](#promptappend). |
 | `priorityPaths` | `string[]` | no | Path prefixes to process first. |
+
+## promptAppend
+
+A plain string is appended to the prompt for every batch:
+
+```ts
+promptAppend: "Treat anything under `legacy/` as untrusted input."
+```
+
+Use the array form when a checklist belongs to one part of the codebase.
+Each entry is included only for batches containing a file that matches one
+of its `paths`, so guidance written for one surface stays off unrelated
+files:
+
+```ts
+promptAppend: [
+  { paths: ["src/payments/**"], text: "Check for amount tampering and missing idempotency keys." },
+  { paths: ["src/uploads/**"], text: "Check for path traversal and missing content-type validation." },
+  { paths: ["src/admin/**"], text: "Check that every route has an authorization guard." },
+]
+```
+
+An entry with no `paths` is unscoped and applies to every batch, so standing
+guidance and path-scoped guidance can live in one list:
+
+```ts
+promptAppend: [
+  { text: "Flag any logger that swallows errors." },
+  { paths: ["src/payments/**"], text: "Check for amount tampering." },
+]
+```
+
+Matched entries are joined in declaration order. Scoping is per batch, not
+per file: a batch mixing `src/payments/` and `src/admin/` files carries both
+entries. Lower `--batch-size` to narrow it further.
+
+### Globs
+
+Patterns match the file path relative to the project root, using the same
+rules as a matcher's `filePatterns`.
+
+| Pattern | Matches |
+|---|---|
+| `src/**` | everything under `src/` |
+| `**/*.ts` | every `.ts` file at any depth |
+| `*.ts` | only `.ts` at the project root, because `*` never crosses a `/` |
+| `SRC/**` | nothing, patterns are case-sensitive |
+| `src\api\**` | nothing, `\` escapes and `/` is the only separator |
+| `#src/**` | nothing, a leading `#` is a comment |
+
+An entry applies when **any** of its patterns matches, so one pattern cannot
+subtract another. A leading `!` does not do it: `!p` means "every path that
+is not `p`".
+
+```ts
+// Applies to every batch, not just the API surface.
+{ paths: ["src/api/**", "!src/api/generated/**"], text: "..." }
+```
+
+| File | `src/api/**` | `!src/api/generated/**` | applies |
+|---|---|---|---|
+| `src/api/users.ts` | yes | yes | yes |
+| `src/api/generated/schema.ts` | yes | no | **yes** |
+| `README.md` | no | yes | **yes** |
+
+To narrow an entry, list the paths you want. To drop files from the review
+entirely, use the project's `ignorePaths`.
 
 ## INFO.md
 
@@ -135,7 +202,10 @@ Some legacy fields still live in `data/<id>/config.json`:
 ```json
 {
   "priorityPaths": ["app/api/", "lib/"],
-  "promptAppend": "Pay extra attention to the booking flow.",
+  "promptAppend": [
+    { "text": "Pay extra attention to the booking flow." },
+    { "paths": ["app/api/payments/**"], "text": "Check for amount tampering." }
+  ],
   "ignorePaths": ["**/legacy/**"]
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,9 +95,9 @@ files:
 
 ```ts
 promptAppend: [
-  { paths: ["src/payments/**"], text: "Check for amount tampering and missing idempotency keys." },
-  { paths: ["src/uploads/**"], text: "Check for path traversal and missing content-type validation." },
-  { paths: ["src/admin/**"], text: "Check that every route has an authorization guard." },
+  { paths: ["apps/web/**"], text: "Confirm nothing renders stored HTML without escaping." },
+  { paths: ["packages/db/**"], text: "Confirm every query is parameterized." },
+  { paths: ["infra/**"], text: "Confirm no bucket or security group is world-readable." },
 ]
 ```
 
@@ -107,12 +107,12 @@ guidance and path-scoped guidance can live in one list:
 ```ts
 promptAppend: [
   { text: "Flag any logger that swallows errors." },
-  { paths: ["src/payments/**"], text: "Check for amount tampering." },
+  { paths: ["packages/db/**"], text: "Confirm every query is parameterized." },
 ]
 ```
 
 Matched entries are joined in declaration order. Scoping is per batch, not
-per file: a batch mixing `src/payments/` and `src/admin/` files carries both
+per file: a batch mixing `apps/web/` and `packages/db/` files carries both
 entries. Lower `--batch-size` to narrow it further.
 
 ### Globs

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,7 @@ entries. Lower `--batch-size` to narrow it further.
 ### Globs
 
 Patterns match the file path relative to the project root, using the same
-rules as a matcher's `filePatterns`.
+options the scanner compiles declarative matcher globs with.
 
 | Pattern | Matches |
 |---|---|
@@ -127,25 +127,15 @@ rules as a matcher's `filePatterns`.
 | `*.ts` | only `.ts` at the project root, because `*` never crosses a `/` |
 | `SRC/**` | nothing, patterns are case-sensitive |
 | `src\api\**` | nothing, `\` escapes and `/` is the only separator |
-| `#src/**` | nothing, a leading `#` is a comment |
+
+A leading `!` or `#` is a literal character here, not negation or a comment.
 
 An entry applies when **any** of its patterns matches, so one pattern cannot
-subtract another. A leading `!` does not do it: `!p` means "every path that
-is not `p`".
+subtract another. To narrow an entry, list the paths you want. To drop files
+from the review entirely, use the project's `ignorePaths`.
 
-```ts
-// Applies to every batch, not just the API surface.
-{ paths: ["src/api/**", "!src/api/generated/**"], text: "..." }
-```
-
-| File | `src/api/**` | `!src/api/generated/**` | applies |
-|---|---|---|---|
-| `src/api/users.ts` | yes | yes | yes |
-| `src/api/generated/schema.ts` | yes | no | **yes** |
-| `README.md` | no | yes | **yes** |
-
-To narrow an entry, list the paths you want. To drop files from the review
-entirely, use the project's `ignorePaths`.
+An entry that declares `paths` but gives an unusable value, such as a string
+instead of an array, is skipped rather than applied everywhere.
 
 ## INFO.md
 

--- a/docs/data-layout.md
+++ b/docs/data-layout.md
@@ -49,7 +49,7 @@ Optional. Read by `scan` and the AI agents.
 | Field | Type | Purpose |
 |---|---|---|
 | `priorityPaths` | `string[]` | Path prefixes processed first. |
-| `promptAppend` | `string` | Free-form text appended to the system prompt for this project. |
+| `promptAppend` | `string \| PromptAppendRule[]` | Free-form text appended to the system prompt. An array scopes each entry to the paths it declares — see [configuration](configuration.md#promptappend). |
 | `ignorePaths` | `string[]` | Glob patterns to skip during scan. |
 
 ## INFO.md

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -8,6 +8,19 @@ import type {
   PeopleProvider,
 } from "./plugin.js";
 
+/**
+ * One entry of a path-scoped prompt addendum. An entry with no `paths`
+ * always applies. Globs match the file path relative to the project root,
+ * the same base the scanner uses for a matcher's `filePatterns`.
+ */
+export interface PromptAppendRule {
+  paths?: string[];
+  text: string;
+}
+
+/** Free-form prompt addendum, applied to every batch or scoped by path. */
+export type PromptAppend = string | PromptAppendRule[];
+
 /** A project the user wants to scan. */
 export interface ProjectDeclaration {
   id: string;
@@ -18,7 +31,7 @@ export interface ProjectDeclaration {
   /** Markdown injected into the AI prompt as repo context (replaces `data/<id>/INFO.md`). */
   infoMarkdown?: string;
   /** Free-form text appended to the AI prompt for this project. */
-  promptAppend?: string;
+  promptAppend?: PromptAppend;
   /** Path prefixes that should be processed before others. */
   priorityPaths?: string[];
 }

--- a/packages/deepsec/src/config.ts
+++ b/packages/deepsec/src/config.ts
@@ -38,6 +38,8 @@ export type {
   Person,
   ProjectConfig,
   ProjectDeclaration,
+  PromptAppend,
+  PromptAppendRule,
   RefusalReport,
   Revalidation,
   RevalidationVerdict,

--- a/packages/processor/package.json
+++ b/packages/processor/package.json
@@ -15,6 +15,7 @@
     "@earendil-works/pi-coding-agent": "0.81.1",
     "@openai/codex": "^0.153.2",
     "@openai/codex-sdk": "^0.153.2",
-    "jsonrepair": "^3.14.0"
+    "jsonrepair": "^3.14.0",
+    "minimatch": "^10.0.0"
   }
 }

--- a/packages/processor/src/__tests__/prompt-assemble.test.ts
+++ b/packages/processor/src/__tests__/prompt-assemble.test.ts
@@ -207,10 +207,28 @@ describe("resolvePromptAppend", () => {
     expect(result.text).toBe("Scoped.");
   });
 
-  it("treats a non-array paths value as unscoped", () => {
-    const result = resolvePromptAppend([{ paths: "src/api/**", text: "Standing." }] as never, [
-      "db/seed.ts",
-    ]);
-    expect(result.text).toBe("Standing.");
+  it("skips an entry whose paths is not an array", () => {
+    // A typo must narrow, never broadcast. `paths: "src/api/**"` (string
+    // instead of array) would otherwise apply the rule to every batch.
+    for (const bad of ["src/api/**", {}, 7]) {
+      const result = resolvePromptAppend([{ paths: bad, text: "Scoped." }] as never, [
+        "src/api/users.ts",
+      ]);
+      expect(result).toEqual({ text: "", rulesApplied: 0 });
+    }
+  });
+
+  it("selects nothing for an entry whose paths is empty", () => {
+    const result = resolvePromptAppend([{ paths: [], text: "Scoped." }], ["src/api/users.ts"]);
+    expect(result).toEqual({ text: "", rulesApplied: 0 });
+  });
+
+  it("treats a leading ! or # as a literal character, not glob syntax", () => {
+    // Matches how the scanner compiles declarative matcher globs.
+    const result = resolvePromptAppend(
+      [{ paths: ["!src/**"], text: "Negated." }],
+      ["src/api/users.ts"],
+    );
+    expect(result.text).toBe("");
   });
 });

--- a/packages/processor/src/__tests__/prompt-assemble.test.ts
+++ b/packages/processor/src/__tests__/prompt-assemble.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { assemblePrompt, CORE_PROMPT, TECH_HIGHLIGHTS } from "../prompt/index.js";
+import {
+  assemblePrompt,
+  CORE_PROMPT,
+  resolvePromptAppend,
+  TECH_HIGHLIGHTS,
+} from "../prompt/index.js";
 
 describe("assemblePrompt", () => {
   it("returns just the core prompt when no tech is detected and no batch slugs", () => {
@@ -62,6 +67,21 @@ describe("assemblePrompt", () => {
     expect(prompt).not.toContain("## Project context");
   });
 
+  it("filters a path-scoped promptAppend against the batch's files", () => {
+    const { prompt, meta } = assemblePrompt({
+      detectedTags: [],
+      batchSlugs: [],
+      batchFilePaths: ["src/api/users.ts"],
+      promptAppend: [
+        { paths: ["src/api/**"], text: "Scoped to the API surface." },
+        { paths: ["db/**"], text: "Scoped to the database surface." },
+      ],
+    });
+    expect(prompt).toContain("Scoped to the API surface.");
+    expect(prompt).not.toContain("Scoped to the database surface.");
+    expect(meta.promptAppendRulesApplied).toBe(1);
+  });
+
   it("falls back to a one-line summary when too many highlights would crowd the prompt", () => {
     // All known tags at once trips the polyglot fallback.
     const allTags = TECH_HIGHLIGHTS.map((h) => h.tag);
@@ -83,5 +103,114 @@ describe("assemblePrompt", () => {
       expect(h.bullets.length).toBeGreaterThanOrEqual(3);
       expect(h.bullets.length).toBeLessThanOrEqual(7);
     }
+  });
+});
+
+describe("resolvePromptAppend", () => {
+  const API_RULE = {
+    paths: ["src/api/**"],
+    text: "Check every handler here for a missing authorization guard.",
+  };
+  const MIGRATION_RULE = {
+    paths: ["db/migrations/**", "db/schema.sql"],
+    text: "Check schema changes for newly exposed columns.",
+  };
+  const STANDING_RULE = { text: "Flag loggers that swallow errors." };
+
+  it("returns an empty result when there is no addendum", () => {
+    expect(resolvePromptAppend(undefined, ["src/api/users.ts"])).toEqual({
+      text: "",
+      rulesApplied: 0,
+    });
+  });
+
+  it("returns a plain string unchanged for any batch", () => {
+    const result = resolvePromptAppend(STANDING_RULE.text, ["db/seed.ts"]);
+    expect(result.text).toBe(STANDING_RULE.text);
+    expect(result.rulesApplied).toBe(0);
+  });
+
+  it("keeps an entry whose glob matches a file in the batch", () => {
+    const result = resolvePromptAppend([API_RULE, MIGRATION_RULE], ["src/api/users.ts"]);
+    expect(result.text).toBe(API_RULE.text);
+    expect(result.rulesApplied).toBe(1);
+  });
+
+  it("matches any of the globs listed on one entry", () => {
+    const result = resolvePromptAppend([MIGRATION_RULE], ["db/schema.sql"]);
+    expect(result.text).toBe(MIGRATION_RULE.text);
+  });
+
+  it("drops every entry when no file in the batch matches", () => {
+    const result = resolvePromptAppend([API_RULE, MIGRATION_RULE], ["src/lib/format.ts"]);
+    expect(result).toEqual({ text: "", rulesApplied: 0 });
+  });
+
+  it("keeps an entry that declares no paths on every batch", () => {
+    const result = resolvePromptAppend([STANDING_RULE, API_RULE], ["src/lib/format.ts"]);
+    expect(result.text).toBe(STANDING_RULE.text);
+    expect(result.rulesApplied).toBe(1);
+  });
+
+  it("keeps only unscoped entries when the caller tracks no files", () => {
+    // Without a file list the caller cannot confirm a surface is present,
+    // so a scoped checklist stays out rather than riding along unverified.
+    const result = resolvePromptAppend([API_RULE, STANDING_RULE], undefined);
+    expect(result.text).toBe(STANDING_RULE.text);
+  });
+
+  it("joins matched entries in declaration order", () => {
+    const result = resolvePromptAppend(
+      [API_RULE, MIGRATION_RULE],
+      ["src/api/users.ts", "db/migrations/001.sql"],
+    );
+    expect(result.text).toBe(`${API_RULE.text}\n\n${MIGRATION_RULE.text}`);
+    expect(result.rulesApplied).toBe(2);
+  });
+
+  // config.json is hand-authored, so the declared type is not a runtime
+  // guarantee. A typo in one entry must not fail the batch.
+
+  it("skips a value that is neither a string nor an array", () => {
+    for (const bad of [null, { text: "x" }, 42]) {
+      expect(resolvePromptAppend(bad as never, ["src/api/users.ts"])).toEqual({
+        text: "",
+        rulesApplied: 0,
+      });
+    }
+  });
+
+  it("skips an entry whose text is missing or not a string", () => {
+    const result = resolvePromptAppend(
+      [{ paths: ["src/api/**"] }, { paths: ["src/api/**"], text: 7 }, API_RULE] as never,
+      ["src/api/users.ts"],
+    );
+    expect(result.text).toBe(API_RULE.text);
+    expect(result.rulesApplied).toBe(1);
+  });
+
+  it("skips an entry whose text is only whitespace", () => {
+    // rulesApplied must count what actually reached the prompt.
+    const result = resolvePromptAppend(
+      [{ paths: ["src/api/**"], text: "   " }, API_RULE],
+      ["src/api/users.ts"],
+    );
+    expect(result.text).toBe(API_RULE.text);
+    expect(result.rulesApplied).toBe(1);
+  });
+
+  it("skips a pattern that is not a string", () => {
+    // minimatch throws "invalid pattern" on a non-string.
+    const result = resolvePromptAppend([{ paths: [123, "src/api/**"], text: "Scoped." }] as never, [
+      "src/api/users.ts",
+    ]);
+    expect(result.text).toBe("Scoped.");
+  });
+
+  it("treats a non-array paths value as unscoped", () => {
+    const result = resolvePromptAppend([{ paths: "src/api/**", text: "Standing." }] as never, [
+      "db/seed.ts",
+    ]);
+    expect(result.text).toBe("Standing.");
   });
 });

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -9,6 +9,7 @@ import {
   dataDir,
   defaultConcurrency,
   ensureFindingIds,
+  findProject,
   getRegistry,
   isPidAlive,
   loadAllFileRecords,
@@ -237,6 +238,8 @@ export async function process(params: {
   } catch {
     // No config.json — that's fine
   }
+  // `config.json` wins over the declaration when both carry the field.
+  const promptAppend = projectConfig.promptAppend ?? findProject(projectId)?.promptAppend;
 
   // Tech detection result drives per-batch threat highlights. Read once
   // from `data/<id>/tech.json` (written by `scan()`); empty list when the
@@ -256,7 +259,7 @@ export async function process(params: {
   const buildBatchPrompt = (batch: FileRecord[]): string => {
     const batchFilePaths = batch.map((r) => r.filePath);
     if (customPromptTemplate !== undefined) {
-      const { text } = resolvePromptAppend(projectConfig.promptAppend, batchFilePaths);
+      const { text } = resolvePromptAppend(promptAppend, batchFilePaths);
       return text ? `${customPromptTemplate}\n${text}` : customPromptTemplate;
     }
     const batchSlugs = Array.from(
@@ -274,7 +277,7 @@ export async function process(params: {
       batchLanguages,
       batchFilePaths,
       projectInfo,
-      promptAppend: projectConfig.promptAppend,
+      promptAppend,
     });
     return prompt;
   };

--- a/packages/processor/src/index.ts
+++ b/packages/processor/src/index.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { FileRecord, Severity } from "@deepsec/core";
+import type { FileRecord, PromptAppend, Severity } from "@deepsec/core";
 import {
   acquireProcessLock,
   completeRun,
@@ -33,7 +33,7 @@ import type {
 } from "./agents/types.js";
 import { batchCandidates } from "./batch.js";
 import { enrichFileRecord } from "./enrich.js";
-import { assemblePrompt } from "./prompt/assemble.js";
+import { assemblePrompt, resolvePromptAppend } from "./prompt/assemble.js";
 import { languagesForBatch } from "./prompt/file-language.js";
 import {
   buildAliasMap,
@@ -230,7 +230,7 @@ export async function process(params: {
   const projectConfigJsonPath = path.join(dataDir(projectId), "config.json");
   let projectConfig: {
     priorityPaths?: string[];
-    promptAppend?: string;
+    promptAppend?: PromptAppend;
   } = {};
   try {
     projectConfig = JSON.parse(fs.readFileSync(projectConfigJsonPath, "utf-8"));
@@ -254,12 +254,10 @@ export async function process(params: {
    *     batch-slug notes, so the prompt adapts to what we detected.
    */
   const buildBatchPrompt = (batch: FileRecord[]): string => {
+    const batchFilePaths = batch.map((r) => r.filePath);
     if (customPromptTemplate !== undefined) {
-      let p = customPromptTemplate;
-      if (projectConfig.promptAppend) {
-        p += "\n" + projectConfig.promptAppend;
-      }
-      return p;
+      const { text } = resolvePromptAppend(projectConfig.promptAppend, batchFilePaths);
+      return text ? `${customPromptTemplate}\n${text}` : customPromptTemplate;
     }
     const batchSlugs = Array.from(
       new Set(batch.flatMap((r) => r.candidates.map((c) => c.vulnSlug))),
@@ -269,11 +267,12 @@ export async function process(params: {
     // files in a polyglot Next.js + Django repo gets the Django pack
     // but not the Next.js pack, even though both are project-level
     // detected tags.
-    const batchLanguages = languagesForBatch(batch.map((r) => r.filePath));
+    const batchLanguages = languagesForBatch(batchFilePaths);
     const { prompt } = assemblePrompt({
       detectedTags,
       batchSlugs,
       batchLanguages,
+      batchFilePaths,
       projectInfo,
       promptAppend: projectConfig.promptAppend,
     });

--- a/packages/processor/src/prompt/assemble.ts
+++ b/packages/processor/src/prompt/assemble.ts
@@ -128,15 +128,20 @@ function renderFrameworkSection(
 }
 
 /**
- * Whether a rule's globs select any file in the batch. A rule that declares
- * no usable patterns is unscoped and applies everywhere.
+ * Whether a rule's globs select any file in the batch. Omitting `paths` is the
+ * documented unscoped form. Declaring it as anything but an array is a typo,
+ * and narrowing to nothing is safer there than broadcasting to every batch.
  */
 function appliesToBatch(patterns: unknown, files: string[]): boolean {
-  if (!Array.isArray(patterns) || patterns.length === 0) return true;
-  // Same options as a matcher's `filePatterns` in the scanner.
+  if (patterns === undefined) return true;
+  if (!Array.isArray(patterns)) return false;
+  // Same options the scanner compiles declarative matcher globs with, so a
+  // leading `!` or `#` stays a literal character rather than glob syntax.
   return files.some((file) =>
     patterns.some(
-      (pat) => typeof pat === "string" && minimatch(file, pat, { dot: true, nocase: false }),
+      (pat) =>
+        typeof pat === "string" &&
+        minimatch(file, pat, { dot: true, nocase: false, nonegate: true, nocomment: true }),
     ),
   );
 }

--- a/packages/processor/src/prompt/assemble.ts
+++ b/packages/processor/src/prompt/assemble.ts
@@ -1,3 +1,5 @@
+import type { PromptAppend } from "@deepsec/core";
+import { minimatch } from "minimatch";
 import { CORE_PROMPT } from "./core.js";
 import { highlightForTag, type TechHighlight } from "./highlights.js";
 import { noteForSlug } from "./slug-notes.js";
@@ -44,15 +46,21 @@ export interface AssembleParams {
    */
   batchLanguages?: string[];
   /**
+   * File paths of the current batch, relative to the project root. Used to
+   * scope a path-scoped `promptAppend`.
+   */
+  batchFilePaths?: string[];
+  /**
    * Optional project-specific INFO.md content (already loaded by caller).
    * Appended verbatim if present.
    */
   projectInfo?: string;
   /**
    * Optional `config.json:promptAppend` content from the project. Appended
-   * verbatim if present.
+   * verbatim if it is a string, or filtered against `batchFilePaths` if it
+   * declares paths.
    */
-  promptAppend?: string;
+  promptAppend?: PromptAppend;
 }
 
 /** Render a highlight as the section it occupies in the final prompt. */
@@ -119,6 +127,46 @@ function renderFrameworkSection(
   };
 }
 
+/**
+ * Whether a rule's globs select any file in the batch. A rule that declares
+ * no usable patterns is unscoped and applies everywhere.
+ */
+function appliesToBatch(patterns: unknown, files: string[]): boolean {
+  if (!Array.isArray(patterns) || patterns.length === 0) return true;
+  // Same options as a matcher's `filePatterns` in the scanner.
+  return files.some((file) =>
+    patterns.some(
+      (pat) => typeof pat === "string" && minimatch(file, pat, { dot: true, nocase: false }),
+    ),
+  );
+}
+
+/**
+ * Resolve the prompt addendum for one batch. `config.json` is hand-authored,
+ * so malformed entries are skipped rather than thrown on: one typo should not
+ * fail a whole paid run.
+ */
+export function resolvePromptAppend(
+  promptAppend: PromptAppend | undefined,
+  batchFilePaths: string[] | undefined,
+): { text: string; rulesApplied: number } {
+  if (typeof promptAppend === "string") {
+    return { text: promptAppend.trim(), rulesApplied: 0 };
+  }
+  if (!Array.isArray(promptAppend)) return { text: "", rulesApplied: 0 };
+
+  const files = batchFilePaths ?? [];
+  const texts: string[] = [];
+
+  for (const rule of promptAppend) {
+    if (typeof rule?.text !== "string") continue;
+    const text = rule.text.trim();
+    if (text.length > 0 && appliesToBatch(rule.paths, files)) texts.push(text);
+  }
+
+  return { text: texts.join("\n\n"), rulesApplied: texts.length };
+}
+
 function renderSlugSection(batchSlugs: string[]): string {
   const unique = Array.from(new Set(batchSlugs));
   const lines = unique
@@ -144,6 +192,8 @@ export interface AssembleResult {
     includedTags: string[];
     droppedToFallback: boolean;
     slugsWithNotes: number;
+    /** Matched path-scoped entries. Always 0 for the string form. */
+    promptAppendRulesApplied: number;
   };
 }
 
@@ -158,15 +208,17 @@ export interface AssembleResult {
  *   ## Slug-specific reviewer notes
  *     - `slug`: one sentence
  *   [project INFO.md, verbatim]
- *   [config.json:promptAppend, verbatim]
+ *   [config.json:promptAppend, verbatim or path-scoped]
  *
  * Highlights are scoped to the techs that apply (from detectedTags); slug
- * notes are scoped to slugs that appear in the current batch. Both
- * sections are dropped (or shrunk to a fallback line) when their content
+ * notes are scoped to slugs that appear in the current batch. A
+ * path-scoped promptAppend is filtered against the batch's file paths.
+ * Sections are dropped (or shrunk to a fallback line) when their content
  * is empty or exceeds the size budget.
  */
 export function assemblePrompt(params: AssembleParams): AssembleResult {
-  const { detectedTags, batchSlugs, batchLanguages, projectInfo, promptAppend } = params;
+  const { detectedTags, batchSlugs, batchLanguages, batchFilePaths, projectInfo, promptAppend } =
+    params;
 
   const sections: string[] = [CORE_PROMPT];
 
@@ -183,8 +235,9 @@ export function assemblePrompt(params: AssembleParams): AssembleResult {
   if (projectInfo && projectInfo.trim().length > 0) {
     sections.push(`---\n\n${projectInfo.trim()}`);
   }
-  if (promptAppend && promptAppend.trim().length > 0) {
-    sections.push(`---\n\n${promptAppend.trim()}`);
+  const appended = resolvePromptAppend(promptAppend, batchFilePaths);
+  if (appended.text.length > 0) {
+    sections.push(`---\n\n${appended.text}`);
   }
 
   const prompt = sections.join("\n\n");
@@ -201,6 +254,7 @@ export function assemblePrompt(params: AssembleParams): AssembleResult {
       slugsWithNotes: slugSection
         ? slugSection.split("\n").filter((l) => l.startsWith("- ")).length
         : 0,
+      promptAppendRulesApplied: appended.rulesApplied,
     },
   };
 }

--- a/packages/processor/src/prompt/index.ts
+++ b/packages/processor/src/prompt/index.ts
@@ -1,5 +1,5 @@
 export type { AssembleParams, AssembleResult } from "./assemble.js";
-export { assemblePrompt } from "./assemble.js";
+export { assemblePrompt, resolvePromptAppend } from "./assemble.js";
 export { CORE_PROMPT } from "./core.js";
 export type { TechHighlight } from "./highlights.js";
 export { highlightForTag, TECH_HIGHLIGHTS } from "./highlights.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       jsonrepair:
         specifier: ^3.14.0
         version: 3.14.0
+      minimatch:
+        specifier: ^10.0.0
+        version: 10.2.5
 
   packages/scanner:
     dependencies:


### PR DESCRIPTION
## What changed

<!-- 1–2 sentences. -->

`promptAppend` can now be an array instead of one string. Each entry says which paths it applies to, and it only shows up in batches that touch those files. A plain string still works exactly as before.

## Why

<!-- The motivation, not the diff. -->

Today every file gets the same appendix. Write a checklist for your payment code and it rides along on every unrelated file too, leaving the model to work out which parts apply.

The assembler already solves this everywhere else. Highlights get filtered by the batch's languages, slug notes by its slugs. `promptAppend` was the last section that always went out in full.

In a monorepo you can work around it by splitting a surface into its own project so it gets its own prompt. That works, but then the agent only sees that subtree and loses the callers that would have explained the bug.

## Verification

- [x] `pnpm test` passes:
> For your information, the 18 failures in `e2e/bundle.test.ts` and `e2e/pipeline.test.ts` reproduce on main branch without this change. everything else is green.
- [x] `pnpm lint` passes
- [x] `pnpm knip` passes
- [ ] ~~If this adds a matcher: ran it against at least one real repo and confirmed the candidate count is sane~~

## Notes for reviewer

<!-- Anything non-obvious. Performance considerations, FP-rate
expectations, knock-on effects elsewhere. -->

- Existing string configs are untouched.
- Globs use the same minimatch options as a matcher's `filePatterns`, so whatever picks a file for scanning picks it here too.